### PR TITLE
Add reviewer links to HawkinsOperations site

### DIFF
--- a/index.html
+++ b/index.html
@@ -350,6 +350,24 @@
           do not inherit successor trust automatically. Claims are promoted only when the
           supporting evidence and review path exist.
         </p>
+        <p>
+          Reviewers should begin with the
+          <a
+            href="https://github.com/HawkinsOperations/.github/blob/main/profile/START_HERE.md"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            HawkinsOperations Start Here
+          </a>
+          guide and the
+          <a
+            href="https://github.com/HawkinsOperations/.github/blob/main/governance/CONTROL_STATUS_MATRIX.md"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Control Status Matrix
+          </a>.
+        </p>
       </section>
     </main>
 


### PR DESCRIPTION
This PR adds reviewer links from the HawkinsOperations site to the Start Here guide and Control Status Matrix.

Changes:
- Updates index.html reviewer note section.

Claim boundaries:
- Website remains rendering only.
- Website presentation does not prove source, runtime, signal, evidence, or public-safe status.
- Reviewer links point to the governed Start Here guide and Control Status Matrix.