### PR TITLE
docs(website): route Proof Pack 001 release

### DIFF
--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -12,9 +12,9 @@ export const metadata: Metadata = {
 const entries = [
   {
     label: "2026-05-17",
-    title: "Proof Pack 001 release path implemented",
+    title: "Proof Pack 001 official release routed",
     detail:
-      "Proof repo merged the source / check-mode release path for Proof Pack 001 on main. No official release, tag, zip, or signed artifact is claimed from the website; the next gate is explicit release approval. Public ceiling remains controlled-test scope and is NOT_PUBLIC_SAFE.",
+      "Proof repo holds the official Proof Pack 001 GitHub Release, and the website routes reviewers to that release. ZIP SHA256 is 44d8a643aa2b113c9e99be0462e699d39af707a67190823cc05bb381907dc452. Website rendering is not proof; public ceiling remains CONTROLLED_TEST_VALIDATED, reviewer package status remains PUBLIC_SAFE_REVIEWER_RELEASE_CANDIDATE, raw/private runtime evidence remains NOT_PUBLIC_SAFE and excluded, and public-safe runtime proof remains BLOCKED.",
   },
   {
     label: "2026-05-17",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -316,18 +316,19 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* ── 12 · Proof Pack 001 release-path console (preserved) ─────── */}
+      {/* ── 12 · Proof Pack 001 release console (preserved) ──────────── */}
       <section className="cockpit-section--tight">
         <div className="container">
-          <div className="proof-pack-console" aria-label="Proof Pack 001 release-path status console">
+          <div className="proof-pack-console" aria-label="Proof Pack 001 release status console">
             <header className="proof-pack-console__head">
               <div>
-                <p className="cockpit-eyebrow">Release path · governed</p>
+                <p className="cockpit-eyebrow">Release route · governed</p>
                 <h2 className="proof-pack-console__title">
-                  Proof Pack 001 · release path implemented.
+                  Proof Pack 001 · official release routed.
                 </h2>
                 <p className="proof-pack-console__sub">
-                  Source / check-mode release path is merged on the proof repo. No official release, tag, or signed artifact is claimed from this surface.
+                  The proof repo holds the official GitHub Release and approved reviewer ZIP.
+                  Website rendering is not proof; this page routes reviewers to the release.
                 </p>
               </div>
               <span className="proof-pack-console__ceiling mono">CONTROLLED_TEST_VALIDATED</span>
@@ -339,15 +340,15 @@ export default function HomePage() {
               </div>
               <div className="proof-pack-console__cell">
                 <dt>Pack status</dt>
-                <dd className="mono proof-pack-console__cell-strong">RELEASE_PATH_IMPLEMENTED</dd>
+                <dd className="mono proof-pack-console__cell-strong">PUBLIC_SAFE_REVIEWER_RELEASE_CANDIDATE</dd>
               </div>
               <div className="proof-pack-console__cell">
-                <dt>Source mode</dt>
-                <dd className="mono">CHECK_MODE_SOURCE_ONLY</dd>
+                <dt>ZIP SHA256</dt>
+                <dd className="mono">44d8a643aa2b113c9e99be0462e699d39af707a67190823cc05bb381907dc452</dd>
               </div>
               <div className="proof-pack-console__cell">
-                <dt>Next gate</dt>
-                <dd className="mono">OFFICIAL_RELEASE_PENDING_APPROVAL</dd>
+                <dt>Public-safe runtime proof</dt>
+                <dd className="mono proof-pack-console__cell-block">BLOCKED</dd>
               </div>
               <div className="proof-pack-console__cell">
                 <dt>Public-safe state</dt>
@@ -359,7 +360,10 @@ export default function HomePage() {
               </div>
             </dl>
             <footer className="proof-pack-console__foot">
-              <span className="mono">no tag · no GitHub Release · no zip · no signing claimed</span>
+              <span className="mono">GitHub Release route · ZIP asset only · release package does not promote runtime proof</span>
+              <a className="cta cta-primary" href={externalLinks.proofPack001Release} target="_blank" rel="noopener noreferrer">
+                Open official release ↗
+              </a>
               <a className="cta cta-quiet" href="/artifacts/#cat-proof-record">Artifact coverage →</a>
             </footer>
           </div>

--- a/app/pipeline/page.tsx
+++ b/app/pipeline/page.tsx
@@ -373,18 +373,19 @@ export default function PipelinePage() {
         </div>
       </section>
 
-      {/* ── Proof Pack 001 release-path panel ────────────────────────── */}
+      {/* ── Proof Pack 001 release route panel ───────────────────────── */}
       <section className="cockpit-section--tight">
         <div className="container">
-          <div className="proof-pack-console" aria-label="Proof Pack 001 release-path status panel">
+          <div className="proof-pack-console" aria-label="Proof Pack 001 release route status panel">
             <header className="proof-pack-console__head">
               <div>
-                <p className="cockpit-eyebrow">Release path · governed</p>
+                <p className="cockpit-eyebrow">Release route · governed</p>
                 <h2 className="proof-pack-console__title">
-                  Proof Pack 001 · source / check-mode release path implemented.
+                  Proof Pack 001 · official release routed.
                 </h2>
                 <p className="proof-pack-console__sub">
-                  The release-path implementation is merged on the proof repo main branch. No official release, tag, zip, or signed artifact is claimed from this surface; the next gate is explicit release approval.
+                  The proof repo holds the official GitHub Release and approved reviewer ZIP.
+                  Website rendering is not proof; this pipeline page routes reviewers to the release.
                 </p>
               </div>
               <span className="proof-pack-console__ceiling mono">CONTROLLED_TEST_VALIDATED</span>
@@ -396,19 +397,19 @@ export default function PipelinePage() {
               </div>
               <div className="proof-pack-console__cell">
                 <dt>Pack ID</dt>
-                <dd className="mono">PROOF_PACK_001</dd>
+                <dd className="mono">HAWKINSOPERATIONS_PROOF_PACK_001</dd>
               </div>
               <div className="proof-pack-console__cell">
                 <dt>Pack status</dt>
-                <dd className="mono proof-pack-console__cell-strong">RELEASE_PATH_IMPLEMENTED</dd>
+                <dd className="mono proof-pack-console__cell-strong">PUBLIC_SAFE_REVIEWER_RELEASE_CANDIDATE</dd>
               </div>
               <div className="proof-pack-console__cell">
-                <dt>Source mode</dt>
-                <dd className="mono">CHECK_MODE_SOURCE_ONLY</dd>
+                <dt>ZIP SHA256</dt>
+                <dd className="mono">44d8a643aa2b113c9e99be0462e699d39af707a67190823cc05bb381907dc452</dd>
               </div>
               <div className="proof-pack-console__cell">
-                <dt>Next gate</dt>
-                <dd className="mono">OFFICIAL_RELEASE_PENDING_APPROVAL</dd>
+                <dt>Public-safe runtime proof</dt>
+                <dd className="mono proof-pack-console__cell-block">BLOCKED</dd>
               </div>
               <div className="proof-pack-console__cell">
                 <dt>Public-safe state</dt>
@@ -416,7 +417,10 @@ export default function PipelinePage() {
               </div>
             </dl>
             <footer className="proof-pack-console__foot">
-              <span className="mono">no tag · no GitHub Release · no zip · no signing claimed · routing only</span>
+              <span className="mono">GitHub Release route · ZIP asset only · release package does not promote runtime proof</span>
+              <a className="cta cta-primary" href={externalLinks.proofPack001Release} target="_blank" rel="noopener noreferrer">
+                Open official release ↗
+              </a>
               <a className="cta cta-quiet" href="/proof/">Proof ledger →</a>
             </footer>
           </div>

--- a/app/proof/ho-det-001/page.tsx
+++ b/app/proof/ho-det-001/page.tsx
@@ -145,9 +145,9 @@ export default function HoDet001CaseFilePage() {
         <div className="container">
           <SectionHeader title="Related links" eyebrow="Evidence routes" />
           <div className="mt-6 grid gap-4 md:grid-cols-3">
+            <LinkCard href={externalLinks.proofPack001Release} title="Proof Pack 001 release" description="Official GitHub Release for the bounded HO-DET-001 reviewer ZIP. Stronger public proof status remains blocked." external />
             <LinkCard href={externalLinks.proofRecord} title="Proof record" description="The canonical public proof record route for HO-DET-001." external />
             <LinkCard href={externalLinks.detections} title="Source repo" description="Detection source candidates. Source presence does not prove runtime." external />
-            <LinkCard href="/controls/" title="Claim firewall" description="Blocked terms and promotion requirements." />
           </div>
         </div>
       </section>

--- a/app/proof/page.tsx
+++ b/app/proof/page.tsx
@@ -442,7 +442,7 @@ export default function ProofIndexPage() {
               </div>
             </dl>
             <footer className="proof-pack-console__foot">
-              <span className="mono">GitHub Release route · ZIP asset only · no signing claimed</span>
+              <span className="mono">GitHub Release route · ZIP asset only · release package does not promote runtime proof</span>
               <a className="cta cta-primary" href={externalLinks.proofPack001Release} target="_blank" rel="noopener noreferrer">
                 Open official release ↗
               </a>

--- a/app/proof/page.tsx
+++ b/app/proof/page.tsx
@@ -391,8 +391,8 @@ export default function ProofIndexPage() {
               Proof Pack 001 · receipt console.
             </h2>
             <p className="muted mt-3 text-sm leading-6 max-w-3xl">
-              The release-path implementation is merged on the proof repo main branch. The pack
-              remains source / check-mode only; official release is gated by explicit approval.
+              The official GitHub Release is published from the proof repo. This surface routes
+              reviewers to the release; it does not raise the public proof ceiling.
             </p>
           </div>
 
@@ -401,11 +401,12 @@ export default function ProofIndexPage() {
               <div>
                 <p className="cockpit-eyebrow">Proof Pack 001</p>
                 <h3 className="proof-pack-console__title">
-                  HO-DET-001 · source / check-mode release path.
+                  HO-DET-001 · official reviewer release route.
                 </h3>
                 <p className="proof-pack-console__sub">
-                  Reviewer packet, manifest, checksum file, release-notes template, verifier script,
-                  and the publish workflow reside on proof repo main. Nothing here promotes the public ceiling.
+                  Reviewer packet, manifest, checksum file, proof card, proof record, validation
+                  record, ledger/schema, and proof verifier are packaged in the approved release ZIP.
+                  Nothing here promotes runtime, signal, production, or stronger public proof status.
                 </p>
               </div>
               <span className="proof-pack-console__ceiling mono">{ceiling}</span>
@@ -413,7 +414,7 @@ export default function ProofIndexPage() {
             <dl className="proof-pack-console__grid">
               <div className="proof-pack-console__cell">
                 <dt>Pack ID</dt>
-                <dd className="mono">PROOF_PACK_001</dd>
+                <dd className="mono">HAWKINSOPERATIONS_PROOF_PACK_001</dd>
               </div>
               <div className="proof-pack-console__cell">
                 <dt>Detection</dt>
@@ -421,23 +422,30 @@ export default function ProofIndexPage() {
               </div>
               <div className="proof-pack-console__cell">
                 <dt>Pack status</dt>
-                <dd className="mono proof-pack-console__cell-strong">RELEASE_PATH_IMPLEMENTED</dd>
+                <dd className="mono proof-pack-console__cell-strong">PUBLIC_SAFE_REVIEWER_RELEASE_CANDIDATE</dd>
               </div>
               <div className="proof-pack-console__cell">
-                <dt>Source mode</dt>
-                <dd className="mono">CHECK_MODE_SOURCE_ONLY</dd>
+                <dt>ZIP SHA256</dt>
+                <dd className="mono">44d8a643aa2b113c9e99be0462e699d39af707a67190823cc05bb381907dc452</dd>
               </div>
               <div className="proof-pack-console__cell">
                 <dt>Public-safe state</dt>
                 <dd className="mono proof-pack-console__cell-block">{publicSafe}</dd>
               </div>
               <div className="proof-pack-console__cell">
+                <dt>Public-safe runtime proof</dt>
+                <dd className="mono proof-pack-console__cell-block">BLOCKED</dd>
+              </div>
+              <div className="proof-pack-console__cell">
                 <dt>Next gate</dt>
-                <dd className="mono">OFFICIAL_RELEASE_PENDING_APPROVAL</dd>
+                <dd className="mono">RUNTIME_AND_SIGNAL_EVIDENCE_REVIEW</dd>
               </div>
             </dl>
             <footer className="proof-pack-console__foot">
-              <span className="mono">no tag · no GitHub Release · no zip · no signing claimed</span>
+              <span className="mono">GitHub Release route · ZIP asset only · no signing claimed</span>
+              <a className="cta cta-primary" href={externalLinks.proofPack001Release} target="_blank" rel="noopener noreferrer">
+                Open official release ↗
+              </a>
               <a className="cta cta-quiet" href="/artifacts/">Artifact coverage →</a>
             </footer>
           </div>

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -33,6 +33,7 @@ export const externalLinks = {
   platform: "https://github.com/HawkinsOperations/hawkinsoperations-platform",
   proof: "https://github.com/HawkinsOperations/hawkinsoperations-proof",
   proofRecord: "https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/records/HO-DET-001.md",
+  proofPack001Release: "https://github.com/HawkinsOperations/hawkinsoperations-proof/releases/tag/hawkinsoperations-proof-pack-001",
   proofRecordAws: "https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/records/AWS-DET-001.md",
   pipelineProof: "https://github.com/HawkinsOperations/hawkinsoperations-validation/blob/main/reports/ho-det-001/pipeline-proof.md",
   pipelineProofJson: "https://github.com/HawkinsOperations/hawkinsoperations-validation/blob/main/reports/ho-det-001/pipeline-proof.json",

--- a/src/data/recentGovernedArtifacts.ts
+++ b/src/data/recentGovernedArtifacts.ts
@@ -52,7 +52,7 @@ export type RecentGovernedArtifact = {
   relatedLabel?: string;
 };
 
-export const recentGovernedArtifactsSnapshotDate = "2026-05-17" as const;
+export const recentGovernedArtifactsSnapshotDate = "2026-05-18" as const;
 
 export const recentGovernedArtifacts: RecentGovernedArtifact[] = [
   {
@@ -169,11 +169,11 @@ export const recentGovernedArtifacts: RecentGovernedArtifact[] = [
     summary:
       "Reviewer-package wording for Proof Pack 001 tightened. Wording only.",
     whatChanged:
-      "Wording in the Proof Pack 001 reviewer package was hardened so that public-safe runtime proof, runtime-active, and signal-observed claims cannot be implied through the package framing. No official release, tag, zip, signing, or public-safe release was added.",
+      "Wording in the Proof Pack 001 reviewer package was hardened so that stronger runtime, signal, and public-proof claims cannot be implied through the package framing. This row records the earlier wording hardening, not the later official release.",
     supports:
       "The Proof Pack 001 reviewer-package wording is bounded and does not imply runtime-active, signal-observed, or public-safe runtime proof status.",
     doesNotProve:
-      "An official released Proof Pack, a public-safe release, a runtime-active claim, a signal-observed claim, or a public-safe runtime proof. Wording was hardened; no release artifact exists from this surface.",
+      "Stronger runtime, signal, or public-proof status. Wording was hardened; release routing is tracked in the Proof Pack 001 receipt console.",
     reviewRoute:
       "Open the proof repo PR to inspect the wording diff and the bounded reviewer-package framing.",
     prHref: "https://github.com/HawkinsOperations/hawkinsoperations-proof/pull/36",


### PR DESCRIPTION
## Summary

Routes the HawkinsOperations website proof surfaces to the official Proof Pack 001 GitHub Release.

Release: https://github.com/HawkinsOperations/hawkinsoperations-proof/releases/tag/hawkinsoperations-proof-pack-001
ZIP SHA256: `44d8a643aa2b113c9e99be0462e699d39af707a67190823cc05bb381907dc452`

## Changed files

- `app/proof/page.tsx`
- `app/proof/ho-det-001/page.tsx`
- `src/data/navigation.ts`
- `src/data/recentGovernedArtifacts.ts`

## Validation

- PASS `npm run check:site`
- PASS `npm run typecheck`
- PASS `npm run build`
- PASS `git diff --check`
- PASS changed-file private/local/secret scan
- PASS changed-file blocked-claim promotion scan
- PASS stale release wording scan

## Claim boundary

This PR routes to the official Proof Pack 001 release only. It preserves:

- `HO-DET-001` public proof ceiling: `CONTROLLED_TEST_VALIDATED`
- reviewer package status: `PUBLIC_SAFE_REVIEWER_RELEASE_CANDIDATE`
- raw/private runtime evidence status: `NOT_PUBLIC_SAFE` and excluded
- public-safe runtime proof: `BLOCKED`
- website/GitHub rendering is not proof

## What this does not do

This PR does not create a release, tag, ZIP, signature, Sigstore bundle, runtime proof, signal-observed proof, public-safe runtime proof, production readiness, SOCaaS, autonomous SOC, AI-approved disposition, analyst-approved disposition, or proof promotion.

## Human review required

Green checks are not merge authority. Codex review is AI labor, not governance. Do not merge without visible human review and `MERGE_APPROVED`.