### PR TITLE
perf: remove unused client router

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,4 @@
 ---
-import { ClientRouter } from "astro:transitions";
 import Header from "@components/Header.astro";
 import Footer from "@components/Footer.astro";
 import "@styles/global.css";
@@ -112,7 +111,6 @@ const structuredData = {
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" />
     <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
-    <ClientRouter fallback="swap" />
   </head>
   <body>
     <a class="skip-link" href="#main-content">Skip to content</a>


### PR DESCRIPTION
This PR removes the unused global Astro ClientRouter from BaseLayout.

Scope:
- Removes the ClientRouter import from src/layouts/BaseLayout.astro
- Removes the global ClientRouter render from src/layouts/BaseLayout.astro
- Leaves global.css view-transition rules unchanged for a separate cleanup decision
- Does not modify fonts, BrandMark assets, pages, components, favicon, docs, homepage content, public claims, proof wording, governance wording, or site copy

Reason:
Discovery found no source references requiring Astro client-side routing or page-swap events:
- no transition:name usage
- no transition:animate usage
- no transition:persist usage
- no astro:page-load listener
- no astro:after-swap listener
- no astro:before-swap listener
- navigation uses ordinary anchors

Expected asset effect:
- Removes the ClientRouter JS request from generated output, confirmed by build inspection
- Prior known ClientRouter asset size:
  - 15,849 bytes raw
  - 5,421 bytes gzip
  - 4,881 bytes brotli
- Post-build dist/_astro contains no JS asset; only BaseLayout CSS and portrait WebP assets remain
- Any live transfer improvement remains UNMEASURED until deployed and measured

Validation:
- npm run build: passed
- npm run check:site: passed
- git diff --check: passed
- focused private/local path and secret scan: no matches
- blocked/public claim scan: no matches; npm run check:site is also the active site contract validator
- built output ClientRouter absence: passed; no ClientRouter JS asset emitted and generated HTML has no ClientRouter transition meta/script references
- local navigation smoke test: passed for / to /proof/, / to /artifacts/, /about/, header navigation, footer navigation, skip link/focus behavior, and console errors/warnings

Proof boundary:
This is an implementation-local performance tuning change until deployed and measured.
Proof ceiling: PERFORMANCE_TUNING_IMPLEMENTED_LOCAL_ONLY.
This does not promote runtime, signal, detection, governance, public-safe, production-wide, evidence, or live performance claims.