### PR TITLE
fix: remove green grid overlay cast

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -55,8 +55,8 @@ body {
   margin: 0;
   min-height: 100vh;
   background:
-    radial-gradient(circle at 16% 6%, rgba(143, 216, 255, 0.085), transparent 32rem),
-    radial-gradient(circle at 84% 12%, rgba(201, 211, 223, 0.065), transparent 32rem),
+    radial-gradient(circle at 16% 6%, rgba(37, 99, 235, 0.065), transparent 32rem),
+    radial-gradient(circle at 84% 12%, rgba(201, 211, 223, 0.045), transparent 32rem),
     radial-gradient(circle at 50% 52%, rgba(9, 14, 24, 0.78), transparent 40rem),
     linear-gradient(150deg, rgba(8, 13, 22, 0.92) 0%, rgba(3, 6, 11, 0.98) 46%, rgba(3, 6, 11, 1) 100%),
     var(--deep-black);
@@ -76,14 +76,14 @@ body::after {
 body::before {
   background-image: radial-gradient(circle at center, rgba(255, 255, 255, 0.18) 0.8px, transparent 0.9px);
   background-size: 32px 32px;
-  opacity: 0.075;
+  opacity: 0.055;
   mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.85), rgba(0, 0, 0, 0.4) 44%, transparent 84%);
 }
 
 body::after {
-  background: linear-gradient(180deg, transparent 0%, rgba(143, 216, 255, 0.05) 52%, transparent 100%);
+  background: linear-gradient(180deg, transparent 0%, rgba(37, 99, 235, 0.035) 52%, transparent 100%);
   background-size: 100% 9rem;
-  opacity: 0.18;
+  opacity: 0.12;
   mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.55), transparent 78%);
 }
 
@@ -1988,7 +1988,7 @@ body {
 body {
   background:
     linear-gradient(180deg, rgba(5, 7, 13, 0.18), rgba(0, 2, 5, 0) 26rem),
-    linear-gradient(135deg, rgba(90, 167, 255, 0.05), transparent 34rem),
+    linear-gradient(135deg, rgba(37, 99, 235, 0.05), transparent 34rem),
     #000205;
 }
 
@@ -1997,12 +1997,12 @@ body::before {
     linear-gradient(to right, rgba(231, 238, 247, 0.035) 1px, transparent 1px),
     linear-gradient(to bottom, rgba(231, 238, 247, 0.035) 1px, transparent 1px);
   background-size: 72px 72px;
-  opacity: 0.28;
+  opacity: 0.22;
   mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.62), transparent 74%);
 }
 
 body::after {
-  background: linear-gradient(90deg, transparent, rgba(90, 167, 255, 0.12), transparent);
+  background: linear-gradient(90deg, transparent, rgba(37, 99, 235, 0.1), transparent);
   height: 1px;
   top: 68px;
   bottom: auto;
@@ -4417,7 +4417,7 @@ body[data-active-surface] .truth-board__status {
   padding: clamp(54px, 8vw, 96px) 0 42px;
   border-bottom: 1px solid var(--moon-border);
   background:
-    radial-gradient(circle at 78% 12%, rgba(143, 216, 255, 0.12), transparent 32%),
+    radial-gradient(circle at 78% 12%, rgba(37, 99, 235, 0.09), transparent 32%),
     linear-gradient(180deg, rgba(6, 12, 21, 0.96), rgba(2, 5, 10, 0.98));
 }
 
@@ -4427,8 +4427,8 @@ body[data-active-surface] .truth-board__status {
   inset: 0;
   pointer-events: none;
   background:
-    repeating-linear-gradient(90deg, rgba(201, 211, 223, 0.035) 0 1px, transparent 1px 96px),
-    repeating-linear-gradient(0deg, rgba(201, 211, 223, 0.025) 0 1px, transparent 1px 72px);
+    repeating-linear-gradient(90deg, rgba(201, 211, 223, 0.024) 0 1px, transparent 1px 96px),
+    repeating-linear-gradient(0deg, rgba(201, 211, 223, 0.018) 0 1px, transparent 1px 72px);
   mask-image: linear-gradient(180deg, black, transparent 78%);
 }
 


### PR DESCRIPTION
## Summary

This PR is a CSS-only visual correction for the green/teal/cyan-looking page-wide grid and overlay cast, especially visible on `/pipeline/`.

## Before/After Color Explanation

Before, page-wide and hero background treatments used pale ice-blue washes such as `rgba(143, 216, 255, ...)` and `rgba(90, 167, 255, ...)`, which could read as cyan/teal over black.

After, the global background and `/pipeline/` hero wash use darker royal/electric blue and lower-opacity neutral gray-blue linework. The site remains black/navy with electric-blue accents.

## Routes Browser-Checked

- `/pipeline/`
- `/`
- `/proof/`
- `/artifacts/`

Checked at desktop and mobile widths.

## Validation Results

- `npm run check:site` passed
- `npm run typecheck` passed
- `npm run build` passed
- `git diff --check` passed
- Private leak scan passed
- Blocked-claim scan passed
- Browser visual review passed
- Favicon check passed with PNG icon assets and no SVG favicon metadata

## Claim Boundary Preserved

- Public ceiling unchanged: `CONTROLLED_TEST_VALIDATED`
- Public-safe unchanged: `NOT_PUBLIC_SAFE`
- No proof wording changed
- No claim-boundary wording changed
- No release, tag, zip, signing, public-safe, runtime-active, signal-observed, production-ready, SOCaaS, live Splunk, Cribl-routed, Wazuh-routed, AWS-live, autonomous SOC, AI-approved disposition, or analyst-approved disposition claim was promoted

Human review required before merge.