### PR TITLE
docs(website): tighten public claim-boundary wording

### DIFF
--- a/SCOPE.md
+++ b/SCOPE.md
@@ -4,9 +4,9 @@ Repository: `hawkinsoperations-website`
 
 ## In Scope
 
-- Public-safe project narrative and navigation
+- Reviewer-facing project narrative and navigation
 - Repository map and system overview pages
-- Public-safe evidence summary links
+- Claim-bounded evidence summary links
 - Astro static routes for reviewer, proof, architecture, repository, claim firewall, field-note, operator, and legacy-boundary pages
 - Typed public rendering data under `src/data`
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,11 +2,11 @@
 
 ## Current Milestone
 
-Astro proof-codex redesign in implementation PR.
+Astro proof-codex redesign merged; current work is post-merge public wording and claim-boundary cleanup.
 
 ## Next Gate
 
-Review, validate, and merge the static Astro + Tailwind + TypeScript website rebuild.
+Preserve the static Astro + Tailwind + TypeScript website rebuild while tightening public wording and claim-boundary guardrails.
 
 ## Blocking Risks
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -13,7 +13,7 @@ export interface Props {
 
 const {
   title,
-  description = "HawkinsOperations Detection Engineering SOC: governed detection engineering and AI-assisted SOC production with separated truth surfaces and proof-bound public claims.",
+  description = "HawkinsOperations Detection Engineering SOC: governed detection engineering and AI-assisted security operations production workflow with separated truth surfaces and proof-bound public claims.",
   ogImage = "/og-preview.png",
   ogImageAlt = "HawkinsOperations monogram preview for governed detection engineering and SOC automation",
 } = Astro.props;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -20,7 +20,7 @@ const previewArtifacts = [
 
 <BaseLayout
   title="HawkinsOperations Detection Engineering SOC"
-  description="HawkinsOperations Detection Engineering SOC — governed detection engineering and AI-assisted SOC production. A proof-bound public reviewer surface separating source, validation, runtime, signal, evidence, and public claims."
+  description="HawkinsOperations Detection Engineering SOC — governed detection engineering and AI-assisted security operations production workflow. A proof-bound public reviewer surface separating source, validation, runtime, signal, evidence, and public claims."
 >
   <!-- ╔══ HERO · Moonlit proof command surface ═══════════════════════════════ -->
   <section class="relative overflow-hidden">
@@ -44,7 +44,7 @@ const previewArtifacts = [
         </h1>
 
         <p class="lede mt-7 max-w-2xl">
-          Governed detection engineering and AI-assisted SOC production.
+          Governed detection engineering and AI-assisted security operations production workflow.
         </p>
         <p class="muted mt-4 max-w-2xl text-base leading-7">
           Speeding up security production without letting the system lie. A proof-bound public surface separating source, validation, runtime, signal, evidence, and public claims.
@@ -150,7 +150,7 @@ const previewArtifacts = [
   <section class="container section-tight">
     <SectionEyebrow
       eyebrow="Artifact vault preview"
-      title="Public-safe receipts, routed by surface"
+      title="Reviewer-facing receipts, routed by surface"
       description="Proof records, validation outputs, CI verifier records, architecture maps, public packets, and legacy references — each carries its own ceiling and proof boundary."
       align="between"
       cta={{ label: "Open the full vault", href: "/artifacts/" }}


### PR DESCRIPTION
Summary:
- Tightens public claim-boundary wording across the website.
- Softens ambiguous public-safe / production phrasing.
- Preserves the senior reviewer surface and HawkinsOperations thesis.
- Keeps website rendering separated from proof authority.

Claim boundary:
- HO-DET-001 remains TEST_VALIDATED_SYNTHETIC_SCOPE.
- Website rendering is not proof.
- This PR does not prove runtime-active, signal-observed, evidence-linked public proof, public-safe status, production-ready status, fleet-wide coverage, Cribl-routed status, Wazuh-routed status, AWS-live status, HO-GPU-01 runtime-active status, autonomous SOC operation, AI-approved disposition, analyst-approved disposition, live Splunk fired as public proof, production AutoSOC triage, enterprise deployed status, or complete AutoSOC status.

Validation:
- npm run check:site passed before commit.
- npm run build passed before commit.
- git diff --cached --check passed before commit.
- Commit created locally as d381e0435facd79c6dac0e847ee2d6da32a23871.
- No private local path, LAN IP, token, password, key value, host leak, or raw evidence was included.