### PR TITLE
design(site): sharpen reviewer cockpit and proof routing

### DIFF
--- a/src/components/ReceiptCard.astro
+++ b/src/components/ReceiptCard.astro
@@ -8,11 +8,12 @@ export interface Props {
   publicSafe: boolean;
   claim: string;
   boundary: string;
+  nextGate?: string;
   href: string;
   hrefLabel: string;
 }
 
-const { title, surface, statusBadge, publicSafe, claim, boundary, href, hrefLabel } = Astro.props;
+const { title, surface, statusBadge, publicSafe, claim, boundary, nextGate, href, hrefLabel } = Astro.props;
 const external = href.startsWith("http");
 ---
 
@@ -35,6 +36,12 @@ const external = href.startsWith("http");
       <span class="receipt-card__label receipt-card__label--block">Boundary</span>
       <p class="receipt-card__text receipt-card__text--block">{boundary}</p>
     </div>
+    {nextGate && (
+      <div class="receipt-card__row receipt-card__row--gate">
+        <span class="receipt-card__label receipt-card__label--gate">Next gate</span>
+        <p class="receipt-card__text receipt-card__text--gate">{nextGate}</p>
+      </div>
+    )}
   </div>
 
   <a

--- a/src/components/ReviewerRouteCard.astro
+++ b/src/components/ReviewerRouteCard.astro
@@ -2,16 +2,28 @@
 export interface Props {
   duration: string;
   title: string;
+  purpose?: string;
   items: string[];
+  links?: { label: string; href: string; external?: boolean }[];
 }
 
-const { duration, title, items } = Astro.props;
+const { duration, title, purpose, items, links = [] } = Astro.props;
 ---
 
-<article class="card p-5">
+<article class="reviewer-route-card card p-5">
   <p class="mono text-xs uppercase text-blue-100">{duration}</p>
   <h3 class="mt-4 text-xl font-semibold text-slate-50">{title}</h3>
+  {purpose && <p class="mt-3 text-sm leading-6 text-slate-400">{purpose}</p>}
   <ol class="mt-5 space-y-3 text-sm leading-6 text-slate-400">
     {items.map((item) => <li>{item}</li>)}
   </ol>
+  {links.length > 0 && (
+    <div class="reviewer-route-card__links" aria-label={`${title} links`}>
+      {links.map((link) => (
+        <a href={link.href} target={link.external ? "_blank" : undefined} rel={link.external ? "noopener noreferrer" : undefined}>
+          {link.label}{link.external ? " ↗" : ""}
+        </a>
+      ))}
+    </div>
+  )}
 </article>

--- a/src/data/credibilityMetrics.ts
+++ b/src/data/credibilityMetrics.ts
@@ -1,0 +1,42 @@
+import { artifacts } from "./artifacts";
+import { blockedClaims } from "./claims";
+
+export type CredibilityMetric = {
+  value: number;
+  label: string;
+  footnote: string;
+};
+
+const boundedProofRecords = artifacts.filter((artifact) => artifact.category === "proof-record").length;
+const separatedTruthSurfaces = new Set(artifacts.map((artifact) => artifact.truthSurface)).size;
+const deterministicValidationRoutes = artifacts.filter((artifact) =>
+  artifact.category === "validation" || artifact.category === "ci-verifier"
+).length;
+
+export const credibilityMetrics: CredibilityMetric[] = [
+  {
+    value: artifacts.length,
+    label: "Reviewer-routed artifacts",
+    footnote: "Counted from src/data/artifacts.ts; routing surface only.",
+  },
+  {
+    value: boundedProofRecords,
+    label: "Bounded proof records",
+    footnote: "Derived from artifact categories; does not assert runtime state.",
+  },
+  {
+    value: separatedTruthSurfaces,
+    label: "Separated truth surfaces",
+    footnote: "Derived from artifact truthSurface labels, not live telemetry.",
+  },
+  {
+    value: blockedClaims.length,
+    label: "Blocked claims made visible",
+    footnote: "Derived from src/data/claims.ts blockedClaims.",
+  },
+  {
+    value: deterministicValidationRoutes,
+    label: "Deterministic validation routes",
+    footnote: "Derived from validation and CI verifier artifact routes.",
+  },
+].filter((metric) => metric.value > 0);

--- a/src/data/reviewerRoutes.ts
+++ b/src/data/reviewerRoutes.ts
@@ -1,0 +1,56 @@
+import { externalLinks } from "./navigation";
+
+export type ReviewerRouteLink = {
+  label: string;
+  href: string;
+  external?: boolean;
+};
+
+export type ReviewerRoute = {
+  duration: string;
+  title: string;
+  purpose: string;
+  items: string[];
+  links: ReviewerRouteLink[];
+};
+
+export const reviewerRoutes: ReviewerRoute[] = [
+  {
+    duration: "3 min",
+    title: "Executive scan",
+    purpose: "Confirm the public ceiling, the blocked claims, and the flagship HO-DET-001 proof route.",
+    items: ["Read the current proof ceiling.", "Open the HO-DET-001 proof card.", "Confirm the blocked claim list."],
+    links: [
+      { label: "Proof ledger", href: "/proof/" },
+      { label: "HO-DET-001 card", href: "/proof/ho-det-001/" },
+      { label: "Claim firewall", href: "/controls/" },
+    ],
+  },
+  {
+    duration: "10 min",
+    title: "Proof review",
+    purpose: "Follow the proof record, validation route, and repository map without inferring runtime state.",
+    items: ["Read the proof ledger.", "Open the validation route.", "Confirm website rendering is not proof."],
+    links: [
+      { label: "Proof repo", href: externalLinks.proof, external: true },
+      { label: "Validation report", href: externalLinks.validationReportHo, external: true },
+      { label: "Repository map", href: "/repos/" },
+    ],
+  },
+  {
+    duration: "Deep",
+    title: "Technical inspection",
+    purpose: "Trace the separated surfaces and promotion gates before accepting any stronger wording.",
+    items: [
+      "Trace source, validation, runtime, signal, evidence, and public proof.",
+      "Inspect owner repositories.",
+      "Review promotion requirements before accepting stronger wording.",
+    ],
+    links: [
+      { label: "Truth surfaces", href: "/architecture/truth-surfaces/" },
+      { label: "Architecture", href: "/architecture/" },
+      { label: "Control matrix", href: externalLinks.controlMatrix, external: true },
+      { label: "Repo authority map", href: externalLinks.repoAuthorityMap, external: true },
+    ],
+  },
+];

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,7 +8,9 @@ import ReceiptCard from "@components/ReceiptCard.astro";
 import SectionEyebrow from "@components/SectionEyebrow.astro";
 import ProofCeilingDisplay from "@components/ProofCeilingDisplay.astro";
 import TruthSurfaceSeparation from "@components/TruthSurfaceSeparation.astro";
+import { credibilityMetrics } from "@data/credibilityMetrics";
 import { externalLinks } from "@data/navigation";
+import { reviewerRoutes } from "@data/reviewerRoutes";
 import { artifacts, type Artifact } from "@data/artifacts";
 
 const previewSlugs = [
@@ -46,6 +48,7 @@ const loopReceipts = [
     publicSafe: true,
     claim: "HO-DET-001 passed synthetic validation against controlled positive and negative process-creation fixtures.",
     boundary: "Does not prove runtime activity, signal observation, fleet scope, or public-safe runtime proof.",
+    nextGate: "Runtime + public-safe evidence review remain separate.",
     href: externalLinks.validationReportHo,
     hrefLabel: "Validation report ↗",
   },
@@ -56,6 +59,7 @@ const loopReceipts = [
     publicSafe: false,
     claim: "HO-DET-001 produced a controlled lab runtime match in Splunk.",
     boundary: "Does not prove runtime-active deployment, public-safe runtime proof, fleet-wide coverage, Cribl-routed telemetry, Wazuh-routed public proof, AWS-live status, autonomous SOC operation, or live Splunk fired as public proof.",
+    nextGate: "Privacy review · evidence linkage · stale review · Raylee approval.",
     href: externalLinks.proofRecord + "#controlled-runtime-signal-packet-001",
     hrefLabel: "Proof record ↗",
   },
@@ -66,6 +70,7 @@ const loopReceipts = [
     publicSafe: false,
     claim: "A controlled clean remote marker was delivered through the Cribl-to-Splunk lab lane and observed in expected Splunk rawdata with marker fields preserved.",
     boundary: "Does not prove HO-DET-001/Sysmon telemetry is Cribl-routed, does not prove Cribl-routed telemetry for production or fleet scope, and does not change the public proof ceiling.",
+    nextGate: "HO-DET-001 / Sysmon field-preservation comparison remains separate.",
     href: externalLinks.proofRecord + "#controlled-cribl-to-splunk-marker-delivery-packet-001",
     hrefLabel: "Proof record ↗",
   },
@@ -76,6 +81,7 @@ const loopReceipts = [
     publicSafe: false,
     claim: "AWS-DET-001 passed fixture-only validation against controlled CloudTrail-style IAM denial fixtures.",
     boundary: "Does not prove AWS-live, CloudTrail live, cloud runtime-active, signal-observed, or public-safe runtime proof.",
+    nextGate: "Live AWS surface remains blocked until separately approved.",
     href: externalLinks.validationReportAws,
     hrefLabel: "Validation report ↗",
   },
@@ -114,12 +120,10 @@ const loopReceipts = [
           Speeding up security production without letting the system lie.
         </p>
 
-        <!-- CTA row -->
+        <!-- CTA row · primary + single secondary; org and operator links live in nav/footer -->
         <div class="mt-9 flex flex-wrap items-center gap-3">
           <a class="cta cta-primary" href="/proof/">Review Proof →</a>
-          <a class="cta cta-quiet" href="/artifacts/">Browse Artifacts</a>
-          <a class="cta cta-quiet" href={externalLinks.githubOrg} target="_blank" rel="noopener noreferrer" aria-label="Open the HawkinsOperations GitHub organization">GitHub Organization ↗</a>
-          <a class="cta cta-quiet" href={externalLinks.rayleeLinkedIn} target="_blank" rel="noopener noreferrer" aria-label="Open Raylee Hawkins on LinkedIn">LinkedIn ↗</a>
+          <a class="cta cta-quiet" href="/start/">Start Here →</a>
         </div>
 
         <!-- Hero proof ceiling micro-panel -->
@@ -171,6 +175,25 @@ const loopReceipts = [
     </ul>
   </section>
 
+  <!-- ╔══ CREDIBILITY STRIP · repo-derived surface counts only ═══════════════ -->
+  <section class="container section-tight" aria-labelledby="credibility-metrics-title">
+    <div class="surface-coverage">
+      <header class="surface-coverage__header">
+        <p class="eyebrow">Surface coverage, not runtime activity</p>
+        <h2 id="credibility-metrics-title" class="headline mt-2 text-2xl md:text-[1.7rem]">Reviewer-visible routes are counted from repo data.</h2>
+      </header>
+      <ul class="surface-coverage__grid" aria-label="Repository-derived surface coverage">
+        {credibilityMetrics.map((metric) => (
+          <li class="surface-coverage__tile">
+            <span class="surface-coverage__value mono">{metric.value}</span>
+            <span class="surface-coverage__label">{metric.label}</span>
+            <span class="surface-coverage__footnote">{metric.footnote}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </section>
+
   <!-- ╔══ EXECUTIVE SUMMARY ═══════════════════════════════════════════════════ -->
   <section class="container section-tight" aria-labelledby="executive-summary-title">
     <div class="executive-summary moon-panel-strong p-6 md:p-8">
@@ -198,6 +221,78 @@ const loopReceipts = [
     </div>
   </section>
 
+  <!-- ╔══ DETERMINISTIC SCANNER · visible trust strip ════════════════════════ -->
+  <section class="container section-tight" aria-labelledby="scanner-strip-title">
+    <div class="scanner-trust-strip">
+      <p class="eyebrow" id="scanner-strip-title">DETERMINISTIC SCANNER</p>
+      <p>Site wording is checked by a deterministic blocked-claim scanner. This does not prove runtime control coverage or branch protection.</p>
+    </div>
+  </section>
+
+  <!-- ╔══ REVIEWER ROUTES · three inline inspection paths ════════════════════ -->
+  <section class="container section-tight" aria-labelledby="review-depth-title">
+    <div class="review-depth-header">
+      <div>
+        <p class="eyebrow">Inspection paths</p>
+        <h2 id="review-depth-title" class="headline mt-2 text-2xl md:text-[1.7rem]">Choose your review depth</h2>
+        <p class="muted mt-3 text-sm leading-6 max-w-xl">
+          Pick the depth that fits the review window and follow the proof from the same public ceiling.
+        </p>
+      </div>
+      <a class="surface-link-label surface-link-label--primary review-depth-header__link" href="/start/">Open full reviewer route →</a>
+    </div>
+    <ul class="review-route-grid" aria-label="Review depths">
+      {reviewerRoutes.map((route) => (
+        <li class="review-route-card">
+          <span class="review-route-card__duration mono">{route.duration}</span>
+          <h3>{route.title}</h3>
+          <p>{route.purpose}</p>
+          <div class="review-route-card__links">
+            {route.links.slice(0, 3).map((link) => (
+              <a href={link.href} target={link.external ? "_blank" : undefined} rel={link.external ? "noopener noreferrer" : undefined}>
+                {link.label}{link.external ? " ↗" : ""}
+              </a>
+            ))}
+          </div>
+        </li>
+      ))}
+    </ul>
+  </section>
+
+  <!-- ╔══ FLAGSHIP PROOF ROUTE · HO-DET-001 visible path ═════════════════════ -->
+  <section class="container section-tight" aria-labelledby="flagship-proof-route-title">
+    <div class="flagship-spread homepage-flagship">
+      <div class="flagship-spread__rail">
+        <p class="eyebrow">Flagship proof route</p>
+        <div>
+          <h2 id="flagship-proof-route-title" class="headline text-3xl md:text-4xl">HO-DET-001 · Closed SOC loop</h2>
+          <p class="muted mt-4 text-base leading-7">Splunk detection → validation → proof record → blocked claims → next gate</p>
+        </div>
+        <div class="homepage-flagship__status mono">TEST_VALIDATED_SYNTHETIC_SCOPE</div>
+      </div>
+      <div class="flagship-spread__body">
+        <dl class="homepage-flagship__claims">
+          <div>
+            <dt>Proves</dt>
+            <dd>Controlled synthetic validation at TEST_VALIDATED_SYNTHETIC_SCOPE.</dd>
+          </div>
+          <div>
+            <dt>Does not prove</dt>
+            <dd>Does not prove runtime-active deployment, signal observation, fleet scope, production, or public-safe runtime proof.</dd>
+          </div>
+          <div>
+            <dt>Next gate</dt>
+            <dd>Privacy review · evidence linkage · stale review · Raylee approval.</dd>
+          </div>
+        </dl>
+        <div class="homepage-flagship__actions">
+          <a class="cta cta-primary" href="/proof/ho-det-001/">Open proof record</a>
+          <a class="cta cta-quiet" href={externalLinks.validationReportHo} target="_blank" rel="noopener noreferrer">Open validation report ↗</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <!-- ╔══ CONTROLLED LOOP RECEIPTS · routed by claim boundary ════════════════ -->
   <section class="container section-tight" aria-labelledby="controlled-loop-receipts-title">
     <header class="mb-7 flex flex-wrap items-end justify-between gap-3">
@@ -218,6 +313,7 @@ const loopReceipts = [
           publicSafe={receipt.publicSafe}
           claim={receipt.claim}
           boundary={receipt.boundary}
+          nextGate={receipt.nextGate}
           href={receipt.href}
           hrefLabel={receipt.hrefLabel}
         />

--- a/src/pages/start.astro
+++ b/src/pages/start.astro
@@ -7,6 +7,7 @@ import ReviewerRouteCard from "@components/ReviewerRouteCard.astro";
 import SectionHeader from "@components/SectionHeader.astro";
 import { blockedClaims, proofCeiling } from "@data/claims";
 import { externalLinks } from "@data/navigation";
+import { reviewerRoutes } from "@data/reviewerRoutes";
 ---
 
 <BaseLayout title="Reviewer Route | HawkinsOperations" description="Reviewer route for HawkinsOperations proof ceiling, blocked claims, and public inspection links.">
@@ -14,9 +15,9 @@ import { externalLinks } from "@data/navigation";
   <section class="container section">
     <SectionHeader title="Choose the route that fits the review window" eyebrow="Inspection paths" />
     <div class="grid gap-4 lg:grid-cols-3">
-      <ReviewerRouteCard duration="3 minutes" title="Ceiling and blocked claims" items={["Read the current proof ceiling.", "Open the HO-DET-001 proof card.", "Confirm the blocked claim list."]} />
-      <ReviewerRouteCard duration="10 minutes" title="Proof and repo context" items={["Read the proof ledger.", "Check the repository map.", "Confirm website rendering is not proof."]} />
-      <ReviewerRouteCard duration="Deep technical" title="Surface-by-surface inspection" items={["Trace source, validation, runtime, signal, evidence, and public proof.", "Inspect owner repositories.", "Review promotion requirements before accepting any stronger wording."]} />
+      {reviewerRoutes.map((route) => (
+        <ReviewerRouteCard duration={route.duration} title={route.title} purpose={route.purpose} items={route.items} links={route.links} />
+      ))}
     </div>
   </section>
   <section class="container section-tight">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1557,6 +1557,246 @@ main { overflow: hidden; }
   .snapshot-grid { grid-template-columns: 1fr; gap: 12px; }
 }
 
+/* ─── Credibility metrics and reviewer routes ─────────────────────── */
+
+.surface-coverage {
+  display: grid;
+  gap: 18px;
+  padding: 22px;
+  border: 1px solid rgba(231, 238, 247, 0.12);
+  border-radius: 8px;
+  background:
+    linear-gradient(90deg, rgba(90, 167, 255, 0.1), rgba(5, 7, 13, 0.78) 36%, rgba(0, 2, 5, 0.92)),
+    #000205;
+}
+
+.surface-coverage__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: end;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.surface-coverage__grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.surface-coverage__tile {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+  padding: 14px;
+  border: 1px solid rgba(231, 238, 247, 0.11);
+  border-radius: 6px;
+  background: rgba(0, 2, 5, 0.58);
+}
+
+.surface-coverage__value {
+  color: var(--ice-blue);
+  font-size: 1.8rem;
+  line-height: 1;
+  font-weight: 800;
+}
+
+.surface-coverage__label {
+  color: var(--silver-bright);
+  font-size: 0.86rem;
+  font-weight: 700;
+  line-height: 1.28;
+}
+
+.surface-coverage__footnote {
+  color: #aebccc;
+  font-size: 0.72rem;
+  line-height: 1.45;
+}
+
+.scanner-trust-strip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px 18px;
+  padding: 14px 16px;
+  border: 1px solid rgba(143, 216, 255, 0.22);
+  border-left: 3px solid var(--ice-blue);
+  border-radius: 8px;
+  background: rgba(5, 7, 13, 0.72);
+}
+
+.scanner-trust-strip p {
+  margin: 0;
+  color: #cbd8e8;
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+
+.review-depth-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: end;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 18px;
+}
+
+.review-depth-header__link {
+  color: var(--ice-blue);
+}
+
+.review-route-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.review-route-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+  padding: 20px;
+  border: 1px solid var(--moon-border);
+  border-top: 2px solid rgba(143, 216, 255, 0.58);
+  border-radius: 8px;
+  background: linear-gradient(180deg, rgba(5, 7, 13, 0.9), rgba(0, 2, 5, 0.96));
+}
+
+.review-route-card:nth-child(2) { border-top-color: rgba(94, 244, 230, 0.62); }
+.review-route-card:nth-child(3) { border-top-color: rgba(231, 238, 247, 0.48); }
+
+.review-route-card__duration {
+  color: var(--ice-blue);
+  font-size: 0.62rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 800;
+}
+
+.review-route-card h3 {
+  margin: 0;
+  color: var(--silver-bright);
+  font-size: 1.1rem;
+  line-height: 1.25;
+}
+
+.review-route-card p {
+  margin: 0;
+  color: #c4d1e2;
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+
+.review-route-card__links,
+.reviewer-route-card__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: auto;
+  padding-top: 6px;
+}
+
+.review-route-card__links a,
+.reviewer-route-card__links a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  padding: 0.34rem 0.56rem;
+  border: 1px solid rgba(143, 216, 255, 0.2);
+  border-radius: 6px;
+  color: #d8e7f6;
+  background: rgba(90, 167, 255, 0.06);
+  font-size: 0.75rem;
+  line-height: 1.2;
+}
+
+.review-route-card__links a:hover,
+.review-route-card__links a:focus-visible,
+.reviewer-route-card__links a:hover,
+.reviewer-route-card__links a:focus-visible {
+  border-color: rgba(143, 216, 255, 0.42);
+  color: var(--ice-blue);
+}
+
+.homepage-flagship {
+  cursor: default;
+}
+
+.homepage-flagship__status {
+  width: fit-content;
+  padding: 0.42rem 0.68rem;
+  border: 1px solid rgba(143, 216, 255, 0.24);
+  border-radius: 6px;
+  color: var(--ice-blue);
+  background: rgba(90, 167, 255, 0.08);
+  font-size: 0.62rem;
+  letter-spacing: 0.14em;
+}
+
+.homepage-flagship__claims {
+  display: grid;
+  gap: 14px;
+  margin: 0;
+}
+
+.homepage-flagship__claims div {
+  display: grid;
+  gap: 5px;
+}
+
+.homepage-flagship__claims dt {
+  color: var(--ice-blue);
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.58rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 800;
+}
+
+.homepage-flagship__claims div:nth-child(2) dt { color: #ffbdc7; }
+
+.homepage-flagship__claims dd {
+  margin: 0;
+  color: #d2dce9;
+  font-size: 0.94rem;
+  line-height: 1.6;
+}
+
+.homepage-flagship__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 6px;
+}
+
+@media (max-width: 980px) {
+  .surface-coverage__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .review-route-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 560px) {
+  .surface-coverage {
+    padding: 18px;
+  }
+
+  .surface-coverage__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* ─── Controlled loop receipts ────────────────────────────────────── */
 
 .receipt-grid {
@@ -1637,6 +1877,7 @@ main { overflow: hidden; }
 }
 
 .receipt-card__label--block { color: #ffbdc7; }
+.receipt-card__label--gate { color: var(--ice-blue); }
 
 .receipt-card__text {
   margin: 0;
@@ -1646,6 +1887,13 @@ main { overflow: hidden; }
 }
 
 .receipt-card__text--block { color: #c8d4e3; }
+.receipt-card__text--gate { color: #d8e7f6; }
+
+.receipt-card__row--gate {
+  margin-top: 4px;
+  padding-top: 10px;
+  border-top: 1px dashed rgba(143, 216, 255, 0.22);
+}
 
 .receipt-card__link {
   margin-top: auto;


### PR DESCRIPTION
Summary:
- Adds homepage reviewer-depth routing.
- Adds HO-DET-001 flagship proof route.
- Adds repo-derived credibility strip.
- Adds receipt next-gate field.
- Moves deterministic scanner note into visible trust strip.
- Preserves TEST_VALIDATED_SYNTHETIC_SCOPE and website rendering-only boundary.

Validation:
- npm run check:site
- npm run build
- git diff --check
- blocked-claim scan
- private-term scan

Claim boundary:
Website remains RENDERING_ONLY / ROUTING_ONLY.
No runtime-active, signal-observed, public-safe runtime proof, production, fleet-wide, AWS-live, Cribl-routed, Wazuh-routed, autonomous SOC, AI-approved, or analyst-approved claim was promoted.