### PR TITLE
chore(governance): add website CODEOWNERS soft enforcement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# CODEOWNERS
+#
+# Purpose: review routing boundaries for public website and public-claim files.
+# Status: SOFT_ENFORCEMENT until GitHub branch protection or rulesets require CODEOWNERS review.
+#
+# TODO: Replace placeholder owner with verified org team slugs before enforcing branch rules.
+# Candidate teams:
+# @HawkinsOperations/proof-reviewers
+# @HawkinsOperations/detections-maintainers
+# @HawkinsOperations/validation-maintainers
+# @HawkinsOperations/website-maintainers
+# @HawkinsOperations/org-maintainers
+
+index.html @raylee-hawkins
+styles.css @raylee-hawkins
+robots.txt @raylee-hawkins
+sitemap.xml @raylee-hawkins
+README.md @raylee-hawkins
+SCOPE.md @raylee-hawkins
+STATUS.md @raylee-hawkins


### PR DESCRIPTION
This PR adds a CODEOWNERS file for the HawkinsOperations website repo.

Scope:
- Adds .github/CODEOWNERS only.
- Establishes soft review-routing boundaries for public website and public-claim files.
- Keeps enforcement soft until branch protection or GitHub rulesets require CODEOWNERS review.
- Uses @raylee-hawkins as the active placeholder owner.
- Keeps candidate org team slugs commented out until verified.

Proof boundary:
- No website content changed.
- No public claims changed.
- No Astro/Tailwind migration included.
- No runtime, signal, Cribl, Wazuh, AWS, public-safe, fleet-wide, or production claims promoted.

Validation:
- CODEOWNERS active rules checked for basic syntax.
- Candidate teams are comments only.
- Working tree was clean before push.