### PR TITLE
[WEBSITE] Add HO-DET-001 proof-card route

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,27 +3,27 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>HawkinsOperations | Raylee Hawkins Detection Engineering</title>
+    <title>HawkinsOperations | Governed Detection Engineering</title>
     <meta
       name="description"
-      content="HawkinsOperations by Raylee Hawkins explains governed AI-assisted detection engineering, SOC automation, detection-as-code, public proof boundaries, and evidence-led claim control."
+      content="HawkinsOperations is Raylee Hawkins' public rendering layer for governed detection engineering, SOC automation, and public proof boundaries."
     >
     <link rel="canonical" href="https://hawkinsoperations.com/">
     <meta property="og:type" content="profile">
     <meta property="og:url" content="https://hawkinsoperations.com/">
-    <meta property="og:title" content="HawkinsOperations | Governed AI-Assisted Detection Engineering">
+    <meta property="og:title" content="HawkinsOperations | Governed Detection Engineering">
     <meta
       property="og:description"
-      content="A public rendering layer for Raylee Hawkins' governed successor architecture for detection engineering, SOC automation, and public proof boundaries."
+      content="A reviewer landing page for a governed detection engineering and SOC automation proof system."
     >
     <meta property="og:site_name" content="HawkinsOperations">
     <meta property="og:profile:first_name" content="Raylee">
     <meta property="og:profile:last_name" content="Hawkins">
     <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="HawkinsOperations | Governed AI-Assisted Detection Engineering">
+    <meta name="twitter:title" content="HawkinsOperations | Governed Detection Engineering">
     <meta
       name="twitter:description"
-      content="Governed AI-assisted detection engineering with source, runtime, signal, evidence, public proof, and legacy/reference boundaries."
+      content="Source truth, runtime truth, signal truth, evidence truth, and public proof are separated before claims are promoted."
     >
     <link rel="stylesheet" href="styles.css">
     <script type="application/ld+json">
@@ -32,7 +32,7 @@
         "@type": "ProfilePage",
         "name": "HawkinsOperations",
         "url": "https://hawkinsoperations.com/",
-        "description": "HawkinsOperations is Raylee Hawkins' public rendering layer for governed AI-assisted detection engineering, SOC automation, detection-as-code, and public proof boundaries.",
+        "description": "HawkinsOperations is Raylee Hawkins' public rendering layer for governed detection engineering, SOC automation, and public proof boundaries.",
         "mainEntity": {
           "@type": "Person",
           "name": "Raylee Hawkins",
@@ -43,15 +43,12 @@
             "SOC automation",
             "Detection-as-code",
             "Security automation",
-            "AI-assisted detection engineering",
             "Public proof boundaries"
           ],
           "sameAs": [
             "https://www.linkedin.com/in/raylee-hawkins",
             "https://github.com/raylee-hawkins",
             "https://github.com/HawkinsOperations",
-            "https://hawkinsops.com",
-            "https://rayleeops.com",
             "https://hawkinsoperations.com"
           ]
         }
@@ -65,446 +62,200 @@
         <span>HawkinsOperations</span>
       </a>
       <nav class="nav" aria-label="Page sections">
-        <a href="#reviewer-start">Reviewer start</a>
-        <a href="#routing">Surface map</a>
-        <a href="#status">Status</a>
-        <a href="#boundaries">Truth boundaries</a>
-        <a href="#detection-path">HO-DET-001</a>
+        <a href="#reviewer-path">Reviewer path</a>
+        <a href="#proof-boundary">Proof boundary</a>
+        <a href="#architecture">Architecture</a>
+        <a href="#surfaces">Surfaces</a>
       </nav>
     </header>
 
     <main id="top">
       <section class="hero" aria-labelledby="hero-title">
         <div class="hero-copy">
-          <p class="eyebrow">Successor architecture</p>
+          <p class="eyebrow">Public reviewer surface</p>
           <h1 id="hero-title">HawkinsOperations</h1>
-          <p class="subtitle">Governed AI-assisted detection engineering.</p>
-          <p class="strategic-frame">
-            Original HawkinsOps proved output. HawkinsOperations proves control.
+          <p class="subtitle">Governed detection engineering and SOC automation proof system.</p>
+          <p class="value-statement">
+            Built to separate source truth, runtime truth, signal truth, evidence truth,
+            and public proof before claims are promoted.
           </p>
-          <p class="hero-text">
-            HawkinsOperations is the governed successor architecture for detection engineering,
-            validation, evidence discipline, and public claim control. It separates source,
-            runtime, signal, evidence, and public-proof truth so AI-assisted security work can
-            be reviewed instead of merely generated.
-          </p>
-          <p class="claim-warning">
-            A claim does not become true because it appears on this site, exists in a repo, or
-            was produced with AI. It becomes public proof only after the required evidence path
-            and human authorization exist.
-          </p>
-          <div class="hero-actions">
-            <a class="button button-primary" href="#reviewer-start">Start review</a>
+          <div class="hero-actions" aria-label="Reviewer actions">
+            <a class="button button-primary" href="#reviewer-path">Start reviewer path</a>
             <a
               class="button"
               href="https://github.com/HawkinsOperations"
               target="_blank"
               rel="noopener noreferrer"
             >
-              Open GitHub org
+              View GitHub organization
             </a>
             <a
-              class="button"
-              href="https://hawkinsops.com"
+              class="button button-subtle"
+              href="https://github.com/HawkinsOperations/hawkinsoperations-validation/blob/main/docs/HO-DET-001_CLOSED_LOOP.md"
               target="_blank"
               rel="noopener noreferrer"
             >
-              Compare legacy HawkinsOps
+              View closed-loop HO-DET-001 walkthrough
             </a>
           </div>
         </div>
-        <aside class="hero-panel" aria-label="Public claim boundary">
-          <p class="panel-kicker">Reviewer shortcut</p>
-          <ul class="shortcut-list">
-            <li><a href="#reviewer-start">Reviewer start path</a></li>
-            <li><a href="#routing">Surface control map</a></li>
-            <li><a href="#status">Current status summary</a></li>
-            <li><a href="#boundaries">Truth boundaries</a></li>
-            <li><a href="#detection-path">HO-DET-001 proof path</a></li>
-          </ul>
+        <aside class="hero-signal" aria-label="Current public proof ceiling">
+          <p class="signal-label">Current public proof ceiling</p>
+          <p class="signal-value">TEST_VALIDATED_SYNTHETIC_SCOPE</p>
+          <p>
+            Website rendering is routing only. Public-safe status remains
+            <strong>BLOCKED / NOT_PUBLIC_SAFE</strong>.
+          </p>
         </aside>
       </section>
 
-      <section id="reviewer-start" class="section" aria-labelledby="reviewer-start-title">
+      <section id="reviewer-path" class="section" aria-labelledby="reviewer-path-title">
         <div class="section-heading">
-          <p class="eyebrow">Reviewer start path</p>
-          <h2 id="reviewer-start-title">Start with control, then inspect proof boundaries.</h2>
+          <p class="eyebrow">Reviewer path</p>
+          <h2 id="reviewer-path-title">Three links, then the boundary.</h2>
+          <p>
+            Start with the organization front door, inspect the closed-loop walkthrough, then
+            confirm status in the matrix.
+          </p>
         </div>
         <div class="reviewer-grid">
-          <a class="reviewer-card" href="https://github.com/HawkinsOperations/.github/blob/main/profile/START_HERE.md" target="_blank" rel="noopener noreferrer">
-            <span class="badge badge-soft">SOFT_ROUTING</span>
-            <h3>1. Start Here</h3>
-            <p><strong>Answers:</strong> where reviewers begin and how the organization is framed.</p>
-            <p><strong>Does not prove:</strong> source, runtime, signal, evidence, or public-safe status.</p>
-            <span class="open-link">Open</span>
-          </a>
-          <a class="reviewer-card" href="https://github.com/HawkinsOperations/.github/blob/main/governance/CONTROL_STATUS_MATRIX.md" target="_blank" rel="noopener noreferrer">
-            <span class="badge badge-report">REPORT_ONLY</span>
-            <h3>2. Control Status Matrix</h3>
-            <p><strong>Answers:</strong> current control states across surfaces.</p>
-            <p><strong>Does not prove:</strong> that a detection is running, validated, or public-safe.</p>
-            <span class="open-link">Open</span>
-          </a>
-          <a class="reviewer-card" href="https://github.com/HawkinsOperations/.github/blob/main/architecture/REPO_AUTHORITY_MAP.md" target="_blank" rel="noopener noreferrer">
-            <span class="badge badge-architecture">SUCCESSOR_ARCHITECTURE</span>
-            <h3>3. Repo Authority Map</h3>
-            <p><strong>Answers:</strong> what each repository owns.</p>
-            <p><strong>Does not prove:</strong> runtime truth or evidence linkage.</p>
-            <span class="open-link">Open</span>
-          </a>
-          <a class="reviewer-card" href="https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/records/HO-DET-001.md" target="_blank" rel="noopener noreferrer">
-            <span class="badge badge-report">TEST_VALIDATED_SYNTHETIC_SCOPE</span>
-            <h3>4. HO-DET-001 proof boundary</h3>
-            <p><strong>Answers:</strong> why HO-DET-001 is a successor ID and what the public proof record currently supports.</p>
-            <p><strong>Supports:</strong> source, Splunk source, and synthetic validation against controlled process-creation fixtures.</p>
-            <p><strong>Does not prove:</strong> production deployment, fleet-wide coverage, Cribl/Wazuh routing, public runtime-active status, public signal-observed status, evidence-linked public proof, or public-safe status.</p>
-            <span class="open-link">Open</span>
-          </a>
-          <a class="reviewer-card" href="https://hawkinsops.com" target="_blank" rel="noopener noreferrer">
-            <span class="badge badge-closed">CLOSED_V1_PROOF</span>
-            <h3>5. HawkinsOps V1 closed proof</h3>
-            <p><strong>Answers:</strong> historical closed proof for the original HawkinsOps surface.</p>
-            <p><strong>Does not prove:</strong> that V2 successor detections are promoted.</p>
-            <span class="open-link">Open</span>
-          </a>
-          <a class="reviewer-card" href="https://rayleeops.com" target="_blank" rel="noopener noreferrer">
-            <span class="badge badge-ledger">REVIEW_LEDGER</span>
-            <h3>6. Reviewed/narrowed claim ledger</h3>
-            <p><strong>Answers:</strong> contested-claim review and narrowed public wording.</p>
-            <p><strong>Does not prove:</strong> HawkinsOperations source, runtime, signal, or public-safe promotion.</p>
-            <span class="open-link">Open</span>
-          </a>
-        </div>
-      </section>
-
-      <section id="proof-scope" class="section" aria-labelledby="proof-scope-title">
-        <div class="section-heading">
-          <p class="eyebrow">Proof scope</p>
-          <h2 id="proof-scope-title">What this proves / What this does not prove</h2>
-        </div>
-        <div class="proof-scope-grid">
-          <article class="scope-card scope-card-yes">
-            <h3>What this proves</h3>
-            <ul>
-              <li>HawkinsOperations has a public successor architecture explanation.</li>
-              <li>The website separates public rendering from proof authority.</li>
-              <li>Reviewer-facing claim boundaries are stated before bulk migration.</li>
-            </ul>
-          </article>
-          <article class="scope-card scope-card-no">
-            <h3>What this does not prove</h3>
-            <ul>
-              <li>It does not prove production deployment or fleet-wide coverage.</li>
-              <li>It does not make private runtime evidence public-safe.</li>
-              <li>It does not make HO-DET-001 public-safe.</li>
-            </ul>
-          </article>
-        </div>
-      </section>
-
-      <section id="thesis" class="section split" aria-labelledby="thesis-title">
-        <div>
-          <p class="eyebrow">Core thesis</p>
-          <h2 id="thesis-title">AI is labor. Governance is authority.</h2>
-        </div>
-        <div class="section-copy">
-          <p>
-            AI can draft, compare, summarize, test candidate ideas, support implementation, and
-            help reviewers find inconsistencies.
-          </p>
-          <p>
-            AI cannot promote truth, approve public claims, declare runtime state, or own
-            evidence status. Human authorization controls final promotion.
-          </p>
-        </div>
-      </section>
-
-      <section class="section lifecycle-section" aria-labelledby="lifecycle-title">
-        <div class="section-heading compact-heading">
-          <p class="eyebrow">Claim lifecycle</p>
-          <h2 id="lifecycle-title">A public claim moves through gates.</h2>
-        </div>
-        <ol class="lifecycle-strip">
-          <li>Source exists</li>
-          <li>Static review</li>
-          <li>Test defined</li>
-          <li>Test validated</li>
-          <li>Runtime active</li>
-          <li>Signal observed</li>
-          <li>Evidence linked</li>
-          <li>Public safe</li>
-        </ol>
-      </section>
-
-      <section id="boundaries" class="section" aria-labelledby="boundaries-title">
-        <div class="section-heading">
-          <p class="eyebrow">Truth boundaries</p>
-          <h2 id="boundaries-title">Separate claims before they become public proof.</h2>
-        </div>
-        <div class="boundary-grid">
-          <article>
-            <span class="card-number">01</span>
-            <h3>Source truth</h3>
-            <p><strong>Counts:</strong> committed files or artifacts.</p>
-            <p><strong>Not:</strong> deployment or test pass.</p>
-            <p><strong>Allowed:</strong> source exists.</p>
-            <p><strong>Blocked:</strong> detection is validated.</p>
-          </article>
-          <article>
-            <span class="card-number">02</span>
-            <h3>Runtime truth</h3>
-            <p><strong>Counts:</strong> deployed and enabled system state.</p>
-            <p><strong>Not:</strong> repository text.</p>
-            <p><strong>Allowed:</strong> runtime not proven.</p>
-            <p><strong>Blocked:</strong> runtime-active.</p>
-          </article>
-          <article>
-            <span class="card-number">03</span>
-            <h3>Signal truth</h3>
-            <p><strong>Counts:</strong> observed telemetry or alert output.</p>
-            <p><strong>Not:</strong> expected behavior.</p>
-            <p><strong>Allowed:</strong> signal not observed.</p>
-            <p><strong>Blocked:</strong> signal-observed.</p>
-          </article>
-          <article>
-            <span class="card-number">04</span>
-            <h3>Evidence truth</h3>
-            <p><strong>Counts:</strong> preserved, linked support.</p>
-            <p><strong>Not:</strong> a claim summary.</p>
-            <p><strong>Allowed:</strong> evidence pending.</p>
-            <p><strong>Blocked:</strong> evidence-linked.</p>
-          </article>
-          <article>
-            <span class="card-number">05</span>
-            <h3>Public proof</h3>
-            <p><strong>Counts:</strong> reviewed and approved external wording.</p>
-            <p><strong>Not:</strong> website presence.</p>
-            <p><strong>Allowed:</strong> not public-safe.</p>
-            <p><strong>Blocked:</strong> public-safe.</p>
-          </article>
-          <article>
-            <span class="card-number">06</span>
-            <h3>Legacy/reference truth</h3>
-            <p><strong>Counts:</strong> scoped V1 context.</p>
-            <p><strong>Not:</strong> successor inheritance.</p>
-            <p><strong>Allowed:</strong> may inform review.</p>
-            <p><strong>Blocked:</strong> V1 proves V2.</p>
-          </article>
-        </div>
-      </section>
-
-      <section id="routing" class="section" aria-labelledby="routing-title">
-        <div class="section-heading">
-          <p class="eyebrow">Surface control map</p>
-          <h2 id="routing-title">Each surface owns a boundary. No surface claims another surface's truth.</h2>
-        </div>
-        <div class="control-map">
-          <a class="control-card" href="https://hawkinsops.com" target="_blank" rel="noopener noreferrer">
-            <span class="badge badge-closed">CLOSED_V1_PROOF</span>
-            <h3>HawkinsOps V1 closed proof surface</h3>
-            <p><strong>Owns:</strong> historical closed proof and portfolio surface.</p>
-            <p><strong>Current status:</strong> closed V1 reference.</p>
-            <p><strong>Proves:</strong> the V1 surface as presented there.</p>
-            <p><strong>Does not prove:</strong> V2 successor promotion.</p>
-            <p><strong>Next gate:</strong> reference only unless reclassified.</p>
-            <span class="open-link">Open</span>
-          </a>
-          <a class="control-card" href="https://rayleeops.com" target="_blank" rel="noopener noreferrer">
-            <span class="badge badge-ledger">REVIEW_LEDGER</span>
-            <h3>RayleeOps contested-claim review layer</h3>
-            <p><strong>Owns:</strong> reviewed and narrowed claim ledger.</p>
-            <p><strong>Current status:</strong> review layer.</p>
-            <p><strong>Proves:</strong> claim-review disposition where documented.</p>
-            <p><strong>Does not prove:</strong> HawkinsOperations runtime or source status.</p>
-            <p><strong>Next gate:</strong> use as context, not V2 proof.</p>
-            <span class="open-link">Open</span>
-          </a>
-          <a class="control-card" href="https://github.com/HawkinsOperations" target="_blank" rel="noopener noreferrer">
-            <span class="badge badge-architecture">SUCCESSOR_ARCHITECTURE</span>
-            <h3>HawkinsOperations GitHub org</h3>
-            <p><strong>Owns:</strong> successor repositories and public governance entry points.</p>
-            <p><strong>Current status:</strong> successor architecture.</p>
-            <p><strong>Proves:</strong> repository presence and published control docs.</p>
-            <p><strong>Does not prove:</strong> runtime, signal, evidence, or public-safe status.</p>
-            <p><strong>Next gate:</strong> inspect repo authority and status matrix.</p>
-            <span class="open-link">Open</span>
-          </a>
-          <a class="control-card" href="https://github.com/HawkinsOperations/hawkinsoperations-website" target="_blank" rel="noopener noreferrer">
-            <span class="badge badge-rendering">RENDERING_ONLY</span>
-            <h3>HawkinsOperations website</h3>
-            <p><strong>Owns:</strong> reviewer routing and public explanation.</p>
-            <p><strong>Current status:</strong> rendering only.</p>
-            <p><strong>Proves:</strong> the site can display scoped public wording.</p>
-            <p><strong>Does not prove:</strong> source, runtime, signal, evidence, or public-safe status.</p>
-            <p><strong>Next gate:</strong> follow linked source and control docs.</p>
-            <span class="open-link">Open</span>
-          </a>
-          <a class="control-card" href="https://github.com/HawkinsOperations/hawkinsoperations-detections" target="_blank" rel="noopener noreferrer">
-            <span class="badge badge-source">SOURCE_EXISTS</span>
-            <h3>Detections repo</h3>
-            <p><strong>Owns:</strong> governed detection source candidates.</p>
-            <p><strong>Current status:</strong> source exists where files are present.</p>
-            <p><strong>Proves:</strong> source presence only.</p>
-            <p><strong>Does not prove:</strong> validation, deployment, signal, or public-safe use.</p>
-            <p><strong>Next gate:</strong> static review and validation plan.</p>
-            <span class="open-link">Open</span>
-          </a>
-          <a class="control-card" href="https://github.com/HawkinsOperations/hawkinsoperations-proof" target="_blank" rel="noopener noreferrer">
-            <span class="badge badge-report">REPORT_ONLY</span>
-            <h3>Proof repo</h3>
-            <p><strong>Owns:</strong> proof contracts, ID boundaries, and claim linkage records.</p>
-            <p><strong>Current status:</strong> boundary records and proof scaffolding.</p>
-            <p><strong>Proves:</strong> proof path definitions where committed.</p>
-            <p><strong>Does not prove:</strong> runtime or signal state by itself.</p>
-            <p><strong>Next gate:</strong> link reviewed evidence before promotion.</p>
-            <span class="open-link">Open</span>
-          </a>
-          <a class="control-card" href="https://github.com/HawkinsOperations/.github" target="_blank" rel="noopener noreferrer">
-            <span class="badge badge-soft">SOFT_ROUTING</span>
-            <h3>.github governance front door</h3>
-            <p><strong>Owns:</strong> reviewer start, matrix summaries, and authority maps.</p>
-            <p><strong>Current status:</strong> soft routing unless a document blocks, fails, or forces correction.</p>
-            <p><strong>Proves:</strong> governance instructions are published.</p>
-            <p><strong>Does not prove:</strong> any detection is promoted.</p>
-            <p><strong>Next gate:</strong> follow blocking or correction rules if triggered.</p>
-            <span class="open-link">Open</span>
-          </a>
-          <a class="control-card" href="https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/records/HO-DET-001.md" target="_blank" rel="noopener noreferrer">
-            <span class="badge badge-report">TEST_VALIDATED_SYNTHETIC_SCOPE</span>
-            <h3>HO-DET-001 successor detection path</h3>
-            <p><strong>Owns:</strong> the successor detection ID boundary.</p>
-            <p><strong>Current status:</strong> public repo proof level TEST_VALIDATED_SYNTHETIC_SCOPE.</p>
-            <p><strong>Proves:</strong> source, Splunk source, and synthetic validation against controlled positive and negative process-creation fixtures.</p>
-            <p><strong>Private lab note:</strong> a controlled lab runtime match has been captured locally, but it is not public-safe proof.</p>
-            <p><strong>Does not prove:</strong> production deployment, fleet-wide coverage, Cribl/Wazuh routing, public runtime-active status, public signal-observed status, evidence-linked public proof, or public-safe status.</p>
-            <p><strong>Next gate:</strong> reviewed wording, privacy review, stale review, evidence linkage review, and Raylee approval before any public-safe promotion.</p>
-            <span class="open-link">Open</span>
-          </a>
-        </div>
-      </section>
-
-      <section id="status" class="section status-section" aria-labelledby="status-title">
-        <div>
-          <p class="eyebrow">Current status</p>
-          <h2 id="status-title">Website summary of the control matrix.</h2>
-          <p class="section-note">
-            This is a skim summary only. The full matrix remains the control reference.
-          </p>
           <a
-            class="button"
-            href="https://github.com/HawkinsOperations/.github/blob/main/governance/CONTROL_STATUS_MATRIX.md"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Open full matrix
-          </a>
-        </div>
-        <div class="status-summary-grid" aria-label="Current status matrix summary">
-          <article class="status-summary-card">
-            <p class="status-surface">Website</p>
-            <p><strong>Current state:</strong> RENDERING_ONLY</p>
-            <p><strong>Truth surface:</strong> public presentation.</p>
-            <p>This site is a public routing surface; website rendering is not proof.</p>
-            <p><strong>Proven:</strong> reviewer routes and warnings render.</p>
-            <p><strong>Not proven:</strong> source, runtime, signal, evidence, or public-safe status.</p>
-            <p><strong>Next action:</strong> follow linked authority docs.</p>
-          </article>
-          <article class="status-summary-card">
-            <p class="status-surface">.github governance docs</p>
-            <p><strong>Current state:</strong> SOFT_ROUTING / REPORT_ONLY</p>
-            <p><strong>Truth surface:</strong> governance front door.</p>
-            <p><strong>Proven:</strong> routing and control summaries exist.</p>
-            <p><strong>Not proven:</strong> detection promotion by themselves.</p>
-            <p><strong>Next action:</strong> check blocks, failures, or forced corrections.</p>
-          </article>
-          <article class="status-summary-card">
-            <p class="status-surface">HO-DET-001 source</p>
-            <p><strong>Current state:</strong> TEST_VALIDATED_SYNTHETIC_SCOPE</p>
-            <p><strong>Truth surface:</strong> detections, validation, and proof repos.</p>
-            <p><strong>Proven:</strong> HO-DET-001 source exists. HO-DET-001 Splunk source exists. HO-DET-001 passed synthetic validation against controlled positive and negative process-creation fixtures.</p>
-            <p><strong>Private lab note:</strong> a controlled lab runtime match has been captured locally, but it is not public-safe proof.</p>
-            <p><strong>Blocked:</strong> production, fleet-wide, Cribl-routed, Wazuh-routed, public runtime-active, public signal-observed, evidence-linked public proof, and public-safe claims.</p>
-            <p><strong>Next action:</strong> public-safe remains blocked pending review and approval.</p>
-          </article>
-          <article class="status-summary-card">
-            <p class="status-surface">HOD-001 baseline proof</p>
-            <p><strong>Current state:</strong> CLOSED_V1_PROOF</p>
-            <p><strong>Truth surface:</strong> legacy/reference proof.</p>
-            <p><strong>Proven:</strong> baseline/reference chain for V1 context.</p>
-            <p><strong>Not proven:</strong> HOD-001 does not validate/promote HO-DET-001.</p>
-            <p><strong>Next action:</strong> use for review context only.</p>
-          </article>
-          <article class="status-summary-card">
-            <p class="status-surface">RayleeOps registry</p>
-            <p><strong>Current state:</strong> REVIEW_LEDGER</p>
-            <p><strong>Truth surface:</strong> claim review layer.</p>
-            <p><strong>Proven:</strong> narrowed claim disposition where documented.</p>
-            <p><strong>Not proven:</strong> HawkinsOperations runtime or source truth.</p>
-            <p><strong>Next action:</strong> use as review ledger context.</p>
-          </article>
-          <article class="status-summary-card">
-            <p class="status-surface">HawkinsOps V1 metrics</p>
-            <p><strong>Current state:</strong> CLOSED_V1_PROOF</p>
-            <p><strong>Truth surface:</strong> historical proof surface.</p>
-            <p><strong>Proven:</strong> V1 metric presentation where scoped there.</p>
-            <p><strong>Not proven:</strong> automatic V2 inheritance.</p>
-            <p><strong>Next action:</strong> do not promote into V2 without gates.</p>
-          </article>
-        </div>
-      </section>
-
-      <section id="detection-path" class="section detection-path" aria-labelledby="detection-title">
-        <p class="eyebrow">Promotion model</p>
-        <h2 id="detection-title">HO-DET-001 is not promoted by HOD-001.</h2>
-        <div class="boundary-callout">
-          <span class="badge badge-report">TEST_VALIDATED_SYNTHETIC_SCOPE</span>
-          <ul>
-            <li>HOD-001 = baseline/reference proof chain.</li>
-            <li>HO-DET-001 = successor governed detection ID.</li>
-            <li>HOD-001 may inform review.</li>
-            <li>HOD-001 does not validate, promote, or make HO-DET-001 public-safe.</li>
-            <li>HO-DET-001 has merged source, Splunk source, and synthetic validation artifacts.</li>
-            <li>The public proof record supports TEST_VALIDATED_SYNTHETIC_SCOPE.</li>
-            <li>A private controlled lab runtime match has been captured locally, but public-safe promotion remains blocked pending review.</li>
-          </ul>
-        </div>
-        <div class="blocked-claims" aria-label="Blocked claims for HO-DET-001">
-          <h3>Blocked claims</h3>
-          <span class="badge badge-blocked">production-ready</span>
-          <span class="badge badge-blocked">fleet-wide</span>
-          <span class="badge badge-blocked">Cribl-routed</span>
-          <span class="badge badge-blocked">Wazuh-routed</span>
-          <span class="badge badge-blocked">runtime-active</span>
-          <span class="badge badge-blocked">signal-observed</span>
-          <span class="badge badge-blocked">evidence-linked public proof</span>
-          <span class="badge badge-blocked">public-safe</span>
-        </div>
-      </section>
-
-      <section class="reviewer-note" aria-labelledby="reviewer-note-title">
-        <h2 id="reviewer-note-title">Reviewer note</h2>
-        <p>
-          The successor architecture is being published before bulk migration so legacy artifacts
-          do not inherit successor trust automatically. Claims are promoted only when the
-          supporting evidence and review path exist.
-        </p>
-        <p>
-          Reviewers should begin with the
-          <a
+            class="card"
             href="https://github.com/HawkinsOperations/.github/blob/main/profile/START_HERE.md"
             target="_blank"
             rel="noopener noreferrer"
           >
-            HawkinsOperations Start Here
+            <span class="card-index">01</span>
+            <h3>Start Here</h3>
+            <p>Reviewer routing for the HawkinsOperations organization and its public entry points.</p>
+            <span class="open-link">Open reviewer start</span>
           </a>
-          guide and the
           <a
+            class="card"
+            href="https://github.com/HawkinsOperations/hawkinsoperations-validation/blob/main/docs/HO-DET-001_CLOSED_LOOP.md"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span class="card-index">02</span>
+            <h3>HO-DET-001 closed-loop walkthrough</h3>
+            <p>Validation path context for HO-DET-001 without promoting public-safe proof.</p>
+            <span class="open-link">Open walkthrough</span>
+          </a>
+          <a
+            class="card"
             href="https://github.com/HawkinsOperations/.github/blob/main/governance/CONTROL_STATUS_MATRIX.md"
             target="_blank"
             rel="noopener noreferrer"
           >
-            Control Status Matrix
-          </a>.
+            <span class="card-index">03</span>
+            <h3>Control Status Matrix</h3>
+            <p>Current public control states and claim boundaries across reviewer surfaces.</p>
+            <span class="open-link">Open matrix</span>
+          </a>
+        </div>
+      </section>
+
+      <section id="proof-boundary" class="section boundary-section" aria-labelledby="proof-boundary-title">
+        <div class="section-heading compact">
+          <p class="eyebrow">Proof boundary</p>
+          <h2 id="proof-boundary-title">Readable in ten seconds.</h2>
+        </div>
+        <div class="proof-grid">
+          <article class="proof-panel supported">
+            <h3>Supported now</h3>
+            <ul>
+              <li>source exists</li>
+              <li>Splunk source exists</li>
+              <li>synthetic validation passed</li>
+              <li>TEST_VALIDATED_SYNTHETIC_SCOPE</li>
+            </ul>
+          </article>
+          <article class="proof-panel not-claimed">
+            <h3>Not claimed</h3>
+            <ul>
+              <li>production-ready</li>
+              <li>fleet-wide</li>
+              <li>public-safe</li>
+              <li>Cribl-routed</li>
+              <li>Wazuh-routed</li>
+              <li>public runtime-active</li>
+              <li>public signal-observed</li>
+            </ul>
+          </article>
+        </div>
+        <p class="boundary-note">
+          Private runtime match is not public-safe proof. Cribl-routed is NOT_PROVEN.
+          Wazuh-routed is NOT_PROVEN. Website rendering is not proof.
+        </p>
+      </section>
+
+      <section id="architecture" class="section" aria-labelledby="architecture-title">
+        <div class="section-heading">
+          <p class="eyebrow">Architecture map</p>
+          <h2 id="architecture-title">Claims move forward only when the next truth surface supports them.</h2>
+        </div>
+        <ol class="flow" aria-label="Claim promotion flow">
+          <li>Source</li>
+          <li>Validation</li>
+          <li>Runtime</li>
+          <li>Signal</li>
+          <li>Evidence</li>
+          <li>Public proof</li>
+        </ol>
+      </section>
+
+      <section id="surfaces" class="section" aria-labelledby="surfaces-title">
+        <div class="section-heading">
+          <p class="eyebrow">Surface map</p>
+          <h2 id="surfaces-title">Each surface has a job. None of them inherit proof by presentation.</h2>
+        </div>
+        <div class="surface-grid">
+          <a
+            class="surface-card"
+            href="https://github.com/HawkinsOperations"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <h3>HawkinsOperations GitHub org</h3>
+            <p>Successor organization, reviewer routing, and public governance entry points.</p>
+          </a>
+          <a
+            class="surface-card"
+            href="https://github.com/HawkinsOperations/hawkinsoperations-detections"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <h3>Detections repo</h3>
+            <p>Detection source candidates. Source presence does not prove deployment or signal.</p>
+          </a>
+          <a
+            class="surface-card"
+            href="https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/records/HO-DET-001.md"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <h3>Validation/proof path</h3>
+            <p>HO-DET-001 public record stays at TEST_VALIDATED_SYNTHETIC_SCOPE until promoted.</p>
+          </a>
+          <a
+            class="surface-card"
+            href="https://hawkinsops.com"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <h3>Legacy HawkinsOps / RayleeOps context</h3>
+            <p>Historical and review context only. Legacy material does not automatically prove V2.</p>
+          </a>
+        </div>
+      </section>
+
+      <section class="section final-boundary" aria-labelledby="final-boundary-title">
+        <p class="eyebrow">Claim safety</p>
+        <h2 id="final-boundary-title">What this page does not promote.</h2>
+        <p>
+          HawkinsOperations does not claim production deployment, fleet-wide coverage, active
+          public deployment, attack coverage, public signal observation, or evidence-linked
+          public proof for HO-DET-001.
         </p>
       </section>
     </main>
@@ -512,20 +263,15 @@
     <footer class="site-footer" aria-labelledby="identity-title">
       <div>
         <h2 id="identity-title">Raylee Hawkins</h2>
-        <p>Detection Engineer | SOC Automation | Detection-as-Code | Security Automation</p>
+        <p>Detection engineering, SOC automation, detection-as-code, and security automation.</p>
       </div>
-      <nav class="identity-links" aria-label="Identity and project links">
+      <nav class="identity-links" aria-label="Raylee Hawkins identity links">
         <a href="https://www.linkedin.com/in/raylee-hawkins" target="_blank" rel="noopener noreferrer">
           LinkedIn
         </a>
         <a href="https://github.com/raylee-hawkins" target="_blank" rel="noopener noreferrer">
           GitHub
         </a>
-        <a href="https://hawkinsops.com" target="_blank" rel="noopener noreferrer">HawkinsOps</a>
-        <a href="https://rayleeops.com" target="_blank" rel="noopener noreferrer">
-          RayleeOps / The Ledger
-        </a>
-        <a href="https://hawkinsoperations.com">HawkinsOperations</a>
       </nav>
     </footer>
   </body>

--- a/styles.css
+++ b/styles.css
@@ -1,19 +1,22 @@
 :root {
   color-scheme: dark;
-  --ink: #f4f8fb;
-  --muted: #aebdca;
-  --paper: #05090d;
-  --panel: #0d1520;
-  --panel-strong: #111c2a;
-  --line: #203244;
-  --accent: #13c8d4;
-  --accent-strong: #7be7e1;
-  --green: #2ff08a;
-  --gold: #e4bb4a;
-  --danger: #ffb36b;
-  --red: #ff6b7d;
-  --violet: #b7a4ff;
-  --shadow: 0 24px 60px rgba(0, 0, 0, 0.34);
+  --paper: #030712;
+  --paper-deep: #01040a;
+  --panel: #07111f;
+  --panel-strong: #0d1b2d;
+  --panel-soft: rgba(8, 20, 36, 0.72);
+  --line: #244159;
+  --line-soft: rgba(116, 159, 190, 0.2);
+  --accent: #72f1ff;
+  --accent-strong: #b9f7ff;
+  --secondary: #8f9cff;
+  --teal: #68d8d6;
+  --muted: #8ea3b8;
+  --ink: #eef7ff;
+  --ink-soft: #c4d4e2;
+  --blocked: #d6a6ff;
+  --shadow: 0 28px 80px rgba(0, 0, 0, 0.38);
+  --radius: 8px;
 }
 
 * {
@@ -25,15 +28,17 @@ html {
 }
 
 body {
+  min-width: 0;
   margin: 0;
+  overflow-x: clip;
   background:
-    radial-gradient(circle at 12% 18%, rgba(19, 200, 212, 0.12), transparent 24%),
-    radial-gradient(circle at 82% 8%, rgba(47, 240, 138, 0.08), transparent 22%),
-    linear-gradient(180deg, #070d13 0%, var(--paper) 42%, #070d13 100%);
+    radial-gradient(circle at 18% 16%, rgba(114, 241, 255, 0.15), transparent 28%),
+    radial-gradient(circle at 84% 6%, rgba(143, 156, 255, 0.13), transparent 28%),
+    linear-gradient(180deg, var(--paper) 0%, var(--paper-deep) 56%, #030814 100%);
   color: var(--ink);
   font-family:
     Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  line-height: 1.6;
+  line-height: 1.55;
 }
 
 body::before {
@@ -43,10 +48,28 @@ body::before {
   pointer-events: none;
   content: "";
   background-image:
-    linear-gradient(rgba(19, 200, 212, 0.08) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(19, 200, 212, 0.08) 1px, transparent 1px);
-  background-size: 96px 96px;
-  mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.5), transparent 82%);
+    linear-gradient(rgba(114, 241, 255, 0.055) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(114, 241, 255, 0.045) 1px, transparent 1px);
+  background-size: 112px 112px;
+  mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.78), transparent 72%);
+}
+
+body::after {
+  position: fixed;
+  top: 10%;
+  right: max(24px, 8vw);
+  z-index: -1;
+  width: min(36vw, 420px);
+  aspect-ratio: 1;
+  pointer-events: none;
+  content: "";
+  border: 1px solid rgba(114, 241, 255, 0.18);
+  border-radius: 50%;
+  background:
+    linear-gradient(90deg, transparent 49.7%, rgba(114, 241, 255, 0.16) 50%, transparent 50.3%),
+    linear-gradient(0deg, transparent 49.7%, rgba(143, 156, 255, 0.14) 50%, transparent 50.3%);
+  opacity: 0.42;
+  filter: blur(0.2px);
 }
 
 a {
@@ -62,61 +85,62 @@ a:focus-visible,
 .site-header {
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: 20;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 24px;
-  padding: 18px clamp(20px, 5vw, 72px);
-  background: rgba(5, 9, 13, 0.88);
-  border-bottom: 1px solid var(--line);
-  backdrop-filter: blur(16px);
+  padding: 16px clamp(18px, 5vw, 72px);
+  border-bottom: 1px solid var(--line-soft);
+  background: rgba(3, 7, 18, 0.82);
+  backdrop-filter: blur(18px);
+}
+
+.brand,
+.nav,
+.identity-links {
+  display: flex;
+  align-items: center;
 }
 
 .brand {
-  display: inline-flex;
-  align-items: center;
   gap: 10px;
-  font-weight: 750;
+  color: var(--ink);
+  font-weight: 800;
   text-decoration: none;
 }
 
 .brand-mark {
-  width: 28px;
-  height: 28px;
-  border: 2px solid var(--accent);
-  border-radius: 7px;
+  width: 26px;
+  height: 26px;
+  border: 1px solid rgba(114, 241, 255, 0.76);
+  border-radius: 8px;
   background:
-    linear-gradient(135deg, transparent 47%, var(--gold) 48% 55%, transparent 56%),
-    linear-gradient(45deg, var(--accent) 0 48%, rgba(47, 240, 138, 0.2) 49%);
-  box-shadow: 0 0 22px rgba(19, 200, 212, 0.28);
+    linear-gradient(135deg, rgba(114, 241, 255, 0.95) 0 46%, transparent 47%),
+    linear-gradient(315deg, rgba(143, 156, 255, 0.55) 0 48%, transparent 49%);
+  box-shadow: 0 0 20px rgba(114, 241, 255, 0.18);
 }
 
 .nav,
 .identity-links {
-  display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
   gap: 8px 18px;
-  color: #c6d2dc;
+  color: var(--ink-soft);
   font-size: 0.92rem;
 }
 
 .nav a,
 .identity-links a,
-.shortcut-list a,
-.route-list a,
-.reviewer-card,
-.control-card {
+.card,
+.surface-card {
   text-decoration: none;
 }
 
 .nav a:hover,
 .identity-links a:hover,
-.shortcut-list a:hover,
-.route-list a:hover,
-.reviewer-card:hover,
-.control-card:hover {
+.card:hover,
+.surface-card:hover {
   color: var(--accent-strong);
 }
 
@@ -127,23 +151,34 @@ main,
 }
 
 .hero {
-  min-height: calc(100vh - 65px);
+  position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 1.08fr) minmax(310px, 0.92fr);
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 0.38fr);
   align-items: center;
-  gap: clamp(28px, 6vw, 80px);
-  padding: clamp(58px, 9vw, 108px) 0 clamp(36px, 6vw, 74px);
+  gap: clamp(28px, 6vw, 76px);
+  min-height: calc(100vh - 62px);
+  padding: clamp(72px, 10vw, 132px) 0 clamp(44px, 7vw, 80px);
+}
+
+.hero::before {
+  position: absolute;
+  right: 28%;
+  bottom: 16%;
+  width: 42%;
+  height: 1px;
+  content: "";
+  background: linear-gradient(90deg, transparent, rgba(114, 241, 255, 0.58), transparent);
 }
 
 .hero-copy {
-  max-width: 830px;
+  max-width: 820px;
 }
 
 .eyebrow {
   margin: 0 0 12px;
   color: var(--accent);
-  font-size: 0.78rem;
-  font-weight: 800;
+  font-size: 0.76rem;
+  font-weight: 850;
   letter-spacing: 0;
   text-transform: uppercase;
 }
@@ -151,293 +186,215 @@ main,
 h1,
 h2,
 h3,
-p {
+p,
+li {
   overflow-wrap: break-word;
 }
 
 h1 {
   margin: 0;
-  font-size: clamp(2.25rem, 5.1vw, 4.65rem);
-  line-height: 0.96;
+  color: #ffffff;
+  max-width: 100%;
+  font-size: clamp(2.15rem, 5.35vw, 5rem);
+  line-height: 0.94;
   letter-spacing: 0;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
 }
 
 h2 {
+  max-width: 880px;
   margin: 0;
-  font-size: clamp(1.8rem, 4.1vw, 4rem);
+  color: #ffffff;
+  font-size: clamp(1.75rem, 3.8vw, 3.4rem);
   line-height: 1.04;
   letter-spacing: 0;
 }
 
 h3 {
-  margin: 0 0 8px;
-  font-size: 1rem;
-  line-height: 1.25;
+  margin: 0;
+  color: #ffffff;
+  font-size: 1.04rem;
+  line-height: 1.24;
 }
 
 .subtitle {
-  margin: 22px 0 0;
+  max-width: 780px;
+  margin: 24px 0 0;
   color: var(--accent-strong);
-  font-size: clamp(1.28rem, 2.7vw, 2.05rem);
-  font-weight: 700;
+  font-size: clamp(1.35rem, 2.7vw, 2.2rem);
+  font-weight: 760;
+  line-height: 1.16;
 }
 
-.strategic-frame,
-.claim-warning {
-  max-width: 720px;
-  margin: 18px 0 0;
-  color: var(--ink);
-  font-size: clamp(1.02rem, 1.5vw, 1.15rem);
-  font-weight: 750;
+.value-statement,
+.section-heading p,
+.final-boundary p,
+.site-footer p {
+  color: var(--ink-soft);
 }
 
-.claim-warning {
-  padding-left: 16px;
-  border-left: 3px solid var(--accent);
-  color: #d5e1eb;
-  font-weight: 650;
-}
-
-.hero-text {
-  max-width: 735px;
-  margin: 20px 0 0;
-  color: #c1cdd8;
-  font-size: clamp(1rem, 1.55vw, 1.18rem);
+.value-statement {
+  max-width: 700px;
+  margin: 22px 0 0;
+  font-size: clamp(1.04rem, 1.5vw, 1.2rem);
 }
 
 .hero-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
-  margin-top: 28px;
+  margin-top: 30px;
 }
 
 .button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 42px;
-  padding: 10px 14px;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: rgba(17, 28, 42, 0.9);
+  min-height: 44px;
+  max-width: 100%;
+  padding: 10px 15px;
+  border: 1px solid rgba(142, 179, 205, 0.36);
+  border-radius: var(--radius);
+  background: rgba(13, 27, 45, 0.82);
   color: var(--ink);
-  font-weight: 750;
+  font-weight: 760;
+  line-height: 1.2;
+  text-align: center;
   text-decoration: none;
 }
 
 .button:hover {
-  border-color: rgba(19, 200, 212, 0.56);
+  border-color: rgba(114, 241, 255, 0.62);
   color: var(--accent-strong);
 }
 
 .button-primary {
-  border-color: rgba(19, 200, 212, 0.58);
-  background: rgba(19, 200, 212, 0.14);
-  color: var(--accent-strong);
+  border-color: rgba(114, 241, 255, 0.7);
+  background: linear-gradient(135deg, rgba(114, 241, 255, 0.18), rgba(143, 156, 255, 0.12));
+  color: #ffffff;
 }
 
-.hero-panel,
-.scope-card,
-.boundary-grid article,
-.route-list article,
-.reviewer-card,
-.control-card,
-.boundary-callout,
-.blocked-claims,
-.status-summary-card,
-.status-cards article,
-.reviewer-note,
+.button-subtle {
+  border-color: rgba(143, 156, 255, 0.42);
+}
+
+.hero-signal,
+.card,
+.proof-panel,
+.surface-card,
+.final-boundary,
 .site-footer {
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: rgba(13, 21, 32, 0.84);
-  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.04) inset;
+  border: 1px solid var(--line-soft);
+  border-radius: var(--radius);
+  background:
+    linear-gradient(180deg, rgba(13, 27, 45, 0.84), rgba(7, 17, 31, 0.68));
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.045) inset;
 }
 
-.hero-panel {
-  align-self: center;
-  padding: 24px;
-  background:
-    linear-gradient(180deg, rgba(17, 28, 42, 0.96), rgba(9, 17, 26, 0.96));
+.hero-signal {
+  padding: 22px;
   box-shadow: var(--shadow);
 }
 
-.panel-kicker {
-  margin: 0 0 14px;
-  color: var(--accent);
-  font-size: 0.82rem;
-  font-weight: 800;
+.hero-signal p {
+  margin: 0;
+  color: var(--ink-soft);
+}
+
+.hero-signal p + p {
+  margin-top: 12px;
+}
+
+.signal-label {
+  color: var(--accent) !important;
+  font-size: 0.74rem;
+  font-weight: 850;
   text-transform: uppercase;
 }
 
-.shortcut-list {
-  display: grid;
-  gap: 10px;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.shortcut-list a {
-  display: block;
-  padding: 10px 12px;
-  border-left: 3px solid var(--accent);
-  border-radius: 6px;
-  background: rgba(19, 200, 212, 0.08);
-  color: #d5e1eb;
+.signal-value {
+  color: #ffffff !important;
+  font-size: clamp(1.05rem, 2vw, 1.35rem);
+  font-weight: 850;
+  line-height: 1.12;
 }
 
 .section {
   padding: clamp(48px, 7vw, 84px) 0;
-  border-top: 1px solid var(--line);
+  border-top: 1px solid var(--line-soft);
 }
 
-.section-heading,
-.compact-heading {
-  max-width: 920px;
+.section-heading {
+  max-width: 880px;
 }
 
-.split,
-.status-section {
-  display: grid;
-  grid-template-columns: minmax(0, 0.86fr) minmax(0, 1.14fr);
-  gap: clamp(28px, 6vw, 72px);
+.section-heading p {
+  max-width: 720px;
+  margin: 16px 0 0;
+  font-size: 1.04rem;
 }
 
-.section-copy p,
-.detection-path p,
-.reviewer-note p,
-.site-footer p {
-  margin: 0;
-  color: #c1cdd8;
-  font-size: 1.06rem;
+.compact {
+  max-width: 700px;
 }
 
-.section-copy p + p {
-  margin-top: 16px;
-}
-
-.proof-scope-grid,
-.boundary-grid,
-.route-list,
 .reviewer-grid,
-.control-map,
-.status-summary-grid,
-.status-cards {
+.proof-grid,
+.surface-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 14px;
   margin-top: 28px;
 }
 
-.proof-scope-grid {
+.reviewer-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.surface-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.proof-grid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.reviewer-grid {
-  grid-template-columns: repeat(6, minmax(0, 1fr));
-  align-items: stretch;
-}
-
-.scope-card,
-.boundary-grid article,
-.route-list article,
-.reviewer-card,
-.control-card,
-.status-cards article {
-  min-height: 128px;
+.card,
+.surface-card {
+  display: flex;
+  min-width: 0;
+  min-height: 210px;
+  flex-direction: column;
+  gap: 14px;
   padding: 20px;
 }
 
-.reviewer-card,
-.control-card {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  color: var(--ink);
+.surface-card {
+  min-height: 178px;
+}
+
+.card:hover,
+.surface-card:hover {
+  border-color: rgba(114, 241, 255, 0.6);
   background:
-    linear-gradient(180deg, rgba(17, 28, 42, 0.94), rgba(9, 17, 26, 0.9));
+    linear-gradient(180deg, rgba(14, 36, 58, 0.9), rgba(7, 17, 31, 0.74));
 }
 
-.reviewer-card {
-  grid-column: span 2;
+.card-index {
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 900;
 }
 
-.reviewer-card:hover,
-.control-card:hover {
-  border-color: rgba(19, 200, 212, 0.64);
-  transform: translateY(-2px);
-}
-
-.reviewer-card p,
-.control-card p {
+.card p,
+.surface-card p {
   margin: 0;
-  color: #b6c4d0;
-  font-size: 0.94rem;
-  line-height: 1.48;
-}
-
-.reviewer-card strong,
-.control-card strong,
-.boundary-grid strong,
-.status-summary-card strong {
-  color: #e6f0f6;
-}
-
-.badge {
-  display: inline-flex;
-  align-items: center;
-  align-self: flex-start;
-  min-height: 24px;
-  padding: 3px 8px;
-  border: 1px solid rgba(19, 200, 212, 0.42);
-  border-radius: 999px;
-  background: rgba(19, 200, 212, 0.12);
-  color: var(--accent-strong);
-  font-size: 0.68rem;
-  font-weight: 850;
-  line-height: 1;
-}
-
-.badge-closed {
-  border-color: rgba(228, 187, 74, 0.48);
-  background: rgba(228, 187, 74, 0.12);
-  color: #ffe39a;
-}
-
-.badge-ledger,
-.badge-architecture {
-  border-color: rgba(183, 164, 255, 0.5);
-  background: rgba(183, 164, 255, 0.12);
-  color: #d7ccff;
-}
-
-.badge-source,
-.badge-report {
-  border-color: rgba(47, 240, 138, 0.42);
-  background: rgba(47, 240, 138, 0.1);
-  color: #9ef8c8;
-}
-
-.badge-rendering,
-.badge-soft {
-  border-color: rgba(19, 200, 212, 0.42);
-  background: rgba(19, 200, 212, 0.12);
-  color: var(--accent-strong);
-}
-
-.badge-blocked {
-  border-color: rgba(255, 107, 125, 0.5);
-  background: rgba(255, 107, 125, 0.12);
-  color: #ffb8c1;
+  color: var(--muted);
 }
 
 .open-link {
   margin-top: auto;
   color: var(--accent);
-  font-size: 0.8rem;
+  font-size: 0.78rem;
   font-weight: 850;
   text-transform: uppercase;
 }
@@ -446,245 +403,194 @@ h3 {
   content: " ->";
 }
 
-.scope-card ul {
+.boundary-section {
   display: grid;
-  gap: 8px;
-  margin: 12px 0 0;
+  grid-template-columns: minmax(0, 0.72fr) minmax(0, 1fr);
+  gap: clamp(24px, 5vw, 64px);
+  align-items: start;
+}
+
+.proof-grid {
+  margin-top: 0;
+}
+
+.proof-panel {
+  padding: 22px;
+}
+
+.proof-panel h3 {
+  margin-bottom: 16px;
+}
+
+.proof-panel ul {
+  display: grid;
+  gap: 9px;
+  margin: 0;
+  padding: 0;
+  color: var(--ink-soft);
+  list-style: none;
+}
+
+.proof-panel li {
+  position: relative;
   padding-left: 18px;
-  color: #c1cdd8;
 }
 
-.scope-card-yes {
-  border-left: 4px solid var(--green);
+.proof-panel li::before {
+  position: absolute;
+  top: 0.68em;
+  left: 0;
+  width: 7px;
+  height: 7px;
+  content: "";
+  border-radius: 50%;
+  background: var(--accent);
+  transform: translateY(-50%);
 }
 
-.scope-card-no {
-  border-left: 4px solid var(--danger);
+.not-claimed li::before {
+  background: var(--blocked);
 }
 
-.lifecycle-strip {
+.supported {
+  border-color: rgba(114, 241, 255, 0.38);
+}
+
+.not-claimed {
+  border-color: rgba(143, 156, 255, 0.38);
+}
+
+.boundary-note {
+  grid-column: 2;
+  margin: 2px 0 0;
+  padding: 14px 16px;
+  border: 1px solid rgba(143, 156, 255, 0.32);
+  border-radius: var(--radius);
+  background: rgba(143, 156, 255, 0.08);
+  color: var(--ink-soft);
+}
+
+.flow {
   display: grid;
-  grid-template-columns: repeat(8, minmax(0, 1fr));
-  gap: 8px;
-  margin: 26px 0 0;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 0;
+  margin: 30px 0 0;
   padding: 0;
   list-style: none;
-  counter-reset: stage;
 }
 
-.lifecycle-strip li {
-  min-height: 76px;
-  padding: 12px;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: rgba(17, 28, 42, 0.72);
-  color: #d5e1eb;
-  font-size: 0.88rem;
-  font-weight: 720;
-}
-
-.lifecycle-strip li::before {
-  display: block;
-  margin-bottom: 6px;
-  color: var(--accent);
-  font-size: 0.72rem;
-  font-weight: 850;
-  counter-increment: stage;
-  content: counter(stage, decimal-leading-zero);
-}
-
-.boundary-grid article {
+.flow li {
   position: relative;
   display: grid;
-  gap: 8px;
-  border-left: 4px solid rgba(19, 200, 212, 0.7);
+  min-height: 78px;
+  place-items: center;
+  padding: 12px;
+  border: 1px solid rgba(114, 241, 255, 0.26);
+  background: rgba(7, 17, 31, 0.74);
+  color: var(--ink);
+  font-weight: 800;
+  text-align: center;
 }
 
-.card-number {
-  display: inline-block;
-  margin-bottom: 14px;
+.flow li:first-child {
+  border-radius: var(--radius) 0 0 var(--radius);
+}
+
+.flow li:last-child {
+  border-radius: 0 var(--radius) var(--radius) 0;
+}
+
+.flow li + li {
+  border-left: 0;
+}
+
+.flow li + li::before {
+  position: absolute;
+  left: -8px;
   color: var(--accent);
-  font-size: 0.78rem;
-  font-weight: 850;
+  content: "->";
 }
 
-.boundary-grid p,
-.route-list p,
-.status-cards p {
-  margin: 0;
-  color: #b6c4d0;
+.final-boundary {
+  margin-bottom: clamp(34px, 6vw, 66px);
+  padding: clamp(22px, 4vw, 34px);
+  border-color: rgba(143, 156, 255, 0.32);
 }
 
-.boundary-grid p {
-  font-size: 0.92rem;
-  line-height: 1.42;
+.final-boundary h2 {
+  font-size: clamp(1.6rem, 3vw, 2.45rem);
 }
 
-.route-list article {
-  min-height: 116px;
-  background: rgba(17, 28, 42, 0.86);
-}
-
-.control-map {
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-}
-
-.control-card {
-  min-height: 320px;
-  border-left: 4px solid rgba(19, 200, 212, 0.68);
-}
-
-.control-card-blocked {
-  border-left-color: var(--red);
-}
-
-.route-list h3 a::after,
-.identity-links a::after {
-  content: " ->";
-  color: var(--accent);
-}
-
-.status-cards {
-  margin-top: 0;
-  grid-template-columns: 1fr;
-}
-
-.status-cards article {
-  min-height: auto;
-}
-
-.section-note {
-  margin: 16px 0 18px;
-  color: #c1cdd8;
-  font-size: 1.02rem;
-}
-
-.status-summary-grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-  margin-top: 0;
-}
-
-.status-summary-card {
-  min-width: 0;
-  min-height: auto;
-  padding: 16px;
-  border-left: 4px solid rgba(19, 200, 212, 0.7);
-  background: rgba(17, 28, 42, 0.86);
-}
-
-.status-summary-card p {
-  margin: 0;
-  color: #b6c4d0;
-  font-size: 0.91rem;
-  line-height: 1.45;
-}
-
-.status-summary-card p + p {
-  margin-top: 7px;
-}
-
-.status-summary-card .status-surface {
-  margin-bottom: 10px;
-  color: var(--accent-strong);
-  font-size: 0.78rem;
-  font-weight: 850;
-  text-transform: uppercase;
-}
-
-.detection-path {
-  max-width: none;
-}
-
-.detection-path p {
-  margin-top: 18px;
-}
-
-.status-line {
-  display: inline-block;
-  padding: 12px 14px;
-  border: 1px solid rgba(19, 200, 212, 0.5);
-  border-radius: 8px;
-  background: rgba(19, 200, 212, 0.12);
-  color: var(--accent-strong) !important;
-  font-weight: 750;
-}
-
-.boundary-callout {
-  margin-top: 24px;
-  padding: 24px;
-  border-left: 4px solid var(--danger);
-  background:
-    linear-gradient(135deg, rgba(255, 179, 107, 0.12), rgba(17, 28, 42, 0.92));
-}
-
-.boundary-callout ul {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px 24px;
-  margin: 18px 0 0;
-  padding-left: 20px;
-  color: #d5e1eb;
-}
-
-.blocked-claims {
-  margin-top: 16px;
-  padding: 18px;
-}
-
-.blocked-claims h3 {
-  margin-bottom: 12px;
-}
-
-.blocked-claims .badge {
-  margin: 0 6px 8px 0;
-}
-
-.reviewer-note {
-  margin: 0 0 46px;
-  padding: 28px;
-  background: linear-gradient(135deg, #0d1520, #101f23);
-  color: #ffffff;
-}
-
-.reviewer-note h2 {
-  font-size: clamp(1.45rem, 2.5vw, 2.2rem);
-}
-
-.reviewer-note p {
+.final-boundary p {
   max-width: 900px;
-  margin-top: 12px;
-  color: rgba(255, 255, 255, 0.84);
+  margin: 16px 0 0;
+  font-size: 1.05rem;
 }
 
 .site-footer {
   display: grid;
-  grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.2fr);
-  gap: 24px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 20px;
+  align-items: start;
   margin-bottom: 34px;
-  padding: 24px;
+  padding: 22px;
 }
 
 .site-footer h2 {
+  margin: 0;
   font-size: clamp(1.45rem, 2.4vw, 2rem);
+}
+
+.site-footer p {
+  margin: 8px 0 0;
 }
 
 .identity-links {
   align-content: start;
-  justify-content: end;
 }
 
-.identity-links a {
-  min-height: 32px;
+.identity-links a::after {
+  color: var(--accent);
+  content: " ->";
 }
 
-@media (max-width: 1020px) {
-  .lifecycle-strip {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+@media (max-width: 980px) {
+  .hero,
+  .boundary-section,
+  .site-footer {
+    grid-template-columns: 1fr;
+  }
+
+  .hero {
+    min-height: auto;
+  }
+
+  .boundary-note {
+    grid-column: auto;
+  }
+
+  .surface-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .flow {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
+  }
+
+  .flow li,
+  .flow li:first-child,
+  .flow li:last-child {
+    border: 1px solid rgba(114, 241, 255, 0.26);
+    border-radius: var(--radius);
+  }
+
+  .flow li + li::before {
+    display: none;
   }
 }
 
-@media (max-width: 860px) {
+@media (max-width: 760px) {
   .site-header {
     position: static;
     align-items: flex-start;
@@ -696,38 +602,13 @@ h3 {
     justify-content: flex-start;
   }
 
-  .hero,
-  .split,
-  .status-section,
-  .site-footer {
-    grid-template-columns: 1fr;
-  }
-
   .hero {
-    min-height: auto;
+    padding-top: 52px;
   }
 
-  .hero-panel {
-    align-self: stretch;
-  }
-
-  .proof-scope-grid,
-  .boundary-grid,
-  .route-list,
-  .control-map,
-  .status-summary-grid {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .reviewer-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .reviewer-card {
-    grid-column: span 1;
-  }
-
-  .boundary-callout ul {
+  .reviewer-grid,
+  .proof-grid,
+  .surface-grid {
     grid-template-columns: 1fr;
   }
 }
@@ -746,90 +627,36 @@ h3 {
     gap: 7px 13px;
   }
 
-  .hero {
-    padding: 44px 0 32px;
-  }
-
-  .section {
-    padding: 34px 0;
-  }
-
   h1 {
-    font-size: clamp(1.95rem, 8.4vw, 2.35rem);
+    font-size: clamp(2.05rem, 9vw, 2.7rem);
   }
 
   h2 {
-    font-size: clamp(1.65rem, 7.4vw, 2.1rem);
-  }
-
-  .subtitle {
-    margin-top: 16px;
-  }
-
-  .hero-text,
-  .claim-warning,
-  .section-copy p,
-  .detection-path p,
-  .reviewer-note p,
-  .site-footer p {
-    font-size: 1rem;
+    font-size: clamp(1.55rem, 8vw, 2.15rem);
   }
 
   .hero-actions {
-    gap: 8px;
-    margin-top: 22px;
+    display: grid;
   }
 
   .button {
-    min-height: 44px;
     width: 100%;
   }
 
-  .proof-scope-grid,
-  .boundary-grid,
-  .route-list,
-  .reviewer-grid,
-  .control-map,
-  .status-summary-grid {
-    grid-template-columns: 1fr;
-    gap: 10px;
-    margin-top: 20px;
+  .section {
+    padding: 38px 0;
   }
 
-  .lifecycle-strip {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 8px;
-    margin-top: 18px;
-  }
-
-  .scope-card,
-  .boundary-grid article,
-  .route-list article,
-  .reviewer-card,
-  .control-card,
-  .status-summary-card,
-  .boundary-callout,
-  .blocked-claims,
-  .status-cards article,
-  .reviewer-note,
-  .site-footer,
-  .hero-panel {
+  .card,
+  .surface-card,
+  .proof-panel,
+  .hero-signal,
+  .final-boundary,
+  .site-footer {
     padding: 16px;
   }
 
-  .lifecycle-strip li {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    min-height: auto;
-    padding: 12px;
-  }
-
-  .identity-links {
-    gap: 6px 14px;
-  }
-
-  .control-card {
-    min-height: auto;
+  .flow {
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
Adds a reviewer-facing HO-DET-001 proof-card route/presentation to the HawkinsOperations website.

## Scope
- Updates index.html
- Updates styles.css
- Does not update README.md
- Does not add CODEOWNERS

## Evidence basis
- HO-DET-001 source exists.
- HO-DET-001 Splunk source exists.
- HO-DET-001 passed synthetic validation.
- HO-DET-001 validation enforcement exists through PR #10 / merge commit 8b48500d2ebbaacd93ac88e77a31dccf1d3b4e25.
- Proof record and org routing remain the authority surfaces.

## Claim boundary
HO-DET-001 remains capped at TEST_VALIDATED_SYNTHETIC_SCOPE.

Website rendering is not proof.

This PR does not claim:
- runtime-active
- signal-observed
- evidence-linked public proof
- public-safe
- live Splunk fired as public proof
- production-ready
- fleet-wide
- Cribl-routed
- Wazuh-routed
- AWS-live
- HO-GPU-01 runtime-active
- autonomous SOC
- AI-approved disposition

## Validation
- `git diff --check -- index.html styles.css`: passed.
- `npx --no-install htmlhint index.html`: passed, scanned 1 file with no errors.
- Focused blocked-claim scan over `index.html` and `styles.css`: passed; blocked terms appear only in negative-boundary or not-claimed contexts.
- Focused public/private leakage scan over `index.html` and `styles.css`: passed; no local Windows paths, LAN IPs, internal hostnames, secrets, raw screenshots, raw CSV names, or private opportunity terms found.
- Browser/Playwright check: Playwright CLI was present, but the no-artifact scripted Node import path was unavailable in this shell; no browser artifacts were written.