### PR TITLE
Add HawkinsOperations control map status cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,10 +65,10 @@
         <span>HawkinsOperations</span>
       </a>
       <nav class="nav" aria-label="Page sections">
-        <a href="#proof-scope">Proof scope</a>
-        <a href="#thesis">Thesis</a>
+        <a href="#reviewer-start">Reviewer start</a>
+        <a href="#routing">Surface map</a>
+        <a href="#status">Status</a>
         <a href="#boundaries">Truth boundaries</a>
-        <a href="#routing">Routing</a>
         <a href="#detection-path">HO-DET-001</a>
       </nav>
     </header>
@@ -94,7 +94,7 @@
             and human authorization exist.
           </p>
           <div class="hero-actions">
-            <a class="button button-primary" href="#detection-path">Review proof path</a>
+            <a class="button button-primary" href="#reviewer-start">Start review</a>
             <a
               class="button"
               href="https://github.com/HawkinsOperations"
@@ -116,14 +116,64 @@
         <aside class="hero-panel" aria-label="Public claim boundary">
           <p class="panel-kicker">Reviewer shortcut</p>
           <ul class="shortcut-list">
-            <li><a href="#proof-scope">What this proves</a></li>
-            <li><a href="#thesis">AI and governance thesis</a></li>
+            <li><a href="#reviewer-start">Reviewer start path</a></li>
+            <li><a href="#routing">Surface control map</a></li>
+            <li><a href="#status">Current status summary</a></li>
             <li><a href="#boundaries">Truth boundaries</a></li>
-            <li><a href="#routing">Surface routing</a></li>
-            <li><a href="#status">Current status</a></li>
             <li><a href="#detection-path">HO-DET-001 proof path</a></li>
           </ul>
         </aside>
+      </section>
+
+      <section id="reviewer-start" class="section" aria-labelledby="reviewer-start-title">
+        <div class="section-heading">
+          <p class="eyebrow">Reviewer start path</p>
+          <h2 id="reviewer-start-title">Start with control, then inspect proof boundaries.</h2>
+        </div>
+        <div class="reviewer-grid">
+          <a class="reviewer-card" href="https://github.com/HawkinsOperations/.github/blob/main/profile/START_HERE.md" target="_blank" rel="noopener noreferrer">
+            <span class="badge badge-soft">SOFT_ROUTING</span>
+            <h3>1. Start Here</h3>
+            <p><strong>Answers:</strong> where reviewers begin and how the organization is framed.</p>
+            <p><strong>Does not prove:</strong> source, runtime, signal, evidence, or public-safe status.</p>
+            <span class="open-link">Open</span>
+          </a>
+          <a class="reviewer-card" href="https://github.com/HawkinsOperations/.github/blob/main/governance/CONTROL_STATUS_MATRIX.md" target="_blank" rel="noopener noreferrer">
+            <span class="badge badge-report">REPORT_ONLY</span>
+            <h3>2. Control Status Matrix</h3>
+            <p><strong>Answers:</strong> current control states across surfaces.</p>
+            <p><strong>Does not prove:</strong> that a detection is running, validated, or public-safe.</p>
+            <span class="open-link">Open</span>
+          </a>
+          <a class="reviewer-card" href="https://github.com/HawkinsOperations/.github/blob/main/architecture/REPO_AUTHORITY_MAP.md" target="_blank" rel="noopener noreferrer">
+            <span class="badge badge-architecture">SUCCESSOR_ARCHITECTURE</span>
+            <h3>3. Repo Authority Map</h3>
+            <p><strong>Answers:</strong> what each repository owns.</p>
+            <p><strong>Does not prove:</strong> runtime truth or evidence linkage.</p>
+            <span class="open-link">Open</span>
+          </a>
+          <a class="reviewer-card" href="https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/docs/ID_BOUNDARY.md" target="_blank" rel="noopener noreferrer">
+            <span class="badge badge-source">SOURCE_EXISTS</span>
+            <h3>4. HO-DET-001 proof boundary</h3>
+            <p><strong>Answers:</strong> why HO-DET-001 is a successor ID, not inherited proof.</p>
+            <p><strong>Does not prove:</strong> validation, runtime activity, signal observation, evidence linkage, or public-safe status.</p>
+            <span class="open-link">Open</span>
+          </a>
+          <a class="reviewer-card" href="https://hawkinsops.com" target="_blank" rel="noopener noreferrer">
+            <span class="badge badge-closed">CLOSED_V1_PROOF</span>
+            <h3>5. HawkinsOps V1 closed proof</h3>
+            <p><strong>Answers:</strong> historical closed proof for the original HawkinsOps surface.</p>
+            <p><strong>Does not prove:</strong> that V2 successor detections are promoted.</p>
+            <span class="open-link">Open</span>
+          </a>
+          <a class="reviewer-card" href="https://rayleeops.com" target="_blank" rel="noopener noreferrer">
+            <span class="badge badge-ledger">REVIEW_LEDGER</span>
+            <h3>6. Reviewed/narrowed claim ledger</h3>
+            <p><strong>Answers:</strong> contested-claim review and narrowed public wording.</p>
+            <p><strong>Does not prove:</strong> HawkinsOperations source, runtime, signal, or public-safe promotion.</p>
+            <span class="open-link">Open</span>
+          </a>
+        </div>
       </section>
 
       <section id="proof-scope" class="section" aria-labelledby="proof-scope-title">
@@ -145,7 +195,7 @@
             <ul>
               <li>It does not prove runtime-active detections.</li>
               <li>It does not prove validation, signal observation, or evidence linkage.</li>
-              <li>It does not make HO-DET-001 public-safe or production-ready.</li>
+              <li>It does not make HO-DET-001 public-safe.</li>
             </ul>
           </article>
         </div>
@@ -194,153 +244,234 @@
           <article>
             <span class="card-number">01</span>
             <h3>Source truth</h3>
-            <p>Files or artifacts exist.</p>
+            <p><strong>Counts:</strong> committed files or artifacts.</p>
+            <p><strong>Not:</strong> deployment or test pass.</p>
+            <p><strong>Allowed:</strong> source exists.</p>
+            <p><strong>Blocked:</strong> detection is validated.</p>
           </article>
           <article>
             <span class="card-number">02</span>
             <h3>Runtime truth</h3>
-            <p>Systems are deployed, enabled, or running under stated conditions.</p>
+            <p><strong>Counts:</strong> deployed and enabled system state.</p>
+            <p><strong>Not:</strong> repository text.</p>
+            <p><strong>Allowed:</strong> runtime not proven.</p>
+            <p><strong>Blocked:</strong> runtime-active.</p>
           </article>
           <article>
             <span class="card-number">03</span>
             <h3>Signal truth</h3>
-            <p>Telemetry, alerts, searches, or outputs were observed.</p>
+            <p><strong>Counts:</strong> observed telemetry or alert output.</p>
+            <p><strong>Not:</strong> expected behavior.</p>
+            <p><strong>Allowed:</strong> signal not observed.</p>
+            <p><strong>Blocked:</strong> signal-observed.</p>
           </article>
           <article>
             <span class="card-number">04</span>
             <h3>Evidence truth</h3>
-            <p>Supporting material is preserved and linked.</p>
+            <p><strong>Counts:</strong> preserved, linked support.</p>
+            <p><strong>Not:</strong> a claim summary.</p>
+            <p><strong>Allowed:</strong> evidence pending.</p>
+            <p><strong>Blocked:</strong> evidence-linked.</p>
           </article>
           <article>
             <span class="card-number">05</span>
             <h3>Public proof</h3>
-            <p>Wording is reviewed, scoped, approved, and safe for external use.</p>
+            <p><strong>Counts:</strong> reviewed and approved external wording.</p>
+            <p><strong>Not:</strong> website presence.</p>
+            <p><strong>Allowed:</strong> not public-safe.</p>
+            <p><strong>Blocked:</strong> public-safe.</p>
           </article>
           <article>
             <span class="card-number">06</span>
             <h3>Legacy/reference truth</h3>
-            <p>Historical material that does not become current truth by copy-paste.</p>
+            <p><strong>Counts:</strong> scoped V1 context.</p>
+            <p><strong>Not:</strong> successor inheritance.</p>
+            <p><strong>Allowed:</strong> may inform review.</p>
+            <p><strong>Blocked:</strong> V1 proves V2.</p>
           </article>
         </div>
       </section>
 
       <section id="routing" class="section" aria-labelledby="routing-title">
         <div class="section-heading">
-          <p class="eyebrow">Surface routing</p>
-          <h2 id="routing-title">No surface may claim another surface's truth.</h2>
+          <p class="eyebrow">Surface control map</p>
+          <h2 id="routing-title">Each surface owns a boundary. No surface claims another surface's truth.</h2>
         </div>
-        <div class="route-list">
-          <article>
-            <h3>
-              <a href="https://hawkinsops.com" target="_blank" rel="noopener noreferrer">
-                Current proof: hawkinsops.com
-              </a>
-            </h3>
-            <p>Current closed proof and hiring portfolio surface for original HawkinsOps.</p>
-          </article>
-          <article>
-            <h3>
-              <a href="https://rayleeops.com" target="_blank" rel="noopener noreferrer">
-                Contested AI-review ledger: rayleeops.com
-              </a>
-            </h3>
-            <p>Public ledger for contested claims, review notes, and operating narrative.</p>
-          </article>
-          <article>
-            <h3>
-              <a href="https://github.com/HawkinsOperations" target="_blank" rel="noopener noreferrer">
-                Successor source governance: GitHub org
-              </a>
-            </h3>
-            <p>Governed successor source and public governance summaries.</p>
-          </article>
-          <article>
-            <h3>
-              <a
-                href="https://github.com/HawkinsOperations/hawkinsoperations-detections"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Detection source repo
-              </a>
-            </h3>
-            <p>Detection source only.</p>
-          </article>
-          <article>
-            <h3>Validation repo</h3>
-            <p>Tests, schemas, and validation checks. Private or reviewer-visible by permission.</p>
-          </article>
-          <article>
-            <h3>Platform repo</h3>
-            <p>Platform architecture and stack truth tracking. Private or reviewer-visible by permission.</p>
-          </article>
-          <article>
-            <h3>
-              <a
-                href="https://github.com/HawkinsOperations/hawkinsoperations-proof"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Proof repo
-              </a>
-            </h3>
-            <p>Proof contracts, evidence indexes, claim linkage, and public-safe records.</p>
-          </article>
-          <article>
-            <h3>
-              <a
-                href="https://github.com/HawkinsOperations/hawkinsoperations-website"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Website repo
-              </a>
-            </h3>
-            <p>Public rendering only.</p>
-          </article>
+        <div class="control-map">
+          <a class="control-card" href="https://hawkinsops.com" target="_blank" rel="noopener noreferrer">
+            <span class="badge badge-closed">CLOSED_V1_PROOF</span>
+            <h3>HawkinsOps V1 closed proof surface</h3>
+            <p><strong>Owns:</strong> historical closed proof and portfolio surface.</p>
+            <p><strong>Current status:</strong> closed V1 reference.</p>
+            <p><strong>Proves:</strong> the V1 surface as presented there.</p>
+            <p><strong>Does not prove:</strong> V2 successor promotion.</p>
+            <p><strong>Next gate:</strong> reference only unless reclassified.</p>
+            <span class="open-link">Open</span>
+          </a>
+          <a class="control-card" href="https://rayleeops.com" target="_blank" rel="noopener noreferrer">
+            <span class="badge badge-ledger">REVIEW_LEDGER</span>
+            <h3>RayleeOps contested-claim review layer</h3>
+            <p><strong>Owns:</strong> reviewed and narrowed claim ledger.</p>
+            <p><strong>Current status:</strong> review layer.</p>
+            <p><strong>Proves:</strong> claim-review disposition where documented.</p>
+            <p><strong>Does not prove:</strong> HawkinsOperations runtime or source status.</p>
+            <p><strong>Next gate:</strong> use as context, not V2 proof.</p>
+            <span class="open-link">Open</span>
+          </a>
+          <a class="control-card" href="https://github.com/HawkinsOperations" target="_blank" rel="noopener noreferrer">
+            <span class="badge badge-architecture">SUCCESSOR_ARCHITECTURE</span>
+            <h3>HawkinsOperations GitHub org</h3>
+            <p><strong>Owns:</strong> successor repositories and public governance entry points.</p>
+            <p><strong>Current status:</strong> successor architecture.</p>
+            <p><strong>Proves:</strong> repository presence and published control docs.</p>
+            <p><strong>Does not prove:</strong> runtime, signal, evidence, or public-safe status.</p>
+            <p><strong>Next gate:</strong> inspect repo authority and status matrix.</p>
+            <span class="open-link">Open</span>
+          </a>
+          <a class="control-card" href="https://github.com/HawkinsOperations/hawkinsoperations-website" target="_blank" rel="noopener noreferrer">
+            <span class="badge badge-rendering">RENDERING_ONLY</span>
+            <h3>HawkinsOperations website</h3>
+            <p><strong>Owns:</strong> reviewer routing and public explanation.</p>
+            <p><strong>Current status:</strong> rendering only.</p>
+            <p><strong>Proves:</strong> the site can display scoped public wording.</p>
+            <p><strong>Does not prove:</strong> source, runtime, signal, evidence, or public-safe status.</p>
+            <p><strong>Next gate:</strong> follow linked source and control docs.</p>
+            <span class="open-link">Open</span>
+          </a>
+          <a class="control-card" href="https://github.com/HawkinsOperations/hawkinsoperations-detections" target="_blank" rel="noopener noreferrer">
+            <span class="badge badge-source">SOURCE_EXISTS</span>
+            <h3>Detections repo</h3>
+            <p><strong>Owns:</strong> governed detection source candidates.</p>
+            <p><strong>Current status:</strong> source exists where files are present.</p>
+            <p><strong>Proves:</strong> source presence only.</p>
+            <p><strong>Does not prove:</strong> validation, deployment, signal, or public-safe use.</p>
+            <p><strong>Next gate:</strong> static review and validation plan.</p>
+            <span class="open-link">Open</span>
+          </a>
+          <a class="control-card" href="https://github.com/HawkinsOperations/hawkinsoperations-proof" target="_blank" rel="noopener noreferrer">
+            <span class="badge badge-report">REPORT_ONLY</span>
+            <h3>Proof repo</h3>
+            <p><strong>Owns:</strong> proof contracts, ID boundaries, and claim linkage records.</p>
+            <p><strong>Current status:</strong> boundary records and proof scaffolding.</p>
+            <p><strong>Proves:</strong> proof path definitions where committed.</p>
+            <p><strong>Does not prove:</strong> runtime or signal state by itself.</p>
+            <p><strong>Next gate:</strong> link reviewed evidence before promotion.</p>
+            <span class="open-link">Open</span>
+          </a>
+          <a class="control-card" href="https://github.com/HawkinsOperations/.github" target="_blank" rel="noopener noreferrer">
+            <span class="badge badge-soft">SOFT_ROUTING</span>
+            <h3>.github governance front door</h3>
+            <p><strong>Owns:</strong> reviewer start, matrix summaries, and authority maps.</p>
+            <p><strong>Current status:</strong> soft routing unless a document blocks, fails, or forces correction.</p>
+            <p><strong>Proves:</strong> governance instructions are published.</p>
+            <p><strong>Does not prove:</strong> any detection is promoted.</p>
+            <p><strong>Next gate:</strong> follow blocking or correction rules if triggered.</p>
+            <span class="open-link">Open</span>
+          </a>
+          <a class="control-card control-card-blocked" href="https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/docs/ID_BOUNDARY.md" target="_blank" rel="noopener noreferrer">
+            <span class="badge badge-blocked">BLOCKED</span>
+            <h3>HO-DET-001 successor detection path</h3>
+            <p><strong>Owns:</strong> the successor detection ID boundary.</p>
+            <p><strong>Current status:</strong> SOURCE_EXISTS ceiling.</p>
+            <p><strong>Proves:</strong> the ID boundary is documented.</p>
+            <p><strong>Does not prove:</strong> HOD-001 validation carries forward.</p>
+            <p><strong>Next gate:</strong> static review plus validation plan.</p>
+            <span class="open-link">Open</span>
+          </a>
         </div>
       </section>
 
       <section id="status" class="section status-section" aria-labelledby="status-title">
         <div>
           <p class="eyebrow">Current status</p>
-          <h2 id="status-title">Governance boundaries are published before bulk migration.</h2>
+          <h2 id="status-title">Website summary of the control matrix.</h2>
+          <p class="section-note">
+            This is a skim summary only. The full matrix remains the control reference.
+          </p>
+          <a
+            class="button"
+            href="https://github.com/HawkinsOperations/.github/blob/main/governance/CONTROL_STATUS_MATRIX.md"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Open full matrix
+          </a>
         </div>
-        <div class="status-cards">
-          <article>
-            <h3>Current public material</h3>
-            <p>
-              Read current public material as source and architecture unless specific
-              evidence-backed claims are linked.
-            </p>
+        <div class="status-summary-grid" aria-label="Current status matrix summary">
+          <article class="status-summary-card">
+            <p class="status-surface">Website</p>
+            <p><strong>Current state:</strong> RENDERING_ONLY</p>
+            <p><strong>Truth surface:</strong> public presentation.</p>
+            <p>This site is a public routing surface; website rendering is not proof.</p>
+            <p><strong>Proven:</strong> reviewer routes and warnings render.</p>
+            <p><strong>Not proven:</strong> source, runtime, signal, evidence, or public-safe status.</p>
+            <p><strong>Next action:</strong> follow linked authority docs.</p>
           </article>
-          <article>
-            <h3>Public claim control</h3>
-            <p>Public claims require evidence, review, stale review, and authorization.</p>
+          <article class="status-summary-card">
+            <p class="status-surface">.github governance docs</p>
+            <p><strong>Current state:</strong> SOFT_ROUTING / REPORT_ONLY</p>
+            <p><strong>Truth surface:</strong> governance front door.</p>
+            <p><strong>Proven:</strong> routing and control summaries exist.</p>
+            <p><strong>Not proven:</strong> detection promotion by themselves.</p>
+            <p><strong>Next action:</strong> check blocks, failures, or forced corrections.</p>
           </article>
-          <article>
-            <h3>Original HawkinsOps</h3>
-            <p>
-              The original HawkinsOps system remains historical and proof-reference material
-              unless explicitly promoted under successor rules.
-            </p>
+          <article class="status-summary-card">
+            <p class="status-surface">HO-DET-001 source</p>
+            <p><strong>Current state:</strong> SOURCE_EXISTS</p>
+            <p><strong>Truth surface:</strong> detections repo.</p>
+            <p><strong>Proven:</strong> successor source candidate exists where committed.</p>
+            <p><strong>Not proven:</strong> validated, runtime-active, signal-observed, evidence-linked, or public-safe.</p>
+            <p><strong>Next action:</strong> static review plus validation plan.</p>
+          </article>
+          <article class="status-summary-card">
+            <p class="status-surface">HOD-001 baseline proof</p>
+            <p><strong>Current state:</strong> CLOSED_V1_PROOF</p>
+            <p><strong>Truth surface:</strong> legacy/reference proof.</p>
+            <p><strong>Proven:</strong> baseline/reference chain for V1 context.</p>
+            <p><strong>Not proven:</strong> HOD-001 does not validate/promote HO-DET-001.</p>
+            <p><strong>Next action:</strong> use for review context only.</p>
+          </article>
+          <article class="status-summary-card">
+            <p class="status-surface">RayleeOps registry</p>
+            <p><strong>Current state:</strong> REVIEW_LEDGER</p>
+            <p><strong>Truth surface:</strong> claim review layer.</p>
+            <p><strong>Proven:</strong> narrowed claim disposition where documented.</p>
+            <p><strong>Not proven:</strong> HawkinsOperations runtime or source truth.</p>
+            <p><strong>Next action:</strong> use as review ledger context.</p>
+          </article>
+          <article class="status-summary-card">
+            <p class="status-surface">HawkinsOps V1 metrics</p>
+            <p><strong>Current state:</strong> CLOSED_V1_PROOF</p>
+            <p><strong>Truth surface:</strong> historical proof surface.</p>
+            <p><strong>Proven:</strong> V1 metric presentation where scoped there.</p>
+            <p><strong>Not proven:</strong> automatic V2 inheritance.</p>
+            <p><strong>Next action:</strong> do not promote into V2 without gates.</p>
           </article>
         </div>
       </section>
 
       <section id="detection-path" class="section detection-path" aria-labelledby="detection-title">
         <p class="eyebrow">Promotion model</p>
-        <h2 id="detection-title">First governed detection path</h2>
-        <p>
-          HO-DET-001 is the first governed detection path. Its purpose is to demonstrate the
-          promotion model across source, proof, validation, runtime, signal, evidence, and
-          public-safe claim boundaries.
-        </p>
-        <p class="status-line">
-          Status: source/proof path in progress. Current claim level: SOURCE_EXISTS for the
-          detection source and draft proof packet. Validation, runtime-active, signal-observed,
-          evidence-linked, and public-safe status are not proven.
-        </p>
+        <h2 id="detection-title">HO-DET-001 is not promoted by HOD-001.</h2>
+        <div class="boundary-callout">
+          <span class="badge badge-source">SOURCE_EXISTS</span>
+          <ul>
+            <li>HOD-001 = baseline/reference proof chain.</li>
+            <li>HO-DET-001 = successor governed detection ID.</li>
+            <li>HOD-001 may inform review.</li>
+            <li>HOD-001 does not validate, promote, or make HO-DET-001 public-safe.</li>
+            <li>HO-DET-001 current ceiling: SOURCE_EXISTS.</li>
+            <li>Next gate: static review + validation plan.</li>
+          </ul>
+        </div>
+        <div class="blocked-claims" aria-label="Blocked claims for HO-DET-001">
+          <h3>Blocked claims</h3>
+          <span class="badge badge-blocked">validated</span>
+          <span class="badge badge-blocked">runtime-active</span>
+          <span class="badge badge-blocked">signal-observed</span>
+          <span class="badge badge-blocked">evidence-linked</span>
+          <span class="badge badge-blocked">public-safe</span>
+        </div>
       </section>
 
       <section class="reviewer-note" aria-labelledby="reviewer-note-title">

--- a/styles.css
+++ b/styles.css
@@ -11,6 +11,8 @@
   --green: #2ff08a;
   --gold: #e4bb4a;
   --danger: #ffb36b;
+  --red: #ff6b7d;
+  --violet: #b7a4ff;
   --shadow: 0 24px 60px rgba(0, 0, 0, 0.34);
 }
 
@@ -103,14 +105,18 @@ a:focus-visible,
 .nav a,
 .identity-links a,
 .shortcut-list a,
-.route-list a {
+.route-list a,
+.reviewer-card,
+.control-card {
   text-decoration: none;
 }
 
 .nav a:hover,
 .identity-links a:hover,
 .shortcut-list a:hover,
-.route-list a:hover {
+.route-list a:hover,
+.reviewer-card:hover,
+.control-card:hover {
   color: var(--accent-strong);
 }
 
@@ -236,6 +242,11 @@ h3 {
 .scope-card,
 .boundary-grid article,
 .route-list article,
+.reviewer-card,
+.control-card,
+.boundary-callout,
+.blocked-claims,
+.status-summary-card,
 .status-cards article,
 .reviewer-note,
 .site-footer {
@@ -311,6 +322,9 @@ h3 {
 .proof-scope-grid,
 .boundary-grid,
 .route-list,
+.reviewer-grid,
+.control-map,
+.status-summary-grid,
 .status-cards {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -322,12 +336,114 @@ h3 {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
+.reviewer-grid {
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  align-items: stretch;
+}
+
 .scope-card,
 .boundary-grid article,
 .route-list article,
+.reviewer-card,
+.control-card,
 .status-cards article {
   min-height: 128px;
   padding: 20px;
+}
+
+.reviewer-card,
+.control-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  color: var(--ink);
+  background:
+    linear-gradient(180deg, rgba(17, 28, 42, 0.94), rgba(9, 17, 26, 0.9));
+}
+
+.reviewer-card {
+  grid-column: span 2;
+}
+
+.reviewer-card:hover,
+.control-card:hover {
+  border-color: rgba(19, 200, 212, 0.64);
+  transform: translateY(-2px);
+}
+
+.reviewer-card p,
+.control-card p {
+  margin: 0;
+  color: #b6c4d0;
+  font-size: 0.94rem;
+  line-height: 1.48;
+}
+
+.reviewer-card strong,
+.control-card strong,
+.boundary-grid strong,
+.status-summary-card strong {
+  color: #e6f0f6;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  min-height: 24px;
+  padding: 3px 8px;
+  border: 1px solid rgba(19, 200, 212, 0.42);
+  border-radius: 999px;
+  background: rgba(19, 200, 212, 0.12);
+  color: var(--accent-strong);
+  font-size: 0.68rem;
+  font-weight: 850;
+  line-height: 1;
+}
+
+.badge-closed {
+  border-color: rgba(228, 187, 74, 0.48);
+  background: rgba(228, 187, 74, 0.12);
+  color: #ffe39a;
+}
+
+.badge-ledger,
+.badge-architecture {
+  border-color: rgba(183, 164, 255, 0.5);
+  background: rgba(183, 164, 255, 0.12);
+  color: #d7ccff;
+}
+
+.badge-source,
+.badge-report {
+  border-color: rgba(47, 240, 138, 0.42);
+  background: rgba(47, 240, 138, 0.1);
+  color: #9ef8c8;
+}
+
+.badge-rendering,
+.badge-soft {
+  border-color: rgba(19, 200, 212, 0.42);
+  background: rgba(19, 200, 212, 0.12);
+  color: var(--accent-strong);
+}
+
+.badge-blocked {
+  border-color: rgba(255, 107, 125, 0.5);
+  background: rgba(255, 107, 125, 0.12);
+  color: #ffb8c1;
+}
+
+.open-link {
+  margin-top: auto;
+  color: var(--accent);
+  font-size: 0.8rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.open-link::after {
+  content: " ->";
 }
 
 .scope-card ul {
@@ -379,6 +495,8 @@ h3 {
 
 .boundary-grid article {
   position: relative;
+  display: grid;
+  gap: 8px;
   border-left: 4px solid rgba(19, 200, 212, 0.7);
 }
 
@@ -397,9 +515,27 @@ h3 {
   color: #b6c4d0;
 }
 
+.boundary-grid p {
+  font-size: 0.92rem;
+  line-height: 1.42;
+}
+
 .route-list article {
   min-height: 116px;
   background: rgba(17, 28, 42, 0.86);
+}
+
+.control-map {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.control-card {
+  min-height: 320px;
+  border-left: 4px solid rgba(19, 200, 212, 0.68);
+}
+
+.control-card-blocked {
+  border-left-color: var(--red);
 }
 
 .route-list h3 a::after,
@@ -417,8 +553,47 @@ h3 {
   min-height: auto;
 }
 
+.section-note {
+  margin: 16px 0 18px;
+  color: #c1cdd8;
+  font-size: 1.02rem;
+}
+
+.status-summary-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 0;
+}
+
+.status-summary-card {
+  min-width: 0;
+  min-height: auto;
+  padding: 16px;
+  border-left: 4px solid rgba(19, 200, 212, 0.7);
+  background: rgba(17, 28, 42, 0.86);
+}
+
+.status-summary-card p {
+  margin: 0;
+  color: #b6c4d0;
+  font-size: 0.91rem;
+  line-height: 1.45;
+}
+
+.status-summary-card p + p {
+  margin-top: 7px;
+}
+
+.status-summary-card .status-surface {
+  margin-bottom: 10px;
+  color: var(--accent-strong);
+  font-size: 0.78rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
 .detection-path {
-  max-width: 860px;
+  max-width: none;
 }
 
 .detection-path p {
@@ -433,6 +608,36 @@ h3 {
   background: rgba(19, 200, 212, 0.12);
   color: var(--accent-strong) !important;
   font-weight: 750;
+}
+
+.boundary-callout {
+  margin-top: 24px;
+  padding: 24px;
+  border-left: 4px solid var(--danger);
+  background:
+    linear-gradient(135deg, rgba(255, 179, 107, 0.12), rgba(17, 28, 42, 0.92));
+}
+
+.boundary-callout ul {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px 24px;
+  margin: 18px 0 0;
+  padding-left: 20px;
+  color: #d5e1eb;
+}
+
+.blocked-claims {
+  margin-top: 16px;
+  padding: 18px;
+}
+
+.blocked-claims h3 {
+  margin-bottom: 12px;
+}
+
+.blocked-claims .badge {
+  margin: 0 6px 8px 0;
 }
 
 .reviewer-note {
@@ -508,8 +713,22 @@ h3 {
 
   .proof-scope-grid,
   .boundary-grid,
-  .route-list {
+  .route-list,
+  .control-map,
+  .status-summary-grid {
     grid-template-columns: 1fr 1fr;
+  }
+
+  .reviewer-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .reviewer-card {
+    grid-column: span 1;
+  }
+
+  .boundary-callout ul {
+    grid-template-columns: 1fr;
   }
 }
 
@@ -568,7 +787,10 @@ h3 {
 
   .proof-scope-grid,
   .boundary-grid,
-  .route-list {
+  .route-list,
+  .reviewer-grid,
+  .control-map,
+  .status-summary-grid {
     grid-template-columns: 1fr;
     gap: 10px;
     margin-top: 20px;
@@ -583,6 +805,11 @@ h3 {
   .scope-card,
   .boundary-grid article,
   .route-list article,
+  .reviewer-card,
+  .control-card,
+  .status-summary-card,
+  .boundary-callout,
+  .blocked-claims,
   .status-cards article,
   .reviewer-note,
   .site-footer,
@@ -600,5 +827,9 @@ h3 {
 
   .identity-links {
     gap: 6px 14px;
+  }
+
+  .control-card {
+    min-height: auto;
   }
 }


### PR DESCRIPTION
## What changed
- Added reviewer start routing and a surface control map.
- Added compressed truth-boundary cards and a six-card status summary.
- Added the exact sentence: website rendering is not proof.

## Claim boundaries preserved
- Website remains scoped to RENDERING_ONLY.
- HO-DET-001 remains scoped to SOURCE_EXISTS.
- HOD-001 remains baseline/reference material only.
- No runtime-active, signal-observed, evidence-linked, public-safe, readiness, or V1-to-V2 inheritance claim is made.

## Validation commands run
- git -C C:\Raylee\Repo\HawkinsOperations\hawkinsoperations-website diff --check
- npx --yes htmlhint C:\Raylee\Repo\HawkinsOperations\hawkinsoperations-website\index.html
- Focused added-line restricted-term scan
- 1440px browser DOM/layout validation at http://127.0.0.1:8765/index.html

## Browser validation result
- No visible horizontal body overflow.
- Status section did not clip.
- status-summary-card count was 6.
- Required reviewer links and claim-boundary text were present.
- Desktop screenshot captured locally under C:\Raylee\Repo\HawkinsOperations\hawkinsoperations-website\output\playwright.

## Safety notes
- Restricted private/infrastructure terms were not present in added lines.
- No merge performed.