### PR TITLE
design(site): senior-grade upgrade — narrative, navy-kill + canvas, React Flow

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -5,468 +5,425 @@ import PortraitCommandFrame from "@components/PortraitCommandFrame";
 import { externalLinks } from "@data/navigation";
 
 export const metadata: Metadata = {
-  title: "About | HawkinsOps",
+  title: "Operator | HawkinsOperations",
   description:
-    "Operator methodology for HawkinsOperations: governed detection engineering, AI-assisted security work bounded by gates, evidence, and human review. HawkinsOps v1 → HawkinsOperations successor framing.",
+    "Operator behind HawkinsOperations: governed detection engineering, AI-assisted security operations bounded by validation, evidence, CI controls, and human review. Manufacturing quality discipline transferred into AI security operations governance.",
 };
 
-type Lane = {
-  eyebrow: string;
-  title: string;
-  steps: string[];
-  note: string;
+type FailureStep = {
+  code: string;
+  label: string;
+  why: string;
 };
 
-const lanes: Lane[] = [
+const failurePath: FailureStep[] = [
   {
-    eyebrow: "Detection engineering",
-    title: "Source → control → bounded claim",
-    steps: ["Detection source", "Controlled validation", "Bounded claim"],
-    note: "Detection-as-code: reviewable source, deterministic validation, no claim that source presence is runtime.",
+    code: "01",
+    label: "AI output",
+    why: "Cheap to produce, hard to govern. Without a gate, downstream surfaces treat it as fact.",
   },
   {
-    eyebrow: "SOC automation",
-    title: "Findings → gate → record",
-    steps: ["Findings packet", "Verifier / CI gate", "Proof record"],
-    note: "Closed engineering loops: source → validation → verifier → CI → record. Every step has a gate; no step skips one.",
+    code: "02",
+    label: "Analyst conclusion",
+    why: "Once pasted into a ticket or brief, AI wording becomes a claim with someone's name on it.",
   },
   {
-    eyebrow: "AI labor",
-    title: "Draft → verifier → operator review",
-    steps: ["AI draft", "Deterministic verifier", "Operator review"],
-    note: "AI accelerates drafting, scaffolding, and review. AI never owns the promotion boundary.",
+    code: "03",
+    label: "Operational action",
+    why: "Block, alert, escalate. The action itself becomes downstream proof the claim was real.",
+  },
+  {
+    code: "04",
+    label: "Public claim",
+    why: "Public statements are hardest to retract. Websites, decks, press become the new baseline.",
+  },
+  {
+    code: "05",
+    label: "Executive truth",
+    why: "Once enough surfaces repeat a claim, executives treat it as established. The AI origin is gone.",
   },
 ];
 
-type TransferRow = { left: string; right: string; note: string };
-const transferRows: TransferRow[] = [
-  { left: "Standard work", right: "Detection-as-code", note: "Reviewable, repeatable, owned." },
-  { left: "Traceability", right: "Evidence records", note: "Bounded artifacts, retained." },
-  { left: "Defect control", right: "Validation failures", note: "Deterministic, gated, surfaced." },
-  { left: "Escalation paths", right: "Human review gates", note: "Operator-approved promotion." },
-  { left: "Quality gates", right: "CI / verifier enforcement", note: "Wording cannot ship until checks pass." },
+type BuiltItem = {
+  label: string;
+  detail: string;
+};
+
+const builtItems: BuiltItem[] = [
+  {
+    label: "Evidence-controlled detection engineering",
+    detail: "Detection-as-code with reviewable source, deterministic validation, and bounded claim wording.",
+  },
+  {
+    label: "Deterministic validators",
+    detail: "Controlled positive and negative test cases produce pass/fail receipts the next surface can require.",
+  },
+  {
+    label: "CI gates",
+    detail: "Site contract verifier, blocked-claim scanner, schema validity, MITRE mapping integrity. CI fails the build when a gate trips.",
+  },
+  {
+    label: "Proof records",
+    detail: "Public proof records carry stated ceilings, evidence pointers, supported wording, and blocked wording.",
+  },
+  {
+    label: "Claim firewall",
+    detail: "Wording outside the supported set is blocked at the public surface — not warned about, blocked.",
+  },
+  {
+    label: "AI labor under human authority",
+    detail: "AI accelerates drafting, scaffolding, triage support, and reviewer preparation. AI does not own the promotion boundary.",
+  },
+];
+
+type ResumeRow = {
+  label: string;
+  value: string;
+  note?: string;
+};
+
+const resumeRows: ResumeRow[] = [
+  {
+    label: "Role focus",
+    value: "AI Security Operations · Detection Engineering · SOC Automation",
+  },
+  {
+    label: "Cases processed",
+    value: "324,074",
+    note: "Across an 8-month controlled build-and-validation cycle. Not an enterprise production claim.",
+  },
+  {
+    label: "Auto-close rate",
+    value: "~88%",
+    note: "Inside the same controlled cycle. Auto-close routed only the cases the validators authorized.",
+  },
+  {
+    label: "Reviewer-escalated evidence packs",
+    value: "8,574",
+    note: "Surfaced for human review under the bounded routing rules.",
+  },
+  {
+    label: "Cycle window",
+    value: "8 months · controlled build and validation",
+  },
+  {
+    label: "Certification",
+    value: "CompTIA Security+ · May 2026",
+  },
+  {
+    label: "Current role",
+    value: "Outlier · AI Model Evaluator · cybersecurity domain · Dec 2025 → present",
+  },
+  {
+    label: "Prior role",
+    value: "Unipres Alabama · Production Supervisor · 30+ operators · audit-heavy IATF/TISAX quality expectations",
+  },
+  {
+    label: "Earlier role",
+    value: "Fehrer Automotive · Production Operator → Team Lead · high-throughput line ownership",
+  },
+];
+
+const stackItems: string[] = [
+  "Detection-as-code",
+  "Python CI verifier",
+  "Schema validity checks",
+  "MITRE mapping integrity",
+  "Claim-scope boundaries",
+  "GitHub Actions self-hosted runner executes verifiers on PRs",
 ];
 
 const isItems = [
-  "Governed detection engineering SOC.",
-  "Proof-bound security engineering system.",
-  "Public reviewer surface with bounded claims.",
+  "An AI security operations control layer.",
+  "A governed detection engineering surface.",
+  "A reviewer-ready proof path with bounded claims.",
 ];
 
 const isNotItems = [
-  "Autonomous SOC is blocked / not claimed.",
-  "Production SOC is blocked / not claimed.",
-  "Fleet-wide enterprise deployment is blocked / not claimed.",
-  "Public-safe runtime proof is blocked / not claimed.",
+  "Not a production-ready SOC. Blocked / not claimed.",
+  "Not public-safe runtime proof. Blocked / not claimed.",
+  "Not an autonomous SOC. Blocked / not claimed.",
+  "Not AI-approved disposition. Blocked / not claimed.",
+  "Not analyst-approved disposition unless explicitly proven. Blocked / not claimed.",
+  "Not fleet-wide enterprise deployment. Blocked / not claimed.",
 ];
 
 const routeSlots = [
   {
+    cat: "INSPECT →",
+    label: "Proof Pack 001",
+    desc: "Released proof pack receipt.",
+    href: externalLinks.proofPack001Release,
+    external: true,
+  },
+  {
+    cat: "TRACE →",
+    label: "HO-DET-001",
+    desc: "End-to-end proof route.",
+    href: "/proof/ho-det-001/",
+  },
+  {
+    cat: "ORG ↗",
+    label: "HawkinsOperations",
+    desc: "Governed organization on GitHub.",
+    href: externalLinks.githubOrg,
+    external: true,
+  },
+  {
     cat: "EXTERNAL ↗",
-    label: "GitHub",
+    label: "GitHub · Raylee",
     desc: "Operator profile.",
     href: externalLinks.rayleeGithub,
     external: true,
   },
   {
     cat: "EXTERNAL ↗",
-    label: "LinkedIn",
+    label: "LinkedIn · Raylee",
     desc: "Professional profile.",
     href: externalLinks.rayleeLinkedIn,
     external: true,
   },
-  {
-    cat: "REFERENCE ↗",
-    label: "Legacy HawkinsOps",
-    desc: "Reference / context only · does not promote current claims.",
-    href: externalLinks.legacyHawkinsOps,
-    external: true,
-  },
-  {
-    cat: "ORGANIZATION ↗",
-    label: "HawkinsOperations",
-    desc: "Current governed organization on GitHub.",
-    href: externalLinks.githubOrg,
-    external: true,
-  },
 ];
 
-export default function AboutPage() {
+export default function OperatorPage() {
   return (
     <>
       {/* ── Hero ─────────────────────────────────────────────────────── */}
       <section className="relative overflow-hidden cockpit-section">
-        <div className="container grid gap-14 lg:grid-cols-[1.45fr_0.85fr] lg:gap-16 items-start">
+        <div className="container-cockpit grid gap-14 lg:grid-cols-[1.4fr_0.85fr] lg:gap-16 items-start">
           <div>
             <div className="flex flex-wrap items-center gap-3">
               <BrandMark size="sm" />
-              <span className="cockpit-eyebrow">Operator methodology · governance authority</span>
+              <span className="cockpit-eyebrow">Operator</span>
             </div>
 
             <h1 className="cockpit-headline cockpit-headline--xl mt-6">
-              Raylee Hawkins.
+              I built HawkinsOperations because AI can accelerate security work
               <span className="block mt-2" style={{ color: "var(--electric-blue-bright)" }}>
-                Detection engineer · SOC automation.
+                faster than most teams can verify it.
               </span>
             </h1>
 
             <p className="lede mt-7 max-w-2xl" style={{ color: "var(--silver)" }}>
-              I build governed detection engineering workflows where AI accelerates work and
-              evidence controls the claim. Manufacturing quality control taught the discipline;
-              detection engineering inherits it.
+              The system is my answer to uncontrolled promotion: AI-generated output becoming
+              analyst conclusion, operational action, public claim, or executive truth before
+              validation, evidence, CI controls, and human review authorize it. AI accelerates the
+              work. Evidence and human review authorize the claim.
             </p>
 
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <a className="cta cta-primary" href={externalLinks.rayleeGithub} target="_blank" rel="noopener noreferrer">
-                GitHub ↗
+              <a
+                className="cta cta-primary"
+                href={externalLinks.proofPack001Release}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Inspect Proof Pack 001 ↗
+              </a>
+              <a className="cta cta-quiet" href="/proof/ho-det-001/">
+                Trace HO-DET-001 →
+              </a>
+              <a
+                className="cta cta-quiet"
+                href={externalLinks.githubOrg}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                GitHub Org ↗
               </a>
               <a className="cta cta-quiet" href={externalLinks.rayleeLinkedIn} target="_blank" rel="noopener noreferrer">
                 LinkedIn ↗
               </a>
-              <a className="cta cta-quiet" href="/proof/">Proof ledger</a>
             </div>
           </div>
 
           <div className="flex flex-col gap-6 items-stretch lg:items-end lg:pt-2">
-            <div className="lg:max-w-[280px] w-full">
+            <div className="lg:max-w-[300px] w-full">
               <PortraitCommandFrame size="compact" showArc={false} showBoundary={false} />
             </div>
             <StatusConsole showLoop={false} />
           </div>
         </div>
 
-        <div className="container mt-12">
+        <div className="container-cockpit mt-12">
           <hr className="cockpit-rule" />
         </div>
       </section>
 
-      {/* ── From HawkinsOps v1 → HawkinsOperations · successor framing ─ */}
+      {/* ── Failure mode · output promoted before proof ─────────────── */}
       <section className="cockpit-section--tight">
-        <div className="container reveal reveal--up">
-          <div className="mb-5">
-            <p className="cockpit-eyebrow">From HawkinsOps v1 to HawkinsOperations</p>
-            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.5rem, 2.4vw, 2.0rem)" }}>
-              The successor system: same builder energy, rebuilt around evidence boundaries.
+        <div className="container-cockpit reveal reveal--up">
+          <div className="mb-6">
+            <p className="cockpit-eyebrow" style={{ color: "var(--blocked-red-strong, #FCA5A5)" }}>
+              The failure mode
+            </p>
+            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
+              Output promoted before proof.
             </h2>
-            <p className="muted mt-3 max-w-3xl text-sm leading-6" style={{ color: "#B7C4D6" }}>
-              HawkinsOps v1 is the historical operating layer. HawkinsOperations is the governed
-              successor.
+            <p className="muted mt-3 text-sm leading-6 max-w-3xl">
+              Without controls, AI output becomes analyst conclusion, operational action, public
+              claim, and executive truth without enough validation, evidence, or human review to
+              support it. HawkinsOperations is built to block that path.
             </p>
           </div>
 
-          <div className="v1-v2">
-            <article className="v1-v2__card v1-v2__card--legacy spotlight">
-              <p className="v1-v2__eyebrow">HawkinsOps v1 · legacy reference</p>
-              <h3 className="v1-v2__title">The work was built.</h3>
-              <p className="v1-v2__body">
-                v1 demonstrated that the work could be done: detections, triage, dashboards, automation,
-                and operational proof-of-work in a historical v1 context. It is the historical operating
-                layer.
-              </p>
-              <ul className="v1-v2__list">
-                <li>Detections shipped</li>
-                <li>Triage automation</li>
-                <li>Dashboards and reporting</li>
-                <li>Operational proof-of-work</li>
-              </ul>
-              <p style={{ marginTop: "0.9rem", fontFamily: '"JetBrains Mono", monospace', fontSize: "0.7rem", letterSpacing: "0.14em" }}>
-                <a
-                  href={externalLinks.legacyHawkinsOps}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  style={{ color: "var(--ice-blue)", borderBottom: "1px solid rgba(143,216,255,0.4)" }}
-                >
-                  Open legacy HawkinsOps reference ↗
-                </a>
-              </p>
-            </article>
+          <ol className="operator-failure" aria-label="Five-stage failure path">
+            {failurePath.map((step) => (
+              <li key={step.code} className="operator-failure__step">
+                <span className="operator-failure__num">{step.code}</span>
+                <span className="operator-failure__label">{step.label}</span>
+                <span className="operator-failure__why">{step.why}</span>
+              </li>
+            ))}
+          </ol>
 
-            <div className="v1-v2__arrow" aria-hidden="true">→</div>
-
-            <article className="v1-v2__card v1-v2__card--successor spotlight spotlight--amber">
-              <p className="v1-v2__eyebrow">HawkinsOperations · governed successor</p>
-              <h3 className="v1-v2__title">Rebuilt with stricter claim boundaries.</h3>
-              <p className="v1-v2__body">
-                HawkinsOperations rebuilds that work with separated truth surfaces, deterministic
-                validation, proof records, blocked-claim wording, and human-review authority. AI
-                accelerates the work. Evidence and human review authorize the claims.
-              </p>
-              <ul className="v1-v2__list">
-                <li>Source · validation · runtime · signal · evidence · public proof — separated</li>
-                <li>Deterministic gates + blocked-claim scanner</li>
-                <li>Proof records with explicit ceilings</li>
-                <li>Human review as promotion authority</li>
-              </ul>
-              <p style={{ marginTop: "0.9rem", fontFamily: '"JetBrains Mono", monospace', fontSize: "0.7rem", letterSpacing: "0.14em", display: "flex", flexWrap: "wrap", gap: "0.6rem 1rem" }}>
-                <a
-                  href="/proof/"
-                  style={{ color: "var(--ceiling-amber)", borderBottom: "1px solid rgba(224,189,99,0.5)" }}
-                >
-                  Inspect governed successor →
-                </a>
-                <a
-                  href="https://github.com/HawkinsOperations"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  style={{ color: "var(--ice-blue)", borderBottom: "1px solid rgba(143,216,255,0.4)" }}
-                >
-                  Open GitHub org ↗
-                </a>
-              </p>
-            </article>
-          </div>
-
-          <p className="v1-v2__caveat">
-            <strong>Legacy claim boundary:</strong> v1 metrics (detections shipped, cases handled,
-            automation built) are historical/reference context. They are not current HawkinsOperations
-            proof and do not automatically transfer into HawkinsOperations claims. Stronger wording for
-            the successor surface requires a separate evidence-backed promotion gate.
+          <p className="muted mt-6 text-sm leading-6 max-w-3xl">
+            HawkinsOperations interrupts this path with deterministic validators, evidence records,
+            CI controls, blocked-claim scanners, and human review. Promotion is upward and gated;
+            public wording stays capped at CONTROLLED_TEST_VALIDATED.
           </p>
         </div>
       </section>
 
-      {/* ── Why this matters · AI governance bridge ──────────────────── */}
+      {/* ── Operator origin · manufacturing → governance ─────────────── */}
       <section className="cockpit-section--tight">
-        <div className="container reveal reveal--up">
-          <div className="mb-5">
-            <p className="cockpit-eyebrow">Why this matters</p>
-            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.5rem, 2.4vw, 2.0rem)" }}>
-              The enterprise AI failure mode is uncontrolled promotion.
-            </h2>
-            <p className="muted mt-3 text-sm leading-6 max-w-3xl" style={{ color: "#B7C4D6" }}>
-              Without controls, AI output becomes analyst conclusion, operational action, public
-              claim, and executive truth without enough validation, evidence, or human review.
-              HawkinsOperations is built to block that path.
-            </p>
-            <details className="disclose" style={{ marginTop: "0.9rem" }}>
-              <summary>Read the failure mode in detail</summary>
-              <dl className="disclose__body">
-                <dt>Where it breaks</dt>
-                <dd>AI output is the cheapest part of an AI system to produce and the hardest to govern. Without a gate, downstream surfaces treat it as fact.</dd>
-                <dt>What HawkinsOperations blocks</dt>
-                <dd>Runtime-active, signal-observed, public-safe runtime proof, autonomous SOC, AI-approved disposition, analyst-approved disposition. Those wordings remain blocked by the claim firewall.</dd>
-                <dt>Next inspection</dt>
-                <dd><a href="/artifacts/ai-governance-control-layer-case-study/" style={{ color: "var(--electric-blue-bright)" }}>Read the AI Governance Control Layer case study →</a></dd>
-              </dl>
-            </details>
-          </div>
-          <div className="biz-translate" role="note" aria-label="Business translation">
-            <span className="biz-translate__label">In plain English</span>
-            <span>
-              <span className="biz-translate__text">
-                Polished output cannot promote a security claim without evidence and human review.
-              </span>{" "}
-              <a
-                href="/artifacts/ai-governance-control-layer-case-study/"
-                style={{ color: "var(--ice-blue)", borderBottom: "1px solid rgba(143,216,255,0.4)" }}
-              >
-                Read the AI Governance Control Layer case study →
-              </a>
-            </span>
-          </div>
-        </div>
-      </section>
-
-      {/* ── Operator profile · concise ────────────────────────────────── */}
-      <section className="cockpit-section--tight">
-        <div className="container reveal reveal--up">
-          <div className="operator-profile spotlight">
+        <div className="container-cockpit reveal reveal--up">
+          <div className="grid gap-10 lg:grid-cols-[1fr_1fr] lg:gap-14 items-start">
             <div>
-              <p className="operator-profile__eyebrow">Operator profile</p>
-              <h2 className="operator-profile__name">Raylee Hawkins</h2>
-              <p className="operator-profile__role">
-                Detection engineer · SOC automation · AI-assisted proof routing
+              <p className="cockpit-eyebrow">Operator origin</p>
+              <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.5rem, 2.4vw, 2.0rem)" }}>
+                Manufacturing quality discipline, transferred into AI security operations.
+              </h2>
+              <p className="muted mt-4 text-sm leading-6">
+                I came up on production floors with audit-heavy quality systems — IATF and TISAX
+                environments where every step had a gate, every defect had an owner, and nothing
+                shipped without a traceable record. Move fast, validate hard, never let a public
+                claim outrun its evidence.
               </p>
-              <div className="operator-profile__bio">
-                <p>
-                  Raylee Hawkins is a self-taught detection engineer and SOC automation builder.
-                </p>
-                <p>
-                  Her background in manufacturing quality systems shaped HawkinsOperations: move fast,
-                  validate hard, and never let a public claim outrun its evidence.
-                </p>
-                <p>
-                  HawkinsOperations applies that discipline to AI-assisted security work. AI accelerates
-                  drafting, triage, and reviewer preparation. Evidence and human review authorize what
-                  can be claimed.
-                </p>
-              </div>
-              <p className="operator-profile__focus">
-                <b>Focus</b>
-                Detection engineering · SOC automation · validation gates · proof records · claim-safe
-                public surfaces.
+              <p className="muted mt-3 text-sm leading-6">
+                HawkinsOperations applies that discipline to AI-assisted security work. AI
+                accelerates drafting, triage, and reviewer preparation. Deterministic validators,
+                CI gates, evidence records, and public claim boundaries decide what becomes
+                operational truth.
               </p>
             </div>
-            <div>
-              <p className="operator-profile__eyebrow">Reviewer routes</p>
-              <div className="operator-profile__ctas">
-                <a className="thesis-band__cta thesis-band__cta--primary" href="/proof/">
-                  Inspect the proof system →
-                </a>
-                <a className="thesis-band__cta thesis-band__cta--quiet" href="/artifacts/">
-                  View artifacts →
-                </a>
-                <a className="thesis-band__cta thesis-band__cta--quiet" href="/artifacts/ai-governance-control-layer-case-study/">
-                  Read case study →
-                </a>
-                <a
-                  className="thesis-band__cta thesis-band__cta--quiet"
-                  href="https://github.com/HawkinsOperations"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Open GitHub org ↗
-                </a>
+            <div className="translation-map" aria-label="Manufacturing quality → AI security operations translation">
+              <div className="translation-map__head">
+                <span className="translation-map__head-cell">Manufacturing QC</span>
+                <span className="translation-map__head-spacer" aria-hidden="true">→</span>
+                <span className="translation-map__head-cell">AI security operations</span>
+                <span className="translation-map__head-cell">Practice outcome</span>
               </div>
-              <p className="operator-profile__focus" style={{ marginTop: "1.4rem" }}>
-                <b>Public-safe</b>
-                NOT_PUBLIC_SAFE. Public ceiling holds at CONTROLLED_TEST_VALIDATED. Website rendering
-                is not proof. Human review required.
-              </p>
+              <div className="translation-map__row">
+                <span className="translation-map__left">Standard work</span>
+                <span className="translation-map__arrow" aria-hidden="true">→</span>
+                <span className="translation-map__right">Detection-as-code</span>
+                <span className="translation-map__note">Reviewable, repeatable, owned.</span>
+              </div>
+              <div className="translation-map__row">
+                <span className="translation-map__left">Traceability</span>
+                <span className="translation-map__arrow" aria-hidden="true">→</span>
+                <span className="translation-map__right">Evidence records</span>
+                <span className="translation-map__note">Bounded artifacts, retained.</span>
+              </div>
+              <div className="translation-map__row">
+                <span className="translation-map__left">Defect control</span>
+                <span className="translation-map__arrow" aria-hidden="true">→</span>
+                <span className="translation-map__right">Validation failures</span>
+                <span className="translation-map__note">Deterministic, gated, surfaced.</span>
+              </div>
+              <div className="translation-map__row">
+                <span className="translation-map__left">Quality gates</span>
+                <span className="translation-map__arrow" aria-hidden="true">→</span>
+                <span className="translation-map__right">CI / verifier enforcement</span>
+                <span className="translation-map__note">Wording cannot ship until checks pass.</span>
+              </div>
+              <div className="translation-map__row">
+                <span className="translation-map__left">Escalation paths</span>
+                <span className="translation-map__arrow" aria-hidden="true">→</span>
+                <span className="translation-map__right">Human review gates</span>
+                <span className="translation-map__note">Operator-approved promotion.</span>
+              </div>
             </div>
           </div>
         </div>
       </section>
 
-      {/* ── Operator lanes ──────────────────────────────────────────── */}
+      {/* ── What I built ─────────────────────────────────────────────── */}
       <section className="cockpit-section--tight">
-        <div className="container">
+        <div className="container-cockpit">
           <div className="mb-6">
-            <p className="cockpit-eyebrow">Operator lanes</p>
+            <p className="cockpit-eyebrow">What I built</p>
             <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
-              Three lanes. One direction. Input → control → output.
+              A control layer for AI-assisted security work.
             </h2>
             <p className="muted mt-3 text-sm leading-6 max-w-3xl">
-              Each lane describes the day-to-day work that produces a bounded artifact. AI
-              accelerates the work inside the lanes; governance owns the boundary.
+              Six surfaces, gated promotion, reviewer-visible receipts. AI is scoped labor. Validators,
+              CI, evidence records, and human review own the boundary.
             </p>
           </div>
-
-          <div className="operator-lanes">
-            {lanes.map((lane) => (
-              <article key={lane.eyebrow} className="operator-lane">
-                <span className="operator-lane__eyebrow">{lane.eyebrow}</span>
-                <h3 className="operator-lane__title">{lane.title}</h3>
-                <div className="operator-lane__flow">
-                  {lane.steps.map((step, i) => (
-                    <div key={step} className="operator-lane__step">
-                      <span className="operator-lane__step-num">{String(i + 1).padStart(2, "0")}</span>
-                      <span className="operator-lane__step-label">{step}</span>
-                      {i < lane.steps.length - 1 && <span className="operator-lane__step-arrow">→</span>}
-                    </div>
-                  ))}
-                </div>
-                <p className="operator-lane__note">{lane.note}</p>
+          <div className="operator-built">
+            {builtItems.map((item) => (
+              <article key={item.label} className="operator-built__card">
+                <p className="operator-built__label">{item.label}</p>
+                <p className="operator-built__detail">{item.detail}</p>
               </article>
             ))}
           </div>
         </div>
       </section>
 
-      {/* ── Methodology translation map (Manufacturing QC → DE) ─────── */}
+      {/* ── Resume snapshot · bounded facts ──────────────────────────── */}
       <section className="cockpit-section--tight">
-        <div className="container">
+        <div className="container-cockpit">
           <div className="mb-6">
-            <p className="cockpit-eyebrow">Methodology transfer</p>
+            <p className="cockpit-eyebrow">Resume snapshot</p>
             <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
-              Manufacturing QC → detection engineering.
+              Bounded public-safe facts, framed inside the controlled cycle.
             </h2>
             <p className="muted mt-3 text-sm leading-6 max-w-3xl">
-              The same discipline, mapped. Each row is a one-to-one translation, not a metaphor.
+              Throughput and ratios below are reviewer-facing facts from an 8-month controlled
+              build-and-validation cycle. They are not an enterprise production-deployment claim.
+              Runtime-active, fleet-wide, and public-safe runtime proof wording remains blocked at
+              this surface.
             </p>
           </div>
 
-          <div className="translation-map">
-            <div className="translation-map__head">
-              <span className="translation-map__head-cell">Manufacturing QC</span>
-              <span className="translation-map__head-spacer" aria-hidden="true">→</span>
-              <span className="translation-map__head-cell">Detection engineering</span>
-              <span className="translation-map__head-cell">Practice outcome</span>
-            </div>
-            {transferRows.map((row) => (
-              <div key={row.left} className="translation-map__row">
-                <span className="translation-map__left">{row.left}</span>
-                <span className="translation-map__arrow" aria-hidden="true">→</span>
-                <span className="translation-map__right">{row.right}</span>
-                <span className="translation-map__note">{row.note}</span>
+          <div className="operator-resume" role="list">
+            {resumeRows.map((row) => (
+              <div key={row.label} role="listitem" className="operator-resume__row">
+                <span className="operator-resume__label">{row.label}</span>
+                <span className="operator-resume__value">{row.value}</span>
+                {row.note ? <span className="operator-resume__note">{row.note}</span> : null}
               </div>
             ))}
           </div>
-        </div>
-      </section>
 
-      {/* ── AI governance flow ───────────────────────────────────────── */}
-      <section className="cockpit-section--tight">
-        <div className="container">
-          <div className="ai-flow">
-            <div className="ai-flow__copy">
-              <p className="cockpit-eyebrow">AI governance</p>
-              <h2 className="ai-flow__title">AI is labor. Governance is authority.</h2>
-              <p className="ai-flow__line">
-                AI accelerates the work — drafting detections, scaffolding validators, surfacing
-                review notes. Authority lives in deterministic verifiers, explicit evidence linkage,
-                and operator-approved promotion gates.
-              </p>
-              <p className="ai-flow__creed">Build loud · Verify hard · Claim tight · Ship receipts</p>
-            </div>
-
-            <div className="ai-flow__visual" aria-hidden="true">
-              <svg viewBox="0 0 460 220" role="img" aria-label="AI accelerates labor; deterministic verifier and operator review own the promotion gate">
-                <defs>
-                  <marker id="aif-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
-                    <path d="M0,0 L10,5 L0,10 z" fill="var(--electric-blue-bright)" />
-                  </marker>
-                </defs>
-
-                {/* Top lane: AI labor */}
-                <text x={28} y={28} fontSize={9} fontFamily='"JetBrains Mono", monospace' fill="var(--electric-blue-bright)" letterSpacing="2">LABOR · AI</text>
-                <rect x={28} y={38} width={104} height={42} rx={5} fill="rgba(8,13,22,0.94)" stroke="var(--electric-blue)" strokeWidth={1.4} />
-                <text x={80} y={56} fontSize={11} fontWeight={700} fontFamily="Inter, ui-sans-serif, system-ui, sans-serif" fill="var(--silver-bright)" textAnchor="middle">AI drafts</text>
-                <text x={80} y={70} fontSize={9} fontFamily='"JetBrains Mono", monospace' fill="var(--ice-blue)" textAnchor="middle" letterSpacing="1.5">DRAFT</text>
-
-                <line x1={132} y1={60} x2={172} y2={60} stroke="var(--electric-blue-bright)" strokeWidth={1.4} markerEnd="url(#aif-arrow)" />
-
-                <rect x={172} y={38} width={120} height={42} rx={5} fill="rgba(8,13,22,0.94)" stroke="var(--electric-blue)" strokeWidth={1.4} />
-                <text x={232} y={56} fontSize={11} fontWeight={700} fontFamily="Inter, ui-sans-serif, system-ui, sans-serif" fill="var(--silver-bright)" textAnchor="middle">Verifier checks</text>
-                <text x={232} y={70} fontSize={9} fontFamily='"JetBrains Mono", monospace' fill="var(--ice-blue)" textAnchor="middle" letterSpacing="1.5">DETERMINISTIC</text>
-
-                <line x1={292} y1={60} x2={332} y2={60} stroke="var(--electric-blue-bright)" strokeWidth={1.4} markerEnd="url(#aif-arrow)" />
-
-                <rect x={332} y={38} width={104} height={42} rx={5} fill="rgba(8,13,22,0.94)" stroke="var(--electric-blue)" strokeWidth={1.4} />
-                <text x={384} y={56} fontSize={11} fontWeight={700} fontFamily="Inter, ui-sans-serif, system-ui, sans-serif" fill="var(--silver-bright)" textAnchor="middle">Evidence link</text>
-                <text x={384} y={70} fontSize={9} fontFamily='"JetBrains Mono", monospace' fill="var(--ice-blue)" textAnchor="middle" letterSpacing="1.5">RECORD</text>
-
-                {/* Lower gate */}
-                <text x={28} y={120} fontSize={9} fontFamily='"JetBrains Mono", monospace' fill="var(--muted)" letterSpacing="2">AUTHORITY · OPERATOR</text>
-                <rect x={132} y={130} width={196} height={48} rx={6} fill="rgba(15,22,36,0.94)" stroke="var(--silver-bright)" strokeWidth={1.6} />
-                <text x={230} y={150} fontSize={12} fontWeight={700} fontFamily="Inter, ui-sans-serif, system-ui, sans-serif" fill="var(--silver-bright)" textAnchor="middle">Operator review · promotion</text>
-                <text x={230} y={166} fontSize={9} fontFamily='"JetBrains Mono", monospace' fill="var(--ice-blue)" textAnchor="middle" letterSpacing="2">GATE · NOT MODEL-OWNED</text>
-
-                <line x1={384} y1={84} x2={328} y2={130} stroke="var(--diagram-line-strong)" strokeWidth={1.4} markerEnd="url(#aif-arrow)" />
-
-                {/* Footer note */}
-                <text x={28} y={206} fontSize={8} fontFamily='"JetBrains Mono", monospace' fill="var(--muted)" letterSpacing="1.5">DRAFT · CHECK · LINK · PROMOTE · NEVER AI-OWNED</text>
-                <text x={432} y={206} fontSize={8} fontFamily='"JetBrains Mono", monospace' fill="var(--ice-blue)" textAnchor="end" letterSpacing="2">AUTHORITY ≠ MODEL</text>
-              </svg>
-            </div>
+          <div className="operator-stack">
+            <p className="operator-stack__eyebrow">Stack · enforcement</p>
+            <ul className="operator-stack__list">
+              {stackItems.map((s) => (
+                <li key={s} className="operator-stack__item">{s}</li>
+              ))}
+            </ul>
           </div>
         </div>
       </section>
 
-      {/* ── Boundary panels ──────────────────────────────────────────── */}
+      {/* ── Is / Is not ──────────────────────────────────────────────── */}
       <section className="cockpit-section--tight">
-        <div className="container">
+        <div className="container-cockpit">
           <div className="mb-6">
             <p className="cockpit-eyebrow">Boundary</p>
             <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
-              What HawkinsOperations is — and is not.
+              What HawkinsOperations is — and what I do not claim.
             </h2>
           </div>
 
           <div className="boundary-panels">
             <div className="boundary-panel boundary-panel--is">
               <p className="mono text-[0.6rem] tracking-[0.2em] uppercase text-[var(--ice-blue)]">Is</p>
-              <h3 className="boundary-panel__title">A governed detection engineering surface.</h3>
+              <h3 className="boundary-panel__title">A governed AI security operations control surface.</h3>
               <ul className="boundary-panel__list">
                 {isItems.map((item) => (
                   <li key={item} className="boundary-panel__item">{item}</li>
@@ -474,8 +431,10 @@ export default function AboutPage() {
               </ul>
             </div>
             <div className="boundary-panel boundary-panel--isnot">
-              <p className="mono text-[0.6rem] tracking-[0.2em] uppercase" style={{ color: "#FCA5A5" }}>Is not</p>
-              <h3 className="boundary-panel__title">Runtime, fleet, and disposition claims stay blocked.</h3>
+              <p className="mono text-[0.6rem] tracking-[0.2em] uppercase" style={{ color: "#FCA5A5" }}>
+                I do not claim
+              </p>
+              <h3 className="boundary-panel__title">Runtime, fleet, autonomous, and AI-approved disposition stay blocked.</h3>
               <ul className="boundary-panel__list">
                 {isNotItems.map((item) => (
                   <li key={item} className="boundary-panel__item">{item}</li>
@@ -488,11 +447,11 @@ export default function AboutPage() {
 
       {/* ── Route dock ───────────────────────────────────────────────── */}
       <section className="cockpit-section--tight pb-24">
-        <div className="container">
+        <div className="container-cockpit">
           <div className="mb-6">
             <p className="cockpit-eyebrow">Operator routes</p>
             <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
-              Where the operator lives outside this surface.
+              Where to look next.
             </h2>
           </div>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -147,7 +147,7 @@ main { overflow: hidden; }
   border: 1px solid var(--moon-border);
   border-radius: 14px;
   background:
-    linear-gradient(180deg, rgba(16, 16, 18$1 0.78), rgba(10, 10, 12$1 0.92));
+    linear-gradient(180deg, rgba(16, 16, 18, 0.78), rgba(10, 10, 12, 0.92));
   box-shadow:
     0 0 0 1px rgba(143, 216, 255, 0.04) inset,
     0 28px 88px rgba(0, 0, 0, 0.55);
@@ -158,7 +158,7 @@ main { overflow: hidden; }
   border: 1px solid var(--moon-border-bright);
   border-radius: 14px;
   background:
-    linear-gradient(180deg, rgba(18, 18, 22$1 0.86), rgba(10, 10, 12$1 0.96));
+    linear-gradient(180deg, rgba(18, 18, 22, 0.86), rgba(10, 10, 12, 0.96));
   box-shadow:
     0 0 0 1px rgba(143, 216, 255, 0.08) inset,
     0 32px 96px rgba(0, 0, 0, 0.6);
@@ -176,7 +176,7 @@ main { overflow: hidden; }
 .surface {
   border: 1px solid var(--moon-border);
   border-radius: 12px;
-  background: linear-gradient(180deg, rgba(14, 14, 16$1 0.82), rgba(10, 10, 12$1 0.92));
+  background: linear-gradient(180deg, rgba(14, 14, 16, 0.82), rgba(10, 10, 12, 0.92));
   box-shadow: var(--shadow);
 }
 
@@ -184,13 +184,13 @@ main { overflow: hidden; }
   position: relative;
   border: 1px solid var(--moon-border);
   border-radius: 12px;
-  background: rgba(10, 10, 12$1 0.66);
+  background: rgba(10, 10, 12, 0.66);
   transition: border-color 200ms ease, transform 200ms ease, background 200ms ease, box-shadow 240ms ease;
 }
 
 .card:hover {
   border-color: var(--moon-border-bright);
-  background: rgba(15, 15, 18$1 0.86);
+  background: rgba(15, 15, 18, 0.86);
   transform: translateY(-3px);
   box-shadow: 0 18px 40px rgba(0, 0, 0, 0.4), 0 0 0 1px var(--ice-blue-soft) inset;
 }
@@ -199,7 +199,7 @@ main { overflow: hidden; }
   position: relative;
   border: 1px solid var(--moon-border);
   border-radius: 14px;
-  background: linear-gradient(180deg, rgba(16, 16, 18$1 0.82), rgba(8, 8, 10$1 0.94));
+  background: linear-gradient(180deg, rgba(16, 16, 18, 0.82), rgba(8, 8, 10, 0.94));
   transition: border-color 240ms ease, transform 240ms ease, box-shadow 280ms ease;
 }
 
@@ -236,7 +236,7 @@ main { overflow: hidden; }
   padding: 0.36rem 0.72rem;
   border: 1px solid var(--moon-border);
   border-radius: 999px;
-  background: rgba(16, 16, 18$1 0.6);
+  background: rgba(16, 16, 18, 0.6);
   color: var(--silver);
   font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
   font-size: 0.68rem;
@@ -297,7 +297,7 @@ main { overflow: hidden; }
   padding: 0.85rem 1.2rem;
   border: 1px solid var(--moon-border-bright);
   border-radius: 4px;
-  background: rgba(14, 14, 16$1 0.65);
+  background: rgba(14, 14, 16, 0.65);
   color: var(--silver-bright);
   font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
   font-size: 0.72rem;
@@ -309,7 +309,7 @@ main { overflow: hidden; }
 
 .cta:hover {
   border-color: var(--ice-blue);
-  background: rgba(18, 18, 22$1 0.85);
+  background: rgba(18, 18, 22, 0.85);
   color: var(--ice-blue);
   transform: translateY(-1px);
   box-shadow: 0 0 0 1px var(--ice-blue-soft) inset, 0 0 28px -10px var(--ice-blue-glow);
@@ -459,7 +459,7 @@ main { overflow: hidden; }
   padding: 0;
   border: 1px solid rgba(201, 211, 223, 0.32);
   border-radius: 4px;
-  background: linear-gradient(180deg, rgba(16, 16, 18$1 0.5), rgba(8, 8, 10$1 0.85));
+  background: linear-gradient(180deg, rgba(16, 16, 18, 0.5), rgba(8, 8, 10, 0.85));
   box-shadow:
     0 0 0 1px rgba(143, 216, 255, 0.05) inset,
     0 32px 80px rgba(0, 0, 0, 0.55);
@@ -496,7 +496,7 @@ main { overflow: hidden; }
   position: absolute;
   inset: 0;
   background:
-    linear-gradient(180deg, rgba(0, 0, 0$1 0) 60%, rgba(0, 0, 0$1 0.5) 100%),
+    linear-gradient(180deg, rgba(0, 0, 0, 0) 60%, rgba(0, 0, 0, 0.5) 100%),
     radial-gradient(140% 80% at 50% -10%, rgba(143, 216, 255, 0.05), transparent 60%);
   pointer-events: none;
 }
@@ -599,9 +599,9 @@ main { overflow: hidden; }
   width: 16px;
   height: 16px;
   border-radius: 999px;
-  background: rgba(10, 10, 12$1 1);
+  background: rgba(10, 10, 12, 1);
   border: 1px solid var(--moon-border);
-  box-shadow: 0 0 0 5px rgba(10, 10, 12$1 1);
+  box-shadow: 0 0 0 5px rgba(10, 10, 12, 1);
   transition: border-color 240ms ease, box-shadow 240ms ease;
   position: relative;
 }
@@ -611,13 +611,13 @@ main { overflow: hidden; }
   background: var(--ice-blue);
   border-color: var(--ice-blue);
   box-shadow:
-    0 0 0 5px rgba(10, 10, 12$1 1),
+    0 0 0 5px rgba(10, 10, 12, 1),
     0 0 18px var(--ice-blue-glow);
 }
 
 .truth-node--inactive .truth-node__dot {
   border-color: rgba(201, 211, 223, 0.28);
-  background: rgba(10, 10, 12$1 1);
+  background: rgba(10, 10, 12, 1);
 }
 .truth-node--inactive .truth-node__dot::after {
   content: "";
@@ -687,14 +687,14 @@ main { overflow: hidden; }
   border: 1px solid var(--moon-border);
   border-radius: 8px;
   overflow: hidden;
-  background: linear-gradient(180deg, rgba(16, 16, 18$1 0.6), rgba(8, 8, 10$1 0.86));
+  background: linear-gradient(180deg, rgba(16, 16, 18, 0.6), rgba(8, 8, 10, 0.86));
 }
 .ledger__head {
   display: grid;
   grid-template-columns: var(--ledger-cols, 0.6fr 1.4fr 1fr 1fr);
   gap: 16px;
   padding: 12px 20px;
-  background: rgba(16, 16, 18$1 0.6);
+  background: rgba(16, 16, 18, 0.6);
   border-bottom: 1px solid var(--moon-border);
   font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
   font-size: 0.6rem;
@@ -729,7 +729,7 @@ main { overflow: hidden; }
 
 .ledger--blocked {
   border-color: rgba(255, 155, 170, 0.18);
-  background: linear-gradient(180deg, rgba(255, 155, 170, 0.035), rgba(8, 8, 10$1 0.86));
+  background: linear-gradient(180deg, rgba(255, 155, 170, 0.035), rgba(8, 8, 10, 0.86));
 }
 
 .ledger--blocked .ledger__head { color: #d5b7c0; }
@@ -791,7 +791,7 @@ main { overflow: hidden; }
   padding: 16px 18px;
   border: 1px solid var(--moon-border);
   border-radius: 6px;
-  background: rgba(14, 14, 16$1 0.5);
+  background: rgba(14, 14, 16, 0.5);
   align-items: center;
 }
 .status-band__rule { width: 4px; height: 100%; min-height: 32px; border-radius: 2px; background: var(--ice-blue); box-shadow: 0 0 12px var(--ice-blue-glow); }
@@ -844,7 +844,7 @@ main { overflow: hidden; }
   padding: 16px 16px 18px;
   border: 1px solid var(--moon-border);
   border-radius: 8px;
-  background: linear-gradient(180deg, rgba(14, 14, 16$1 0.5), rgba(8, 8, 10$1 0.78));
+  background: linear-gradient(180deg, rgba(14, 14, 16, 0.5), rgba(8, 8, 10, 0.78));
   color: inherit;
   cursor: pointer;
   transition: border-color 200ms ease, transform 200ms ease, box-shadow 240ms ease;
@@ -895,7 +895,7 @@ main { overflow: hidden; }
   border: 1px solid var(--moon-border-bright);
   border-radius: 12px;
   overflow: hidden;
-  background: linear-gradient(140deg, rgba(18, 18, 22$1 0.92), rgba(8, 8, 10$1 0.96));
+  background: linear-gradient(140deg, rgba(18, 18, 22, 0.92), rgba(8, 8, 10, 0.96));
   color: inherit;
   cursor: pointer;
   transition: border-color 220ms ease, transform 240ms ease, box-shadow 280ms ease;
@@ -913,7 +913,7 @@ main { overflow: hidden; }
   padding: 24px;
   background:
     radial-gradient(120% 80% at 0% 0%, rgba(143, 216, 255, 0.12), transparent 55%),
-    linear-gradient(180deg, rgba(16, 16, 18$1 0.6), rgba(8, 8, 10$1 0.85));
+    linear-gradient(180deg, rgba(16, 16, 18, 0.6), rgba(8, 8, 10, 0.85));
   border-right: 1px solid var(--moon-border);
   display: flex;
   flex-direction: column;
@@ -932,7 +932,7 @@ main { overflow: hidden; }
   border: 1px dashed rgba(201, 211, 223, 0.18);
   border-radius: 8px;
   padding: 14px 16px;
-  background: linear-gradient(180deg, rgba(14, 14, 16$1 0.26), rgba(8, 8, 10$1 0.46));
+  background: linear-gradient(180deg, rgba(14, 14, 16, 0.26), rgba(8, 8, 10, 0.46));
   color: var(--muted);
   font-size: 0.85rem;
   display: flex;
@@ -966,7 +966,7 @@ main { overflow: hidden; }
   padding: 18px 18px 20px;
   border: 1px solid var(--moon-border);
   border-radius: 12px;
-  background: linear-gradient(180deg, rgba(16, 16, 18$1 0.76), rgba(10, 10, 12$1 0.92));
+  background: linear-gradient(180deg, rgba(16, 16, 18, 0.76), rgba(10, 10, 12, 0.92));
 }
 
 .loop-step__num {
@@ -1000,7 +1000,7 @@ main { overflow: hidden; }
   padding: 22px 22px 20px;
   border: 1px solid var(--moon-border);
   border-radius: 14px;
-  background: linear-gradient(180deg, rgba(16, 16, 18$1 0.78), rgba(8, 8, 10$1 0.94));
+  background: linear-gradient(180deg, rgba(16, 16, 18, 0.78), rgba(8, 8, 10, 0.94));
   color: var(--silver);
   transition: border-color 240ms ease, transform 260ms ease, box-shadow 280ms ease;
   position: relative;
@@ -1100,21 +1100,21 @@ main { overflow: hidden; }
   border-color: var(--moon-border-bright);
   background:
     radial-gradient(120% 80% at 0% 0%, rgba(143, 216, 255, 0.1), transparent 55%),
-    linear-gradient(180deg, rgba(18, 18, 22$1 0.86), rgba(8, 8, 10$1 0.96));
+    linear-gradient(180deg, rgba(18, 18, 22, 0.86), rgba(8, 8, 10, 0.96));
 }
 
 .artifact-card--flagship .artifact-card__title { font-size: 1.5rem; }
 
 .artifact-card--legacy {
   border-style: dashed;
-  background: linear-gradient(180deg, rgba(14, 14, 16$1 0.6), rgba(6, 6, 8$1 0.8));
+  background: linear-gradient(180deg, rgba(14, 14, 16, 0.6), rgba(6, 6, 8, 0.8));
 }
 
 .artifact-card--blocked {
   border-color: rgba(251, 113, 133, 0.28);
   background:
     radial-gradient(140% 100% at 100% 0%, rgba(251, 113, 133, 0.08), transparent 55%),
-    linear-gradient(180deg, rgba(16, 16, 18$1 0.78), rgba(8, 8, 10$1 0.94));
+    linear-gradient(180deg, rgba(16, 16, 18, 0.78), rgba(8, 8, 10, 0.94));
 }
 
 /* ─── Boundary notice ─────────────────────────────────────────────── */
@@ -1127,7 +1127,7 @@ main { overflow: hidden; }
   padding: 18px 22px;
   border-radius: 10px;
   border: 1px solid var(--moon-border);
-  background: linear-gradient(90deg, rgba(143, 216, 255, 0.07), rgba(14, 14, 16$1 0.4) 60%);
+  background: linear-gradient(90deg, rgba(143, 216, 255, 0.07), rgba(14, 14, 16, 0.4) 60%);
   color: var(--silver);
 }
 
@@ -1169,7 +1169,7 @@ main { overflow: hidden; }
   padding: 12px 14px 12px 34px;
   border: 1px solid rgba(201, 211, 223, 0.16);
   border-radius: 8px;
-  background: rgba(10, 10, 12$1 0.44);
+  background: rgba(10, 10, 12, 0.44);
   color: var(--silver);
   font-size: 0.94rem;
   line-height: 1.45;
@@ -1196,7 +1196,7 @@ main { overflow: hidden; }
 .plain-glossary details {
   border: 1px solid var(--moon-border);
   border-radius: 8px;
-  background: linear-gradient(180deg, rgba(16, 16, 18$1 0.58), rgba(10, 10, 12$1 0.82));
+  background: linear-gradient(180deg, rgba(16, 16, 18, 0.58), rgba(10, 10, 12, 0.82));
   color: #c1cede;
   overflow: hidden;
 }
@@ -1306,12 +1306,12 @@ main { overflow: hidden; }
   height: 26px;
   border: 1px solid rgba(143, 216, 255, 0.32);
   border-radius: 999px;
-  background: rgba(0, 0, 0$1 1);
+  background: rgba(0, 0, 0, 1);
   color: var(--ice-blue);
   font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
   font-size: 0.58rem;
   letter-spacing: 0.1em;
-  box-shadow: 0 0 0 4px rgba(0, 0, 0$1 1);
+  box-shadow: 0 0 0 4px rgba(0, 0, 0, 1);
 }
 
 .truth-plane__body {
@@ -1319,7 +1319,7 @@ main { overflow: hidden; }
   padding: 18px 16px;
   border: 1px solid var(--moon-border);
   border-radius: 8px;
-  background: linear-gradient(180deg, rgba(14, 14, 16$1 0.72), rgba(5, 9, 15, 0.92));
+  background: linear-gradient(180deg, rgba(14, 14, 16, 0.72), rgba(5, 9, 15, 0.92));
 }
 
 .truth-plane__body h3 {
@@ -1361,7 +1361,7 @@ main { overflow: hidden; }
 .truth-plane--6 .truth-plane__index {
   border-color: rgba(251, 113, 133, 0.26);
   color: #ffbdc7;
-  box-shadow: 0 0 0 4px rgba(0, 0, 0$1 1);
+  box-shadow: 0 0 0 4px rgba(0, 0, 0, 1);
 }
 
 /* ─── Footer and mobile navigation readability ───────────────────── */
@@ -1507,7 +1507,7 @@ main { overflow: hidden; }
 .hero-ceiling {
   position: relative;
   border-left: 2px solid rgba(143, 216, 255, 0.55);
-  background: linear-gradient(90deg, rgba(16, 16, 18$1 0.55), rgba(10, 10, 12$1 0.2) 75%, transparent);
+  background: linear-gradient(90deg, rgba(16, 16, 18, 0.55), rgba(10, 10, 12, 0.2) 75%, transparent);
   border-radius: 0 6px 6px 0;
 }
 
@@ -1559,7 +1559,7 @@ main { overflow: hidden; }
   border: 1px solid var(--moon-border);
   border-top: 2px solid rgba(143, 216, 255, 0.45);
   border-radius: 4px;
-  background: linear-gradient(180deg, rgba(16, 16, 18$1 0.7), rgba(10, 10, 12$1 0.92));
+  background: linear-gradient(180deg, rgba(16, 16, 18, 0.7), rgba(10, 10, 12, 0.92));
 }
 
 .snapshot-card__num {
@@ -1848,7 +1848,7 @@ main { overflow: hidden; }
   padding: 20px 20px 18px;
   border: 1px solid var(--moon-border);
   border-radius: 8px;
-  background: linear-gradient(180deg, rgba(16, 16, 18$1 0.75), rgba(10, 10, 12$1 0.92));
+  background: linear-gradient(180deg, rgba(16, 16, 18, 0.75), rgba(10, 10, 12, 0.92));
   position: relative;
   overflow: hidden;
 }
@@ -2302,7 +2302,7 @@ body::after {
   border-radius: 12px;
   padding: clamp(20px, 3vw, 32px);
   background:
-    linear-gradient(180deg, rgba(18, 18, 22$1 0.86), rgba(10, 10, 12$1 0.96));
+    linear-gradient(180deg, rgba(18, 18, 22, 0.86), rgba(10, 10, 12, 0.96));
   box-shadow:
     0 0 0 1px rgba(143, 216, 255, 0.08) inset,
     0 32px 96px rgba(0, 0, 0, 0.6);
@@ -2346,7 +2346,7 @@ body::after {
   padding: 12px 14px;
   border: 1px solid var(--moon-border);
   border-radius: 8px;
-  background: rgba(6, 6, 8$1 0.7);
+  background: rgba(6, 6, 8, 0.7);
   transition: border-color 200ms ease, transform 200ms ease;
 }
 
@@ -2388,7 +2388,7 @@ body::after {
   padding: 6px;
   border: 1px solid var(--moon-border);
   border-radius: 8px;
-  background: rgba(6, 6, 8$1 0.65);
+  background: rgba(6, 6, 8, 0.65);
   margin-bottom: 18px;
 }
 
@@ -2414,7 +2414,7 @@ body::after {
 .cockpit-tabs__label:hover {
   color: var(--silver-bright);
   border-color: var(--moon-border);
-  background: rgba(16, 16, 18$1 0.6);
+  background: rgba(16, 16, 18, 0.6);
 }
 
 .cockpit-tabs__dot {
@@ -2461,7 +2461,7 @@ body::after {
   padding: 8px 12px;
   border: 1px solid var(--moon-border);
   border-radius: 999px;
-  background: rgba(16, 16, 18$1 0.6);
+  background: rgba(16, 16, 18, 0.6);
   font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
   font-size: 0.66rem;
   font-weight: 600;
@@ -2536,7 +2536,7 @@ body::after {
   border: 1px solid var(--moon-border);
   border-radius: 10px;
   background:
-    linear-gradient(180deg, rgba(14, 14, 16$1 0.86), rgba(6, 6, 8$1 0.96));
+    linear-gradient(180deg, rgba(14, 14, 16, 0.86), rgba(6, 6, 8, 0.96));
   transition: border-color 220ms ease, transform 220ms ease, box-shadow 240ms ease, background 220ms ease;
 }
 
@@ -2544,7 +2544,7 @@ body::after {
   border-color: var(--moon-border-bright);
   transform: translateY(-3px);
   background:
-    linear-gradient(180deg, rgba(18, 18, 22$1 0.92), rgba(10, 10, 12$1 1));
+    linear-gradient(180deg, rgba(18, 18, 22, 0.92), rgba(10, 10, 12, 1));
   box-shadow:
     0 0 0 1px rgba(143, 216, 255, 0.16) inset,
     0 18px 40px rgba(0, 0, 0, 0.45),
@@ -2633,7 +2633,7 @@ body::after {
   border: 1px solid var(--moon-border);
   border-radius: 10px;
   background:
-    linear-gradient(180deg, rgba(14, 14, 16$1 0.86), rgba(6, 6, 8$1 0.96));
+    linear-gradient(180deg, rgba(14, 14, 16, 0.86), rgba(6, 6, 8, 0.96));
   transition: border-color 220ms ease, transform 220ms ease, box-shadow 240ms ease;
 }
 
@@ -2710,7 +2710,7 @@ body::after {
   padding: 12px;
   border: 1px solid var(--moon-border);
   border-radius: 8px;
-  background: rgba(6, 6, 8$1 0.55);
+  background: rgba(6, 6, 8, 0.55);
 }
 
 .lane-card__meta > div {
@@ -2751,7 +2751,7 @@ body::after {
   border: 1px dashed var(--moon-border);
   border-radius: 6px;
   padding: 8px 12px;
-  background: rgba(6, 6, 8$1 0.4);
+  background: rgba(6, 6, 8, 0.4);
   opacity: 0.78;
   transition: opacity 200ms ease, border-color 200ms ease;
 }
@@ -2860,7 +2860,7 @@ body::after {
   border: 1px solid rgba(143, 216, 255, 0.4);
   border-radius: 8px;
   background:
-    linear-gradient(90deg, rgba(143, 216, 255, 0.1), rgba(6, 6, 8$1 0.85));
+    linear-gradient(90deg, rgba(143, 216, 255, 0.1), rgba(6, 6, 8, 0.85));
   font-size: 0.68rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -3034,7 +3034,7 @@ body::after {
   border: 1px solid var(--moon-border);
   border-radius: 10px;
   background:
-    linear-gradient(180deg, rgba(14, 14, 16$1 0.86), rgba(6, 6, 8$1 0.96));
+    linear-gradient(180deg, rgba(14, 14, 16, 0.86), rgba(6, 6, 8, 0.96));
   text-align: left;
   font: inherit;
   color: inherit;
@@ -3046,7 +3046,7 @@ body::after {
   border-color: var(--moon-border-bright);
   transform: translateY(-3px);
   background:
-    linear-gradient(180deg, rgba(18, 18, 22$1 0.92), rgba(10, 10, 12$1 1));
+    linear-gradient(180deg, rgba(18, 18, 22, 0.92), rgba(10, 10, 12, 1));
   box-shadow:
     0 0 0 1px rgba(143, 216, 255, 0.16) inset,
     0 18px 40px rgba(0, 0, 0, 0.45),
@@ -3061,7 +3061,7 @@ body::after {
 .pipeline__node.is-active {
   border-color: rgba(143, 216, 255, 0.55);
   background:
-    linear-gradient(180deg, rgba(20, 34, 56, 0.95), rgba(10, 10, 12$1 1));
+    linear-gradient(180deg, rgba(20, 34, 56, 0.95), rgba(10, 10, 12, 1));
   box-shadow:
     0 0 0 1px rgba(143, 216, 255, 0.45) inset,
     0 0 36px -8px var(--ice-blue-glow);
@@ -3100,7 +3100,7 @@ body::after {
   border-radius: 10px;
   padding: 20px;
   background:
-    linear-gradient(180deg, rgba(18, 18, 22$1 0.92), rgba(10, 10, 12$1 0.98));
+    linear-gradient(180deg, rgba(18, 18, 22, 0.92), rgba(10, 10, 12, 0.98));
   box-shadow:
     0 0 0 1px rgba(143, 216, 255, 0.1) inset,
     0 16px 40px rgba(0, 0, 0, 0.5);
@@ -3222,7 +3222,7 @@ body::after {
   border: 1px solid var(--moon-border);
   border-radius: 10px;
   background:
-    linear-gradient(180deg, rgba(14, 14, 16$1 0.86), rgba(6, 6, 8$1 0.96));
+    linear-gradient(180deg, rgba(14, 14, 16, 0.86), rgba(6, 6, 8, 0.96));
   transition: border-color 220ms ease, box-shadow 240ms ease, transform 220ms ease;
 }
 
@@ -3402,7 +3402,7 @@ body::after {
   padding: 14px;
   border: 1px solid var(--moon-border);
   border-radius: 8px;
-  background: rgba(6, 6, 8$1 0.55);
+  background: rgba(6, 6, 8, 0.55);
 }
 
 .lane-card__meta > div { display: grid; gap: 4px; }
@@ -3440,7 +3440,7 @@ body::after {
   border: 1px dashed var(--moon-border);
   border-radius: 6px;
   padding: 8px 12px;
-  background: rgba(6, 6, 8$1 0.4);
+  background: rgba(6, 6, 8, 0.4);
   opacity: 0.78;
   transition: opacity 200ms ease, border-color 200ms ease;
 }
@@ -3538,7 +3538,7 @@ body::after {
   padding: 6px 12px;
   border: 1px solid var(--moon-border);
   border-radius: 999px;
-  background: rgba(6, 6, 8$1 0.6);
+  background: rgba(6, 6, 8, 0.6);
   font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
   font-size: 0.6rem;
   letter-spacing: 0.16em;
@@ -3588,7 +3588,7 @@ body::after {
   padding: 8px 14px;
   border: 1px solid var(--moon-border);
   border-radius: 999px;
-  background: rgba(6, 6, 8$1 0.6);
+  background: rgba(6, 6, 8, 0.6);
   font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
   font-size: 0.64rem;
   letter-spacing: 0.16em;
@@ -3731,7 +3731,7 @@ body[data-active-surface] .lane-card__details.is-surface-match {
 .cockpit {
   border-radius: 8px;
   background:
-    linear-gradient(180deg, rgba(11, 11, 13$1 0.92), rgba(4, 7, 12, 0.98));
+    linear-gradient(180deg, rgba(11, 11, 13, 0.92), rgba(4, 7, 12, 0.98));
 }
 
 .cockpit-tabs__bar {
@@ -3753,7 +3753,7 @@ body[data-active-surface] .lane-card__details.is-surface-match {
   border: 1px solid var(--moon-border);
   border-radius: 8px;
   background:
-    linear-gradient(180deg, rgba(6, 10, 17, 0.82), rgba(0, 0, 0$1 0.94));
+    linear-gradient(180deg, rgba(6, 10, 17, 0.82), rgba(0, 0, 0, 0.94));
 }
 
 .cockpit-tabs:has(#cockpit-mode-exec:checked) .command-panel[data-mode="exec"],
@@ -3995,7 +3995,7 @@ body[data-active-surface] .lane-card__details.is-surface-match {
   border: 1px solid var(--moon-border-bright);
   border-radius: 8px;
   background:
-    linear-gradient(180deg, rgba(11, 11, 13$1 0.94), rgba(0, 0, 0$1 0.98));
+    linear-gradient(180deg, rgba(11, 11, 13, 0.94), rgba(0, 0, 0, 0.98));
   box-shadow:
     0 0 0 1px rgba(143, 216, 255, 0.08) inset,
     0 28px 70px rgba(0, 0, 0, 0.48);
@@ -4020,7 +4020,7 @@ body[data-active-surface] .lane-card__details.is-surface-match {
   padding: 0 12px;
   border: 1px solid var(--moon-border);
   border-radius: 4px;
-  background: rgba(6, 6, 8$1 0.65);
+  background: rgba(6, 6, 8, 0.65);
   font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
   font-size: 0.62rem;
   letter-spacing: 0.16em;
@@ -4053,7 +4053,7 @@ body[data-active-surface] .lane-card__details.is-surface-match {
   padding: 0 12px;
   border: 1px solid var(--moon-border);
   border-radius: 4px;
-  background: rgba(6, 6, 8$1 0.72);
+  background: rgba(6, 6, 8, 0.72);
   font: inherit;
   font-size: 0.86rem;
   color: var(--silver);
@@ -4365,7 +4365,7 @@ body[data-active-surface] .truth-board__status {
   border: 1px solid var(--moon-border);
   border-radius: 8px;
   background:
-    linear-gradient(180deg, rgba(11, 11, 13$1 0.84), rgba(4, 7, 12, 0.96));
+    linear-gradient(180deg, rgba(11, 11, 13, 0.84), rgba(4, 7, 12, 0.96));
 }
 
 .qc-map__rows {
@@ -4507,14 +4507,14 @@ body[data-active-surface] .truth-board__status {
   border: 1px solid var(--moon-border);
   border-radius: 6px;
   background:
-    linear-gradient(180deg, rgba(143, 216, 255, 0.05), rgba(8, 8, 10$1 0.82));
+    linear-gradient(180deg, rgba(143, 216, 255, 0.05), rgba(8, 8, 10, 0.82));
 }
 
 .scoreboard__cell--quiet { opacity: 0.86; }
 .scoreboard__cell--pass { border-color: rgba(143, 216, 255, 0.34); }
 .scoreboard__cell--block {
   border-color: rgba(255, 155, 170, 0.36);
-  background: linear-gradient(180deg, rgba(255, 155, 170, 0.07), rgba(8, 8, 10$1 0.82));
+  background: linear-gradient(180deg, rgba(255, 155, 170, 0.07), rgba(8, 8, 10, 0.82));
 }
 
 .scoreboard__value {
@@ -4563,7 +4563,7 @@ body[data-active-surface] .truth-board__status {
   padding: 24px;
   border: 1px solid var(--moon-border);
   border-radius: 6px;
-  background: linear-gradient(180deg, rgba(14, 14, 16$1 0.66), rgba(4, 7, 12, 0.92));
+  background: linear-gradient(180deg, rgba(14, 14, 16, 0.66), rgba(4, 7, 12, 0.92));
 }
 
 .proof-split__panel--block {
@@ -4795,7 +4795,7 @@ body {
 
 body {
   background:
-    linear-gradient(180deg, rgba(11, 11, 13$1 0.9), #02050a 34rem),
+    linear-gradient(180deg, rgba(11, 11, 13, 0.9), #02050a 34rem),
     #02050a;
 }
 
@@ -4823,7 +4823,7 @@ body::after {
 .doctrine-strip,
 .moon-panel,
 .moon-panel-strong {
-  background-image: linear-gradient(180deg, rgba(11, 11, 13$1 0.92), rgba(0, 0, 0$1 0.98));
+  background-image: linear-gradient(180deg, rgba(11, 11, 13, 0.92), rgba(0, 0, 0, 0.98));
 }
 
 /* Homepage refinement pass: readable story, controlled promotion, quiet boundaries. */
@@ -4874,7 +4874,7 @@ body::after {
   gap: 14px;
   align-items: baseline;
   padding: 12px 14px;
-  background: rgba(11, 11, 13$1 0.72);
+  background: rgba(11, 11, 13, 0.72);
 }
 
 .prior-evidence__metrics strong {
@@ -4989,7 +4989,7 @@ body::after {
   border: 1px solid var(--moon-border);
   border-radius: 6px;
   padding: 14px;
-  background: rgba(0, 0, 0$1 0.62);
+  background: rgba(0, 0, 0, 0.62);
 }
 
 .promotion-system__footer p {
@@ -5028,7 +5028,7 @@ body::after {
 .boundary-drawer {
   border: 1px solid rgba(201, 211, 223, 0.14);
   border-radius: 8px;
-  background: rgba(0, 0, 0$1 0.68);
+  background: rgba(0, 0, 0, 0.68);
 }
 
 .boundary-drawer summary {
@@ -5151,7 +5151,7 @@ body::after {
   padding: 20px 22px;
   border: 1px solid var(--diagram-line);
   border-radius: 10px;
-  background: linear-gradient(180deg, rgba(7, 12, 22, 0.96), rgba(0, 0, 0$1 0.98));
+  background: linear-gradient(180deg, rgba(7, 12, 22, 0.96), rgba(0, 0, 0, 0.98));
   box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.06) inset, 0 24px 56px rgba(0, 0, 0, 0.55);
   font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
   color: var(--silver);
@@ -5173,7 +5173,7 @@ body::after {
   width: 100%;
   border: 1px solid var(--diagram-line);
   border-radius: 14px;
-  background: linear-gradient(180deg, rgba(11, 11, 13$1 0.92), rgba(0, 0, 0$1 0.98));
+  background: linear-gradient(180deg, rgba(11, 11, 13, 0.92), rgba(0, 0, 0, 0.98));
   box-shadow: 0 24px 80px rgba(0, 0, 0, 0.55);
   overflow: hidden;
 }
@@ -5213,7 +5213,7 @@ body::after {
   position: relative;
   border: 1px solid var(--diagram-line);
   border-radius: 14px;
-  background: linear-gradient(180deg, rgba(7, 12, 22, 0.94), rgba(0, 0, 0$1 0.98));
+  background: linear-gradient(180deg, rgba(7, 12, 22, 0.94), rgba(0, 0, 0, 0.98));
   padding: 28px 22px;
 }
 .proof-loop-diagram__svg { width: 100%; height: auto; display: block; max-width: 920px; margin: 0 auto; }
@@ -5227,7 +5227,7 @@ body::after {
   padding: 14px 16px;
   border: 1px solid var(--moon-border);
   border-radius: 10px;
-  background: rgba(11, 11, 13$1 0.7);
+  background: rgba(11, 11, 13, 0.7);
 }
 .proof-loop-diagram__phase {
   font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
@@ -5243,7 +5243,7 @@ body::after {
 .truth-infographic {
   border: 1px solid var(--diagram-line);
   border-radius: 14px;
-  background: linear-gradient(180deg, rgba(7, 12, 22, 0.94), rgba(0, 0, 0$1 0.98));
+  background: linear-gradient(180deg, rgba(7, 12, 22, 0.94), rgba(0, 0, 0, 0.98));
   padding: 22px;
   display: flex;
   flex-direction: column;
@@ -5257,7 +5257,7 @@ body::after {
   padding: 14px 18px;
   border: 1px solid var(--moon-border);
   border-radius: 10px;
-  background: rgba(11, 11, 13$1 0.6);
+  background: rgba(11, 11, 13, 0.6);
   position: relative;
 }
 .truth-infographic__gate {
@@ -5291,7 +5291,7 @@ body::after {
 .repo-dag {
   border: 1px solid var(--diagram-line);
   border-radius: 14px;
-  background: linear-gradient(180deg, rgba(7, 12, 22, 0.94), rgba(0, 0, 0$1 0.98));
+  background: linear-gradient(180deg, rgba(7, 12, 22, 0.94), rgba(0, 0, 0, 0.98));
   padding: 22px;
   overflow: hidden;
 }
@@ -5307,7 +5307,7 @@ body::after {
 .artifact-matrix {
   border: 1px solid var(--diagram-line);
   border-radius: 14px;
-  background: linear-gradient(180deg, rgba(7, 12, 22, 0.94), rgba(0, 0, 0$1 0.98));
+  background: linear-gradient(180deg, rgba(7, 12, 22, 0.94), rgba(0, 0, 0, 0.98));
   padding: 22px;
   overflow-x: auto;
 }
@@ -5322,7 +5322,7 @@ body::after {
 /* Inline row highlight on hover/focus — no floating tooltip. */
 .artifact-matrix__row:hover .artifact-matrix__cell,
 .artifact-matrix__row:focus-within .artifact-matrix__cell {
-  background-color: rgba(18, 18, 22$1 0.7);
+  background-color: rgba(18, 18, 22, 0.7);
   outline: 1px solid rgba(143, 216, 255, 0.18);
   outline-offset: -1px;
 }
@@ -5334,10 +5334,10 @@ body::after {
   font-size: 0.72rem;
   letter-spacing: 0.06em;
   color: var(--muted);
-  background: rgba(11, 11, 13$1 0.55);
+  background: rgba(11, 11, 13, 0.55);
 }
-.artifact-matrix__cell--head { color: var(--electric-blue-bright); text-transform: uppercase; letter-spacing: 0.18em; font-size: 0.62rem; background: rgba(0, 0, 0$1 0.8); }
-.artifact-matrix__cell--row-head { color: var(--silver-bright); font-weight: 600; text-transform: none; letter-spacing: 0.02em; font-size: 0.85rem; background: rgba(0, 0, 0$1 0.5); }
+.artifact-matrix__cell--head { color: var(--electric-blue-bright); text-transform: uppercase; letter-spacing: 0.18em; font-size: 0.62rem; background: rgba(0, 0, 0, 0.8); }
+.artifact-matrix__cell--row-head { color: var(--silver-bright); font-weight: 600; text-transform: none; letter-spacing: 0.02em; font-size: 0.85rem; background: rgba(0, 0, 0, 0.5); }
 .artifact-matrix__cell--filled { color: var(--electric-blue-bright); background: linear-gradient(180deg, rgba(59, 130, 246, 0.22), rgba(59, 130, 246, 0.06)); text-align: center; font-size: 1rem; }
 .artifact-matrix__cell--gated { color: var(--ice-blue); text-align: center; font-size: 1rem; }
 .artifact-matrix__cell--empty { color: var(--muted); text-align: center; }
@@ -5357,7 +5357,7 @@ body::after {
 .review-route-selector__route {
   border: 1px solid var(--diagram-line);
   border-radius: 14px;
-  background: linear-gradient(180deg, rgba(7, 12, 22, 0.94), rgba(0, 0, 0$1 0.98));
+  background: linear-gradient(180deg, rgba(7, 12, 22, 0.94), rgba(0, 0, 0, 0.98));
   padding: 22px;
   display: flex;
   flex-direction: column;
@@ -5376,7 +5376,7 @@ body::after {
 .proof-path-timeline {
   border: 1px solid var(--diagram-line);
   border-radius: 14px;
-  background: linear-gradient(180deg, rgba(7, 12, 22, 0.94), rgba(0, 0, 0$1 0.98));
+  background: linear-gradient(180deg, rgba(7, 12, 22, 0.94), rgba(0, 0, 0, 0.98));
   padding: 28px 22px;
   display: flex;
   flex-direction: column;
@@ -5388,7 +5388,7 @@ body::after {
 .proof-path-timeline__ceiling { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; color: var(--ice-blue); font-size: 0.72rem; letter-spacing: 0.18em; text-transform: uppercase; padding: 6px 10px; border: 1px solid var(--ice-blue-soft); border-radius: 4px; }
 .proof-path-timeline__svg { width: 100%; height: auto; display: block; }
 .proof-path-timeline__rows { display: grid; grid-template-columns: 1fr; gap: 10px; }
-.proof-path-timeline__row { display: grid; grid-template-columns: 44px 200px 1fr auto; gap: 16px; align-items: center; padding: 12px 14px; border: 1px solid var(--moon-border); border-radius: 8px; background: rgba(11, 11, 13$1 0.55); }
+.proof-path-timeline__row { display: grid; grid-template-columns: 44px 200px 1fr auto; gap: 16px; align-items: center; padding: 12px 14px; border: 1px solid var(--moon-border); border-radius: 8px; background: rgba(11, 11, 13, 0.55); }
 .proof-path-timeline__row-num { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; color: var(--electric-blue); font-weight: 700; }
 .proof-path-timeline__row-code { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; color: var(--ice-blue); font-size: 0.72rem; letter-spacing: 0.16em; text-transform: uppercase; }
 .proof-path-timeline__row-text { color: var(--silver); font-size: 0.86rem; line-height: 1.5; }
@@ -5404,7 +5404,7 @@ body::after {
 .claim-firewall-panel {
   border: 1px solid var(--moon-border-bright);
   border-radius: 12px;
-  background: linear-gradient(180deg, rgba(11, 18, 32, 0.92), rgba(0, 0, 0$1 0.98));
+  background: linear-gradient(180deg, rgba(11, 18, 32, 0.92), rgba(0, 0, 0, 0.98));
   padding: 22px;
   display: grid;
   gap: 18px;
@@ -5463,7 +5463,7 @@ body::after {
   border: 1px solid var(--moon-border-bright);
   border-radius: 14px;
   background:
-    linear-gradient(180deg, rgba(18, 18, 22$1 0.86), rgba(10, 10, 12$1 0.96));
+    linear-gradient(180deg, rgba(18, 18, 22, 0.86), rgba(10, 10, 12, 0.96));
   box-shadow:
     0 0 0 1px rgba(143, 216, 255, 0.08) inset,
     0 32px 96px rgba(0, 0, 0, 0.6);
@@ -5524,7 +5524,7 @@ body::after {
   padding: 18px 18px 16px;
   border: 1px solid var(--moon-border);
   border-radius: 12px;
-  background: linear-gradient(180deg, rgba(14, 14, 16$1 0.82), rgba(8, 8, 10$1 0.94));
+  background: linear-gradient(180deg, rgba(14, 14, 16, 0.82), rgba(8, 8, 10, 0.94));
   transition: border-color 200ms ease, box-shadow 200ms ease, transform 200ms ease;
 }
 .claim-route-card:hover {
@@ -5561,7 +5561,7 @@ body::after {
   border: 1px solid rgba(252, 165, 165, 0.28);
   border-left: 3px solid rgba(252, 165, 165, 0.6);
   border-radius: 10px;
-  background: linear-gradient(180deg, rgba(28, 12, 16, 0.4), rgba(10, 10, 12$1 0.92));
+  background: linear-gradient(180deg, rgba(28, 12, 16, 0.4), rgba(10, 10, 12, 0.92));
 }
 .blocked-category__head { display: flex; flex-direction: column; gap: 6px; }
 .blocked-category__title { color: var(--silver-bright); font-weight: 700; font-size: 1.05rem; }
@@ -5581,7 +5581,7 @@ body::after {
   position: relative;
   border: 1px solid var(--moon-border-bright);
   border-radius: 14px;
-  background: linear-gradient(180deg, rgba(18, 18, 22$1 0.86), rgba(10, 10, 12$1 0.96));
+  background: linear-gradient(180deg, rgba(18, 18, 22, 0.86), rgba(10, 10, 12, 0.96));
   box-shadow: 0 0 0 1px rgba(143, 216, 255, 0.08) inset, 0 28px 80px rgba(0, 0, 0, 0.55);
   overflow: hidden;
 }
@@ -5630,7 +5630,7 @@ body::after {
 .gate-ladder__node {
   position: relative; z-index: 1;
   width: 28px; height: 28px; border-radius: 999px;
-  border: 1px solid var(--electric-blue); background: rgba(11, 11, 13$1 0.96);
+  border: 1px solid var(--electric-blue); background: rgba(11, 11, 13, 0.96);
   display: flex; align-items: center; justify-content: center;
   margin-top: 4px; box-shadow: 0 0 16px rgba(59,130,246,0.25);
 }
@@ -5645,18 +5645,18 @@ body::after {
   position: relative;
   display: flex; gap: 10px; flex-wrap: wrap; padding: 14px;
   border: 1px solid var(--moon-border); border-radius: 12px;
-  background: linear-gradient(180deg, rgba(14, 14, 16$1 0.7), rgba(8, 8, 10$1 0.92));
+  background: linear-gradient(180deg, rgba(14, 14, 16, 0.7), rgba(8, 8, 10, 0.92));
   box-shadow: 0 0 0 1px rgba(143, 216, 255, 0.06) inset;
 }
 .vault-shelf__rail { position: absolute; left: 14px; right: 14px; bottom: 0; height: 1px; background: linear-gradient(to right, transparent, var(--diagram-line-strong), transparent); }
 .vault-shelf__slot {
   flex: 1 1 130px; position: relative;
   padding: 10px 12px 12px; border: 1px solid transparent; border-radius: 8px;
-  background: rgba(11, 11, 13$1 0.6);
+  background: rgba(11, 11, 13, 0.6);
   display: flex; flex-direction: column; gap: 4px;
   transition: border-color 180ms ease, background 180ms ease, color 180ms ease, transform 180ms ease;
 }
-.vault-shelf__slot:hover { border-color: var(--moon-border-bright); background: rgba(18, 18, 22$1 0.86); transform: translateY(-1px); }
+.vault-shelf__slot:hover { border-color: var(--moon-border-bright); background: rgba(18, 18, 22, 0.86); transform: translateY(-1px); }
 .vault-shelf__cat { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; font-size: 0.58rem; letter-spacing: 0.2em; text-transform: uppercase; color: var(--ice-blue); }
 .vault-shelf__label { color: var(--silver-bright); font-size: 0.9rem; line-height: 1.3; font-weight: 600; }
 .vault-shelf__count { color: var(--muted); font-size: 0.72rem; }
@@ -5666,7 +5666,7 @@ body::after {
 .anchor-spread {
   position: relative; display: grid; gap: 16px;
   padding: 22px 24px; border: 1px solid var(--moon-border-bright); border-radius: 14px;
-  background: linear-gradient(180deg, rgba(18, 18, 22$1 0.86), rgba(10, 10, 12$1 0.96));
+  background: linear-gradient(180deg, rgba(18, 18, 22, 0.86), rgba(10, 10, 12, 0.96));
   box-shadow: 0 0 0 1px rgba(143, 216, 255, 0.08) inset, 0 32px 96px rgba(0, 0, 0, 0.55);
   transition: transform 200ms ease, border-color 200ms ease, box-shadow 200ms ease;
 }
@@ -5697,7 +5697,7 @@ body::after {
 .record-row {
   display: grid; gap: 12px; grid-template-columns: 1fr;
   padding: 18px 20px; border: 1px solid var(--moon-border); border-radius: 12px;
-  background: linear-gradient(180deg, rgba(14, 14, 16$1 0.8), rgba(8, 8, 10$1 0.92));
+  background: linear-gradient(180deg, rgba(14, 14, 16, 0.8), rgba(8, 8, 10, 0.92));
   transition: border-color 200ms ease, transform 200ms ease, box-shadow 200ms ease;
 }
 .record-row:hover { border-color: var(--moon-border-bright); transform: translateY(-2px); box-shadow: 0 16px 40px rgba(0,0,0,0.4), 0 0 0 1px var(--ice-blue-soft) inset; }
@@ -5712,21 +5712,21 @@ body::after {
 .record-row__meta-value { color: var(--muted); line-height: 1.45; font-size: 0.82rem; }
 
 /* ── Artifacts: receipt conveyor ───────────────────────────────────── */
-.receipt-conveyor { display: grid; gap: 0; grid-template-columns: 1fr; border: 1px solid var(--moon-border); border-radius: 12px; background: linear-gradient(180deg, rgba(14, 14, 16$1 0.7), rgba(8, 8, 10$1 0.92)); overflow: hidden; }
+.receipt-conveyor { display: grid; gap: 0; grid-template-columns: 1fr; border: 1px solid var(--moon-border); border-radius: 12px; background: linear-gradient(180deg, rgba(14, 14, 16, 0.7), rgba(8, 8, 10, 0.92)); overflow: hidden; }
 @media (min-width: 800px) { .receipt-conveyor { grid-template-columns: 1fr 1fr; } }
 @media (min-width: 1100px) { .receipt-conveyor { grid-template-columns: 1fr 1fr 1fr 1fr; } }
 .receipt-conveyor__cell { display: flex; flex-direction: column; gap: 6px; padding: 16px 18px; border-right: 1px solid var(--moon-border); border-bottom: 1px solid var(--moon-border); transition: background 180ms ease, color 180ms ease; }
 .receipt-conveyor__cell:last-child { border-right: 0; }
-.receipt-conveyor__cell:hover { background: rgba(18, 18, 22$1 0.7); }
+.receipt-conveyor__cell:hover { background: rgba(18, 18, 22, 0.7); }
 .receipt-conveyor__cat { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; font-size: 0.58rem; letter-spacing: 0.2em; text-transform: uppercase; color: var(--electric-blue-bright); }
 .receipt-conveyor__title { color: var(--silver-bright); font-weight: 600; font-size: 0.96rem; line-height: 1.3; }
 .receipt-conveyor__desc { color: var(--muted); line-height: 1.5; font-size: 0.82rem; }
 .receipt-conveyor__link { color: var(--ice-blue); font-family: "JetBrains Mono", monospace; font-size: 0.66rem; letter-spacing: 0.16em; text-transform: uppercase; margin-top: 4px; }
 
 /* ── Artifacts: archive isolation strip ────────────────────────────── */
-.archive-strip { position: relative; display: grid; gap: 10px; grid-template-columns: 1fr; padding: 16px 18px; border-top: 1px dashed rgba(201, 211, 223, 0.36); border-bottom: 1px dashed rgba(201, 211, 223, 0.36); background: rgba(11, 11, 13$1 0.4); }
+.archive-strip { position: relative; display: grid; gap: 10px; grid-template-columns: 1fr; padding: 16px 18px; border-top: 1px dashed rgba(201, 211, 223, 0.36); border-bottom: 1px dashed rgba(201, 211, 223, 0.36); background: rgba(11, 11, 13, 0.4); }
 .archive-strip__label { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; font-size: 0.6rem; letter-spacing: 0.22em; text-transform: uppercase; color: var(--muted); }
-.archive-row { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: 10px; padding: 8px 12px; border: 1px dashed var(--moon-border); border-radius: 8px; background: rgba(11, 11, 13$1 0.5); color: var(--silver); }
+.archive-row { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: 10px; padding: 8px 12px; border: 1px dashed var(--moon-border); border-radius: 8px; background: rgba(11, 11, 13, 0.5); color: var(--silver); }
 .archive-row:hover { color: var(--silver-bright); border-color: var(--moon-border-bright); }
 .archive-row__tag { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; font-size: 0.6rem; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ice-blue); }
 
@@ -5736,7 +5736,7 @@ body::after {
 .operator-lane {
   position: relative; display: flex; flex-direction: column; gap: 10px;
   padding: 20px 20px 18px; border: 1px solid var(--moon-border-bright); border-radius: 14px;
-  background: linear-gradient(180deg, rgba(18, 18, 22$1 0.86), rgba(10, 10, 12$1 0.96)); overflow: hidden;
+  background: linear-gradient(180deg, rgba(18, 18, 22, 0.86), rgba(10, 10, 12, 0.96)); overflow: hidden;
 }
 .operator-lane::before { content: ""; position: absolute; left: 0; top: 18%; bottom: 18%; width: 2px; background: linear-gradient(to bottom, var(--electric-blue), var(--ice-blue)); }
 .operator-lane__eyebrow { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; font-size: 0.62rem; letter-spacing: 0.2em; text-transform: uppercase; color: var(--ice-blue); }
@@ -5749,15 +5749,15 @@ body::after {
 .operator-lane__note { color: var(--muted); font-size: 0.86rem; line-height: 1.55; margin-top: 6px; }
 
 /* ── About: methodology translation map ────────────────────────────── */
-.translation-map { position: relative; display: grid; gap: 0; grid-template-columns: 1fr; border: 1px solid var(--moon-border-bright); border-radius: 14px; background: linear-gradient(180deg, rgba(18, 18, 22$1 0.86), rgba(10, 10, 12$1 0.96)); overflow: hidden; }
-.translation-map__head { display: grid; grid-template-columns: 1fr 28px 1fr 1.2fr; align-items: center; gap: 10px; padding: 12px 18px; border-bottom: 1px solid var(--moon-border); background: rgba(11, 11, 13$1 0.6); }
+.translation-map { position: relative; display: grid; gap: 0; grid-template-columns: 1fr; border: 1px solid var(--moon-border-bright); border-radius: 14px; background: linear-gradient(180deg, rgba(18, 18, 22, 0.86), rgba(10, 10, 12, 0.96)); overflow: hidden; }
+.translation-map__head { display: grid; grid-template-columns: 1fr 28px 1fr 1.2fr; align-items: center; gap: 10px; padding: 12px 18px; border-bottom: 1px solid var(--moon-border); background: rgba(11, 11, 13, 0.6); }
 .translation-map__head-cell,
 .translation-map__head-spacer { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; font-size: 0.6rem; letter-spacing: 0.2em; text-transform: uppercase; color: var(--muted); }
 .translation-map__row { display: grid; grid-template-columns: 1fr 28px 1fr 1.2fr; align-items: center; gap: 10px; padding: 14px 18px; border-bottom: 1px solid var(--moon-border); }
 .translation-map__row:last-child { border-bottom: 0; }
-.translation-map__row:hover { background: rgba(18, 18, 22$1 0.6); }
+.translation-map__row:hover { background: rgba(18, 18, 22, 0.6); }
 .translation-map__left { color: var(--silver); font-size: 0.94rem; }
-.translation-map__arrow { width: 28px; height: 28px; border: 1px solid var(--electric-blue); border-radius: 999px; display: flex; align-items: center; justify-content: center; color: var(--electric-blue-bright); font-family: "JetBrains Mono", monospace; font-size: 0.86rem; background: rgba(11, 11, 13$1 0.94); box-shadow: 0 0 12px rgba(59,130,246,0.2); }
+.translation-map__arrow { width: 28px; height: 28px; border: 1px solid var(--electric-blue); border-radius: 999px; display: flex; align-items: center; justify-content: center; color: var(--electric-blue-bright); font-family: "JetBrains Mono", monospace; font-size: 0.86rem; background: rgba(11, 11, 13, 0.94); box-shadow: 0 0 12px rgba(59,130,246,0.2); }
 .translation-map__right { color: var(--silver-bright); font-weight: 600; font-size: 0.96rem; }
 .translation-map__note { color: var(--muted); font-size: 0.82rem; line-height: 1.45; }
 @media (max-width: 700px) {
@@ -5769,7 +5769,7 @@ body::after {
 }
 
 /* ── About: AI governance flow diagram ─────────────────────────────── */
-.ai-flow { position: relative; display: grid; gap: 18px; grid-template-columns: 1fr; padding: 22px 24px; border: 1px solid var(--moon-border-bright); border-radius: 14px; background: linear-gradient(180deg, rgba(18, 18, 22$1 0.86), rgba(10, 10, 12$1 0.96)); box-shadow: 0 0 0 1px rgba(143, 216, 255, 0.08) inset, 0 28px 80px rgba(0, 0, 0, 0.55); overflow: hidden; }
+.ai-flow { position: relative; display: grid; gap: 18px; grid-template-columns: 1fr; padding: 22px 24px; border: 1px solid var(--moon-border-bright); border-radius: 14px; background: linear-gradient(180deg, rgba(18, 18, 22, 0.86), rgba(10, 10, 12, 0.96)); box-shadow: 0 0 0 1px rgba(143, 216, 255, 0.08) inset, 0 28px 80px rgba(0, 0, 0, 0.55); overflow: hidden; }
 .ai-flow::before { content: ""; position: absolute; inset: 0; background: radial-gradient(120% 110% at 100% 0%, rgba(59,130,246,0.10), transparent 55%); pointer-events: none; }
 @media (min-width: 900px) { .ai-flow { grid-template-columns: 1fr 1.1fr; align-items: center; } }
 .ai-flow__copy { position: relative; }
@@ -5782,7 +5782,7 @@ body::after {
 /* ── About: opposing is/is-not panels ──────────────────────────────── */
 .boundary-panels { display: grid; gap: 12px; grid-template-columns: 1fr; }
 @media (min-width: 900px) { .boundary-panels { grid-template-columns: 1fr 1fr; } }
-.boundary-panel { position: relative; padding: 22px 24px; border: 1px solid var(--moon-border-bright); border-radius: 14px; background: linear-gradient(180deg, rgba(18, 18, 22$1 0.86), rgba(10, 10, 12$1 0.96)); }
+.boundary-panel { position: relative; padding: 22px 24px; border: 1px solid var(--moon-border-bright); border-radius: 14px; background: linear-gradient(180deg, rgba(18, 18, 22, 0.86), rgba(10, 10, 12, 0.96)); }
 .boundary-panel--is { border-left: 3px solid var(--electric-blue); }
 .boundary-panel--isnot { border-left: 3px solid var(--blocked-red); }
 .boundary-panel__title { color: var(--silver-bright); font-size: 1.3rem; font-weight: 700; margin-top: 6px; }
@@ -5793,11 +5793,11 @@ body::after {
 .boundary-panel--isnot .boundary-panel__item::before { background: var(--blocked-red); box-shadow: 0 0 8px rgba(252, 165, 165, 0.5); }
 
 /* ── About: route dock ─────────────────────────────────────────────── */
-.route-dock { display: grid; gap: 0; grid-template-columns: 1fr; border: 1px solid var(--moon-border); border-radius: 12px; background: linear-gradient(180deg, rgba(14, 14, 16$1 0.78), rgba(8, 8, 10$1 0.92)); overflow: hidden; }
+.route-dock { display: grid; gap: 0; grid-template-columns: 1fr; border: 1px solid var(--moon-border); border-radius: 12px; background: linear-gradient(180deg, rgba(14, 14, 16, 0.78), rgba(8, 8, 10, 0.92)); overflow: hidden; }
 @media (min-width: 700px) { .route-dock { grid-template-columns: 1fr 1fr; } }
 @media (min-width: 1100px) { .route-dock { grid-template-columns: repeat(4, 1fr); } }
 .route-dock__slot { position: relative; display: flex; flex-direction: column; gap: 6px; padding: 16px 18px; border-right: 1px solid var(--moon-border); border-bottom: 1px solid var(--moon-border); transition: background 180ms ease, color 180ms ease; }
-.route-dock__slot:hover { background: rgba(18, 18, 22$1 0.7); }
+.route-dock__slot:hover { background: rgba(18, 18, 22, 0.7); }
 .route-dock__slot:last-child { border-right: 0; }
 .route-dock__cat { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; font-size: 0.6rem; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ice-blue); }
 .route-dock__label { color: var(--silver-bright); font-weight: 700; font-size: 1rem; }
@@ -5813,7 +5813,7 @@ body::after {
 .metric-clusters { display: grid; gap: 14px; grid-template-columns: 1fr; }
 @media (min-width: 800px) { .metric-clusters { grid-template-columns: 1fr 1fr; } }
 @media (min-width: 1100px) { .metric-clusters { grid-template-columns: repeat(4, 1fr); } }
-.metric-cluster { position: relative; display: flex; flex-direction: column; gap: 8px; padding: 18px 18px 16px; border: 1px solid var(--moon-border-bright); border-radius: 12px; background: linear-gradient(180deg, rgba(18, 18, 22$1 0.86), rgba(10, 10, 12$1 0.96)); overflow: hidden; }
+.metric-cluster { position: relative; display: flex; flex-direction: column; gap: 8px; padding: 18px 18px 16px; border: 1px solid var(--moon-border-bright); border-radius: 12px; background: linear-gradient(180deg, rgba(18, 18, 22, 0.86), rgba(10, 10, 12, 0.96)); overflow: hidden; }
 .metric-cluster::before { content: ""; position: absolute; left: 0; top: 18%; bottom: 18%; width: 2px; background: var(--electric-blue-bright); }
 .metric-cluster--block::before { background: var(--blocked-red); }
 .metric-cluster__eyebrow { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; font-size: 0.6rem; letter-spacing: 0.2em; text-transform: uppercase; color: var(--ice-blue); }
@@ -5826,13 +5826,13 @@ body::after {
 .metric-cluster__label { color: var(--muted); font-size: 0.78rem; line-height: 1.4; text-align: right; }
 
 /* Pipeline machine strip variant */
-.pipeline-machine { position: relative; border: 1px solid var(--moon-border-bright); border-radius: 14px; background: linear-gradient(180deg, rgba(18, 18, 22$1 0.86), rgba(10, 10, 12$1 0.96)); box-shadow: 0 0 0 1px rgba(143, 216, 255, 0.08) inset, 0 28px 80px rgba(0, 0, 0, 0.55); padding: 18px; overflow: hidden; }
+.pipeline-machine { position: relative; border: 1px solid var(--moon-border-bright); border-radius: 14px; background: linear-gradient(180deg, rgba(18, 18, 22, 0.86), rgba(10, 10, 12, 0.96)); box-shadow: 0 0 0 1px rgba(143, 216, 255, 0.08) inset, 0 28px 80px rgba(0, 0, 0, 0.55); padding: 18px; overflow: hidden; }
 .pipeline-machine__viewport { overflow-x: auto; overflow-y: hidden; -webkit-overflow-scrolling: touch; }
 .pipeline-machine__stages { list-style: none; margin: 0; padding: 4px 4px 8px; display: flex; gap: 14px; min-width: max-content; }
-.pipeline-machine__stage { position: relative; flex: 0 0 220px; display: flex; flex-direction: column; gap: 8px; padding: 14px 16px; border: 1px solid var(--moon-border); border-radius: 10px; background: linear-gradient(180deg, rgba(16, 16, 18$1 0.86), rgba(10, 10, 12$1 0.96)); color: var(--silver); transition: border-color 200ms ease, transform 200ms ease; }
+.pipeline-machine__stage { position: relative; flex: 0 0 220px; display: flex; flex-direction: column; gap: 8px; padding: 14px 16px; border: 1px solid var(--moon-border); border-radius: 10px; background: linear-gradient(180deg, rgba(16, 16, 18, 0.86), rgba(10, 10, 12, 0.96)); color: var(--silver); transition: border-color 200ms ease, transform 200ms ease; }
 .pipeline-machine__stage:hover { border-color: var(--moon-border-bright); transform: translateY(-2px); }
-.pipeline-machine__stage--final { border-color: var(--silver-bright); background: linear-gradient(180deg, rgba(22, 30, 46, 0.92), rgba(10, 10, 12$1 0.98)); }
-.pipeline-machine__stage--block { border-color: rgba(252, 165, 165, 0.42); background: linear-gradient(180deg, rgba(28, 12, 16, 0.55), rgba(10, 10, 12$1 0.92)); }
+.pipeline-machine__stage--final { border-color: var(--silver-bright); background: linear-gradient(180deg, rgba(22, 30, 46, 0.92), rgba(10, 10, 12, 0.98)); }
+.pipeline-machine__stage--block { border-color: rgba(252, 165, 165, 0.42); background: linear-gradient(180deg, rgba(28, 12, 16, 0.55), rgba(10, 10, 12, 0.92)); }
 .pipeline-machine__stage::after { content: "→"; position: absolute; right: -14px; top: 50%; transform: translateY(-50%); color: var(--electric-blue-bright); font-family: "JetBrains Mono", monospace; font-size: 1rem; }
 .pipeline-machine__stage:last-child::after { content: ""; }
 .pipeline-machine__num { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; font-size: 0.62rem; letter-spacing: 0.2em; color: var(--electric-blue-bright); }
@@ -5849,7 +5849,7 @@ body::after {
 /* Pipeline: receipt route lanes */
 .receipt-lanes { display: grid; gap: 14px; grid-template-columns: 1fr; }
 @media (min-width: 900px) { .receipt-lanes { grid-template-columns: 1fr 1fr; } }
-.receipt-lane { position: relative; display: flex; flex-direction: column; gap: 4px; padding: 14px 18px; border: 1px solid var(--moon-border); border-radius: 10px; background: linear-gradient(180deg, rgba(14, 14, 16$1 0.82), rgba(8, 8, 10$1 0.94)); transition: border-color 180ms ease, transform 180ms ease, box-shadow 180ms ease; }
+.receipt-lane { position: relative; display: flex; flex-direction: column; gap: 4px; padding: 14px 18px; border: 1px solid var(--moon-border); border-radius: 10px; background: linear-gradient(180deg, rgba(14, 14, 16, 0.82), rgba(8, 8, 10, 0.94)); transition: border-color 180ms ease, transform 180ms ease, box-shadow 180ms ease; }
 .receipt-lane:hover { border-color: var(--moon-border-bright); transform: translateY(-2px); box-shadow: 0 16px 36px rgba(0,0,0,0.4), 0 0 0 1px var(--ice-blue-soft) inset; }
 .receipt-lane__route { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; font-size: 0.58rem; letter-spacing: 0.2em; text-transform: uppercase; color: var(--electric-blue-bright); }
 .receipt-lane__title { color: var(--silver-bright); font-weight: 700; font-size: 1rem; }
@@ -5857,7 +5857,7 @@ body::after {
 .receipt-lane__inspect { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; color: var(--ice-blue); letter-spacing: 0.16em; text-transform: uppercase; font-size: 0.66rem; margin-top: 6px; }
 
 /* Pipeline: reviewer takeaway final panel */
-.reviewer-takeaway { position: relative; padding: 28px 28px 24px; border: 1px solid var(--moon-border-bright); border-radius: 14px; background: linear-gradient(180deg, rgba(18, 18, 22$1 0.9), rgba(10, 10, 12$1 0.97)); box-shadow: 0 0 0 1px rgba(143, 216, 255, 0.08) inset, 0 32px 96px rgba(0, 0, 0, 0.6); overflow: hidden; }
+.reviewer-takeaway { position: relative; padding: 28px 28px 24px; border: 1px solid var(--moon-border-bright); border-radius: 14px; background: linear-gradient(180deg, rgba(18, 18, 22, 0.9), rgba(10, 10, 12, 0.97)); box-shadow: 0 0 0 1px rgba(143, 216, 255, 0.08) inset, 0 32px 96px rgba(0, 0, 0, 0.6); overflow: hidden; }
 .reviewer-takeaway::before { content: ""; position: absolute; left: 0; top: 16%; bottom: 16%; width: 3px; background: linear-gradient(to bottom, var(--electric-blue), var(--ice-blue)); }
 .reviewer-takeaway__eyebrow { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; font-size: 0.66rem; letter-spacing: 0.22em; text-transform: uppercase; color: var(--ice-blue); }
 .reviewer-takeaway__title { color: var(--silver-bright); font-size: 1.45rem; font-weight: 700; line-height: 1.25; margin-top: 8px; }
@@ -5870,7 +5870,7 @@ body::after {
   padding: 24px 26px 22px;
   border: 1px solid var(--moon-border-bright);
   border-radius: 14px;
-  background: linear-gradient(180deg, rgba(18, 18, 22$1 0.92), rgba(10, 10, 12$1 0.98));
+  background: linear-gradient(180deg, rgba(18, 18, 22, 0.92), rgba(10, 10, 12, 0.98));
   box-shadow: 0 0 0 1px rgba(143, 216, 255, 0.08) inset, 0 32px 80px rgba(0, 0, 0, 0.55);
   overflow: hidden;
 }
@@ -5936,7 +5936,7 @@ body::after {
   padding: 12px 14px;
   border: 1px solid var(--moon-border);
   border-radius: 10px;
-  background: linear-gradient(180deg, rgba(14, 14, 16$1 0.82), rgba(8, 8, 10$1 0.94));
+  background: linear-gradient(180deg, rgba(14, 14, 16, 0.82), rgba(8, 8, 10, 0.94));
 }
 .proof-pack-console__cell dt {
   font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
@@ -5975,7 +5975,7 @@ body::after {
   padding: 6px;
   border: 1px solid var(--moon-border-bright);
   border-radius: 14px;
-  background: linear-gradient(180deg, rgba(18, 18, 22$1 0.86), rgba(10, 10, 12$1 0.96));
+  background: linear-gradient(180deg, rgba(18, 18, 22, 0.86), rgba(10, 10, 12, 0.96));
   box-shadow: 0 0 0 1px rgba(143, 216, 255, 0.06) inset, 0 30px 80px rgba(0, 0, 0, 0.55);
   overflow-x: auto;
 }
@@ -6005,7 +6005,7 @@ body::after {
 }
 .coverage-matrix__row:hover {
   border-color: var(--moon-border-bright);
-  background: rgba(18, 18, 22$1 0.5);
+  background: rgba(18, 18, 22, 0.5);
 }
 .coverage-matrix__family {
   color: var(--silver-bright);
@@ -6025,7 +6025,7 @@ body::after {
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--silver);
-  background: rgba(14, 14, 16$1 0.6);
+  background: rgba(14, 14, 16, 0.6);
 }
 .coverage-matrix__cell--present {
   color: var(--silver-bright);
@@ -6072,7 +6072,7 @@ body::after {
 .coverage-matrix__cell--reference {
   color: var(--silver);
   border-color: var(--moon-border);
-  background: rgba(18, 18, 22$1 0.55);
+  background: rgba(18, 18, 22, 0.55);
 }
 .coverage-matrix__cell[data-value="—"] {
   border-style: dashed;
@@ -6142,7 +6142,7 @@ body::after {
   border: 1px solid var(--moon-border-bright);
   border-top: 1.5px solid var(--ice-blue);
   border-bottom: 1.5px solid var(--ice-blue);
-  background: rgba(0, 0, 0$1 0.6);
+  background: rgba(0, 0, 0, 0.6);
   font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
   font-size: 0.78rem;
   font-weight: 700;
@@ -6165,7 +6165,7 @@ body::after {
   color: var(--silver);
   transition: background 160ms ease;
 }
-.ledger-row:hover { background: rgba(18, 18, 22$1 0.6); }
+.ledger-row:hover { background: rgba(18, 18, 22, 0.6); }
 .ledger-row__date { color: var(--electric-blue-bright); letter-spacing: 0.12em; }
 .ledger-row__repo {
   color: var(--silver);
@@ -6242,8 +6242,8 @@ body::after {
   border: 1px solid rgba(252, 165, 165, 0.32);
   border-radius: 10px;
   background:
-    linear-gradient(180deg, rgba(252, 165, 165, 0.04), rgba(0, 0, 0$1 0)),
-    rgba(14, 14, 16$1 0.65);
+    linear-gradient(180deg, rgba(252, 165, 165, 0.04), rgba(0, 0, 0, 0)),
+    rgba(14, 14, 16, 0.65);
   padding: 1.8rem;
 }
 .failure-strip__head {
@@ -6285,9 +6285,9 @@ body::after {
     repeating-linear-gradient(
       135deg,
       rgba(143, 216, 255, 0.06) 0 8px,
-      rgba(0, 0, 0$1 0) 8px 16px
+      rgba(0, 0, 0, 0) 8px 16px
     ),
-    rgba(11, 11, 13$1 0.85);
+    rgba(11, 11, 13, 0.85);
 }
 .failure-strip__footer-stamp {
   font-family: "JetBrains Mono", monospace;
@@ -6325,13 +6325,13 @@ body::after {
   padding: 1rem 1.2rem;
   border: 1px solid var(--moon-border);
   border-radius: 8px;
-  background: rgba(14, 14, 16$1 0.65);
+  background: rgba(14, 14, 16, 0.65);
 }
 .promo-ladder__rung--top {
   border-color: var(--ceiling-amber);
   background:
     linear-gradient(180deg, rgba(224, 189, 99, 0.08), transparent),
-    rgba(14, 14, 16$1 0.85);
+    rgba(14, 14, 16, 0.85);
 }
 .promo-ladder__rung-num {
   font-family: "JetBrains Mono", monospace;
@@ -6395,7 +6395,7 @@ body::after {
   padding: 1rem 1.1rem;
   border: 1px solid var(--moon-border);
   border-radius: 8px;
-  background: rgba(14, 14, 16$1 0.7);
+  background: rgba(14, 14, 16, 0.7);
 }
 .promo-ladder__card--rule { border-color: var(--ceiling-amber-soft); }
 .promo-ladder__card--prev { border-color: rgba(252, 165, 165, 0.32); }
@@ -6416,7 +6416,7 @@ body::after {
   overflow-x: auto;
   border: 1px solid var(--moon-border);
   border-radius: 10px;
-  background: rgba(14, 14, 16$1 0.6);
+  background: rgba(14, 14, 16, 0.6);
 }
 .truth-matrix__table {
   width: 100%;
@@ -6438,7 +6438,7 @@ body::after {
   text-transform: uppercase;
   font-size: 0.66rem;
   text-align: center;
-  background: rgba(11, 11, 13$1 0.7);
+  background: rgba(11, 11, 13, 0.7);
   position: sticky;
   top: 0;
 }
@@ -6468,7 +6468,7 @@ body::after {
   gap: 0.7rem 1.4rem;
   padding: 1rem 1.2rem;
   border-top: 1px solid var(--moon-border);
-  background: rgba(11, 11, 13$1 0.5);
+  background: rgba(11, 11, 13, 0.5);
   font-family: "JetBrains Mono", monospace;
   font-size: 0.7rem;
   letter-spacing: 0.1em;
@@ -6480,7 +6480,7 @@ body::after {
 .activity-ledger {
   border: 1px solid var(--moon-border);
   border-radius: 10px;
-  background: rgba(14, 14, 16$1 0.6);
+  background: rgba(14, 14, 16, 0.6);
 }
 .activity-ledger__head {
   display: flex;
@@ -6535,7 +6535,7 @@ body::after {
   gap: 0.8rem;
   padding: 1rem 1.4rem;
   border-top: 1px solid var(--moon-border);
-  background: rgba(11, 11, 13$1 0.5);
+  background: rgba(11, 11, 13, 0.5);
 }
 .activity-ledger__foot-note {
   color: var(--muted);
@@ -6672,7 +6672,7 @@ body::after {
   border-radius: 12px;
   background:
     radial-gradient(120% 100% at 100% 0%, rgba(143, 216, 255, 0.06), transparent 60%),
-    linear-gradient(180deg, rgba(18, 18, 22$1 0.92), rgba(0, 0, 0$1 0.96));
+    linear-gradient(180deg, rgba(18, 18, 22, 0.92), rgba(0, 0, 0, 0.96));
   box-shadow: 0 28px 80px rgba(0, 0, 0, 0.55), 0 0 0 1px rgba(143, 216, 255, 0.06) inset;
   overflow: hidden;
 }
@@ -6779,7 +6779,7 @@ body::after {
   border-top: 2px solid var(--electric-blue);
   border-radius: 10px;
   background:
-    linear-gradient(180deg, rgba(18, 18, 22$1 0.82), rgba(0, 0, 0$1 0.95));
+    linear-gradient(180deg, rgba(18, 18, 22, 0.82), rgba(0, 0, 0, 0.95));
   transition: transform 200ms ease, border-color 200ms ease, box-shadow 220ms ease;
 }
 .prevention-card:hover {
@@ -6866,7 +6866,7 @@ body::after {
   margin-top: 0.6rem;
   padding: 0.8rem 1rem;
   border-left: 2px solid var(--electric-blue);
-  background: rgba(11, 11, 13$1 0.7);
+  background: rgba(11, 11, 13, 0.7);
   border-radius: 0 4px 4px 0;
   font-size: 0.88rem;
   line-height: 1.55;
@@ -6947,12 +6947,12 @@ body::after {
   transition: background 140ms ease;
 }
 .truth-matrix__table tbody tr:hover {
-  background: rgba(18, 18, 22$1 0.6);
+  background: rgba(18, 18, 22, 0.6);
 }
 .truth-matrix__details {
   border-top: 1px solid var(--moon-border);
   padding: 1rem 1.2rem 1.2rem;
-  background: rgba(11, 11, 13$1 0.55);
+  background: rgba(11, 11, 13, 0.55);
 }
 .truth-matrix__details-grid {
   display: grid;
@@ -6964,7 +6964,7 @@ body::after {
   padding: 0.7rem 0.9rem;
   border: 1px solid var(--moon-border);
   border-radius: 4px;
-  background: rgba(14, 14, 16$1 0.7);
+  background: rgba(14, 14, 16, 0.7);
   font-family: "JetBrains Mono", monospace;
   font-size: 0.74rem;
   letter-spacing: 0.04em;
@@ -6975,7 +6975,7 @@ body::after {
 /* Activity ledger row hover route emphasis */
 .ledger-row { transition: background 140ms ease, box-shadow 200ms ease; }
 .ledger-row:hover {
-  background: rgba(18, 18, 22$1 0.7);
+  background: rgba(18, 18, 22, 0.7);
   box-shadow: inset 4px 0 0 var(--electric-blue);
 }
 .ledger-row__title { transition: color 140ms ease; }
@@ -7074,7 +7074,7 @@ body::after {
   background:
     radial-gradient(120% 100% at 100% 0%, rgba(143, 216, 255, 0.08), transparent 60%),
     radial-gradient(60% 60% at 50% 100%, rgba(59, 130, 246, 0.08), transparent 70%),
-    linear-gradient(180deg, rgba(18, 18, 22$1 0.94), rgba(0, 0, 0$1 0.98));
+    linear-gradient(180deg, rgba(18, 18, 22, 0.94), rgba(0, 0, 0, 0.98));
   box-shadow:
     0 32px 100px rgba(0, 0, 0, 0.65),
     0 0 0 1px rgba(143, 216, 255, 0.08) inset,
@@ -7195,7 +7195,7 @@ body::after {
   border: 1px dashed var(--moon-border);
   border-left: 3px solid var(--ice-blue);
   border-radius: 4px;
-  background: rgba(11, 11, 13$1 0.55);
+  background: rgba(11, 11, 13, 0.55);
   font-size: 0.92rem;
   line-height: 1.5;
   color: var(--silver);
@@ -7307,7 +7307,7 @@ body::after {
   width: 1.1rem;
   height: 1.1rem;
   border-radius: 50%;
-  background: rgba(0, 0, 0$1 0.95);
+  background: rgba(0, 0, 0, 0.95);
   border: 2px solid var(--electric-blue);
   box-shadow: 0 0 12px rgba(59, 130, 246, 0.4);
 }
@@ -7350,7 +7350,7 @@ body::after {
   padding: 1rem 1.1rem;
   border: 1px solid var(--moon-border);
   border-radius: 8px;
-  background: rgba(14, 14, 16$1 0.7);
+  background: rgba(14, 14, 16, 0.7);
   margin-bottom: 0.7rem;
 }
 .truth-matrix__mobile-card-id {
@@ -7426,7 +7426,7 @@ body::after {
 .rga {
   border: 1px solid var(--moon-border);
   border-radius: 10px;
-  background: rgba(14, 14, 16$1 0.6);
+  background: rgba(14, 14, 16, 0.6);
 }
 .rga__head {
   display: flex;
@@ -7485,7 +7485,7 @@ body::after {
   position: relative;
   border: 1px solid var(--moon-border);
   border-radius: 8px;
-  background: linear-gradient(180deg, rgba(18, 18, 22$1 0.85), rgba(0, 0, 0$1 0.96));
+  background: linear-gradient(180deg, rgba(18, 18, 22, 0.85), rgba(0, 0, 0, 0.96));
   transition: transform 200ms ease, border-color 200ms ease, box-shadow 220ms ease;
 }
 .rga__card:hover {
@@ -7566,7 +7566,7 @@ body::after {
   gap: 0.8rem;
   padding: 1rem 1.4rem;
   border-top: 1px solid var(--moon-border);
-  background: rgba(11, 11, 13$1 0.5);
+  background: rgba(11, 11, 13, 0.5);
 }
 .rga__foot-note {
   color: var(--muted);
@@ -7603,7 +7603,7 @@ body::after {
   padding: 0.9rem 1.1rem;
   border: 1px solid var(--moon-border-bright);
   border-radius: 4px;
-  background: rgba(14, 14, 16$1 0.7);
+  background: rgba(14, 14, 16, 0.7);
   font-family: "JetBrains Mono", monospace;
   font-size: 0.7rem;
   letter-spacing: 0.12em;
@@ -7625,7 +7625,7 @@ body::after {
   border: 1px solid var(--moon-border);
   border-top: 3px solid var(--electric-blue);
   border-radius: 8px;
-  background: linear-gradient(180deg, rgba(18, 18, 22$1 0.85), rgba(0, 0, 0$1 0.95));
+  background: linear-gradient(180deg, rgba(18, 18, 22, 0.85), rgba(0, 0, 0, 0.95));
   transition: transform 200ms ease, box-shadow 200ms ease;
 }
 .artifact-review__field:hover { transform: translateY(-2px); box-shadow: 0 14px 36px rgba(0,0,0,0.45), var(--route-glow); }
@@ -7654,8 +7654,8 @@ body::after {
   border-left: 4px solid var(--ceiling-amber);
   border-radius: 8px;
   background:
-    linear-gradient(180deg, rgba(224, 189, 99, 0.05), rgba(0, 0, 0$1 0)),
-    rgba(14, 14, 16$1 0.8);
+    linear-gradient(180deg, rgba(224, 189, 99, 0.05), rgba(0, 0, 0, 0)),
+    rgba(14, 14, 16, 0.8);
 }
 .artifact-review__boundary-label {
   font-family: "JetBrains Mono", monospace;
@@ -7708,7 +7708,7 @@ body::after {
   border: 1px solid var(--moon-border);
   border-top: 2px solid var(--electric-blue);
   border-radius: 10px;
-  background: linear-gradient(180deg, rgba(18, 18, 22$1 0.85), rgba(0, 0, 0$1 0.95));
+  background: linear-gradient(180deg, rgba(18, 18, 22, 0.85), rgba(0, 0, 0, 0.95));
   transition: transform 200ms ease, box-shadow 200ms ease, border-color 200ms ease;
   text-decoration: none;
   color: inherit;
@@ -7769,7 +7769,7 @@ body::after {
   border-radius: 10px;
   background:
     radial-gradient(80% 60% at 50% 0%, rgba(59, 130, 246, 0.08), transparent 60%),
-    linear-gradient(180deg, rgba(18, 18, 22$1 0.9), rgba(0, 0, 0$1 0.97));
+    linear-gradient(180deg, rgba(18, 18, 22, 0.9), rgba(0, 0, 0, 0.97));
   box-shadow: 0 26px 80px rgba(0, 0, 0, 0.5);
 }
 .gate-flow__svg-wrap { overflow-x: auto; }
@@ -7799,7 +7799,7 @@ body::after {
   padding: 0.7rem 0.9rem;
   border: 1px solid var(--moon-border);
   border-radius: 4px;
-  background: rgba(11, 11, 13$1 0.85);
+  background: rgba(11, 11, 13, 0.85);
 }
 .gate-flow__node > summary {
   display: inline-flex; align-items: center; gap: 0.5rem;
@@ -7830,7 +7830,7 @@ body::after {
   border: 1px solid var(--moon-border);
   border-top: 2px solid var(--electric-blue);
   border-radius: 10px;
-  background: linear-gradient(180deg, rgba(18, 18, 22$1 0.85), rgba(0, 0, 0$1 0.95));
+  background: linear-gradient(180deg, rgba(18, 18, 22, 0.85), rgba(0, 0, 0, 0.95));
   transition: transform 200ms ease, box-shadow 220ms ease, border-color 200ms ease;
 }
 .gh-gate-card:hover {
@@ -7892,7 +7892,7 @@ body::after {
   border-radius: 10px;
   background:
     radial-gradient(80% 60% at 100% 0%, rgba(224, 189, 99, 0.07), transparent 60%),
-    linear-gradient(180deg, rgba(18, 18, 22$1 0.9), rgba(0, 0, 0$1 0.97));
+    linear-gradient(180deg, rgba(18, 18, 22, 0.9), rgba(0, 0, 0, 0.97));
   box-shadow: 0 22px 70px rgba(0, 0, 0, 0.5);
 }
 .gpu-lane__head {
@@ -7951,7 +7951,7 @@ body::after {
   padding: 1rem 1.1rem 1.05rem;
   border: 1px solid var(--moon-border);
   border-radius: 8px;
-  background: linear-gradient(180deg, rgba(18, 18, 22$1 0.92), rgba(0, 0, 0$1 0.98));
+  background: linear-gradient(180deg, rgba(18, 18, 22, 0.92), rgba(0, 0, 0, 0.98));
   color: inherit;
   text-decoration: none;
   display: block;
@@ -8032,7 +8032,7 @@ body::after {
   padding: 1.4rem 1.3rem 1.3rem;
   border: 1px solid var(--moon-border);
   border-radius: 10px;
-  background: linear-gradient(180deg, rgba(18, 18, 22$1 0.85), rgba(0, 0, 0$1 0.95));
+  background: linear-gradient(180deg, rgba(18, 18, 22, 0.85), rgba(0, 0, 0, 0.95));
   transition: transform 200ms ease, border-color 200ms ease, box-shadow 220ms ease;
 }
 .v1-v2__card:hover,
@@ -8108,7 +8108,7 @@ body::after {
   padding: 1.4rem 1.4rem 1.4rem;
   border: 1px solid var(--moon-border-bright);
   border-radius: 10px;
-  background: linear-gradient(180deg, rgba(18, 18, 22$1 0.85), rgba(0, 0, 0$1 0.95));
+  background: linear-gradient(180deg, rgba(18, 18, 22, 0.85), rgba(0, 0, 0, 0.95));
 }
 @media (max-width: 760px) { .operator-profile { grid-template-columns: 1fr; } }
 .operator-profile__eyebrow {
@@ -8210,7 +8210,7 @@ body::after {
   font-size: 0.72rem;
   letter-spacing: 0.12em;
   font-weight: 600;
-  background: rgba(11, 11, 13$1 0.85);
+  background: rgba(11, 11, 13, 0.85);
   border: 1px solid rgba(96, 165, 250, 0.35);
   color: var(--silver-bright);
 }
@@ -8487,7 +8487,7 @@ body::after {
   border: 1px solid var(--moon-border);
   border-left: 3px solid var(--blocked-red);
   border-radius: 8px;
-  background: linear-gradient(180deg, rgba(14, 14, 16$1 0.7), rgba(10, 10, 12$1 0.86));
+  background: linear-gradient(180deg, rgba(14, 14, 16, 0.7), rgba(10, 10, 12, 0.86));
   padding: 14px 14px 16px;
   display: flex;
   flex-direction: column;
@@ -8596,7 +8596,7 @@ body::after {
   margin-top: 18px;
   border: 1px dashed var(--moon-border);
   border-radius: 10px;
-  background: rgba(10, 10, 12$1 0.5);
+  background: rgba(10, 10, 12, 0.5);
   padding: 14px 16px;
 }
 .operator-stack__eyebrow {
@@ -8623,7 +8623,7 @@ body::after {
   padding: 6px 10px;
   border: 1px solid var(--moon-border);
   border-radius: 999px;
-  background: rgba(16, 16, 18$1 0.6);
+  background: rgba(16, 16, 18, 0.6);
 }
 
 /* ─── React Flow · global overrides for cockpit aesthetic ──────────── */
@@ -8954,4 +8954,129 @@ body::after {
   line-height: 1.55;
   color: var(--silver-bright);
   margin: 2px 0 0;
+}
+
+/* ─── Polish · blocked-claim tooltip · cursor not-allowed ─────────── */
+
+/* Universal data-tooltip pattern — instant, no delay. Applied to any
+   element with [data-tooltip="..."]. Pure CSS, no JS, no portal. */
+[data-tooltip] { position: relative; }
+[data-tooltip]:hover::after,
+[data-tooltip]:focus-visible::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: #000;
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  padding: 7px 11px;
+  border-radius: 4px;
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  line-height: 1.45;
+  white-space: normal;
+  max-width: 280px;
+  width: max-content;
+  text-align: left;
+  text-transform: none;
+  z-index: 200;
+  pointer-events: none;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.55);
+}
+[data-tooltip]:hover::before,
+[data-tooltip]:focus-visible::before {
+  content: "";
+  position: absolute;
+  bottom: calc(100% + 2px);
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+  border-top-color: #000;
+  z-index: 200;
+  pointer-events: none;
+}
+
+/* not-allowed cursor on visibly blocked surfaces */
+.chip-block,
+.hero-status__chip--blocked,
+.claim-firewall-panel__chip,
+.boundary-panel--isnot .boundary-panel__item,
+.upf-node--failure {
+  cursor: not-allowed;
+}
+
+/* ─── Polish · scanner sweep on claim firewall + truth matrix ─────── */
+
+.scan-sweep { position: relative; overflow: hidden; }
+.scan-sweep::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(
+    105deg,
+    transparent 0%,
+    transparent 38%,
+    rgba(143, 216, 255, 0.10) 50%,
+    transparent 62%,
+    transparent 100%
+  );
+  background-size: 220% 100%;
+  background-position: 220% 0;
+  animation: scan-sweep 11s linear infinite;
+  mix-blend-mode: screen;
+  z-index: 1;
+}
+.scan-sweep > * { position: relative; z-index: 2; }
+@keyframes scan-sweep {
+  0%   { background-position: 220% 0; }
+  100% { background-position: -120% 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .scan-sweep::after { animation: none; opacity: 0; }
+}
+
+/* ─── Polish · LED-style indicators · color is not the only signal ── */
+
+/* Bright lit core for supported items */
+.boundary-panel--is .boundary-panel__item::before {
+  background: radial-gradient(
+    circle at center,
+    #E0F2FE 0%,
+    var(--electric-blue-bright) 40%,
+    var(--electric-blue) 100%
+  );
+  box-shadow:
+    0 0 0 1px rgba(96, 165, 250, 0.55),
+    0 0 12px var(--electric-blue-glow);
+}
+/* Hollow ring for blocked items — visibly different shape from filled LED */
+.boundary-panel--isnot .boundary-panel__item::before {
+  background: transparent;
+  box-shadow:
+    0 0 0 1.5px var(--blocked-red),
+    inset 0 0 0 0.5px rgba(0, 0, 0, 0.65);
+}
+
+/* Truth-matrix glyph LED glow — color + glyph + glow stack three signals */
+.truth-matrix__glyph--supported {
+  text-shadow: 0 0 9px var(--electric-blue-glow), 0 0 2px rgba(255, 255, 255, 0.5);
+}
+.truth-matrix__glyph--at-ceiling {
+  text-shadow: 0 0 7px rgba(224, 189, 99, 0.45);
+}
+.truth-matrix__glyph--gate-defined {
+  text-shadow: 0 0 5px rgba(143, 216, 255, 0.32);
+}
+.truth-matrix__glyph--blocked {
+  text-shadow: 0 0 5px rgba(252, 165, 165, 0.45);
+}
+
+/* ─── Polish · Operator failure ladder · keep tablet single-column ─── */
+
+@media (min-width: 768px) and (max-width: 1023px) {
+  .operator-failure { grid-template-columns: 1fr 1fr !important; gap: 12px; }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -8625,3 +8625,333 @@ body::after {
   border-radius: 999px;
   background: rgba(16, 16, 18$1 0.6);
 }
+
+/* ─── React Flow · global overrides for cockpit aesthetic ──────────── */
+
+.react-flow {
+  background: transparent;
+  --xy-edge-stroke-default: rgba(143, 216, 255, 0.55);
+  --xy-edge-stroke-selected-default: var(--ice-blue);
+  --xy-handle-background-color-default: rgba(220, 224, 232, 0.45);
+  --xy-controls-button-background-color-default: rgba(10, 10, 12, 0.9);
+  --xy-controls-button-background-color-hover-default: rgba(18, 18, 22, 0.95);
+  --xy-controls-button-color-default: var(--silver-bright);
+  --xy-controls-button-border-color-default: var(--moon-border);
+  --xy-attribution-background-color-default: transparent;
+}
+.react-flow__handle {
+  width: 6px;
+  height: 6px;
+  background: rgba(220, 224, 232, 0.5);
+  border: none;
+}
+.react-flow__edge.upf-edge--dim,
+.react-flow__edge.raf-edge--dim {
+  opacity: 0.32;
+}
+.react-flow__edge-path {
+  transition: stroke 200ms ease, opacity 200ms ease;
+}
+.react-flow__controls {
+  background: rgba(10, 10, 12, 0.85);
+  border: 1px solid var(--moon-border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.react-flow__controls-button {
+  border-bottom: 1px solid var(--moon-border);
+}
+.react-flow__controls-button:last-child { border-bottom: 0; }
+.react-flow__controls-button svg { fill: var(--silver); }
+.react-flow__controls-button:hover svg { fill: var(--ice-blue); }
+
+@media (prefers-reduced-motion: reduce) {
+  .react-flow__edge-path { animation: none !important; }
+}
+
+/* ─── UncontrolledPromotionFlow ───────────────────────────────────── */
+
+.upf-shell {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: 1fr;
+}
+@media (min-width: 1100px) {
+  .upf-shell {
+    grid-template-columns: minmax(0, 1.65fr) minmax(280px, 0.95fr);
+    gap: 22px;
+  }
+}
+.upf-canvas {
+  position: relative;
+  width: 100%;
+  height: 520px;
+  border: 1px solid var(--moon-border);
+  border-radius: 12px;
+  background: linear-gradient(180deg, rgba(16, 16, 18, 0.78), rgba(10, 10, 12, 0.92));
+  overflow: hidden;
+}
+@media (min-width: 1400px) {
+  .upf-canvas { height: 560px; }
+}
+
+.upf-node {
+  position: relative;
+  width: 184px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  border: 1.4px solid var(--moon-border);
+  background: linear-gradient(180deg, rgba(16, 16, 20, 0.96), rgba(10, 10, 12, 0.96));
+  color: var(--silver-bright);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  cursor: pointer;
+  transition: border-color 200ms ease, transform 200ms ease, box-shadow 220ms ease, opacity 200ms ease;
+}
+.upf-node:hover { transform: translateY(-1px); }
+.upf-node__kind {
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.55rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.upf-node__title {
+  font-size: 0.92rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+.upf-node__sub {
+  font-size: 0.7rem;
+  line-height: 1.4;
+  color: var(--silver);
+}
+.upf-node--origin { border-color: rgba(220, 224, 232, 0.45); }
+.upf-node--origin .upf-node__kind { color: var(--silver-bright); }
+.upf-node--failure {
+  border-color: rgba(252, 165, 165, 0.55);
+  box-shadow: 0 0 0 1px rgba(252, 165, 165, 0.08) inset;
+}
+.upf-node--failure .upf-node__kind { color: var(--blocked-red); }
+.upf-node--gate {
+  border-color: rgba(143, 216, 255, 0.55);
+  box-shadow: 0 0 0 1px rgba(143, 216, 255, 0.10) inset;
+}
+.upf-node--gate .upf-node__kind { color: var(--ice-blue); }
+.upf-node--boundary {
+  border-color: rgba(224, 189, 99, 0.55);
+  box-shadow: 0 0 0 1px rgba(224, 189, 99, 0.12) inset;
+}
+.upf-node--boundary .upf-node__kind { color: var(--ceiling-amber); }
+.upf-node--active {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.55), 0 0 0 1px var(--ice-blue-soft) inset, 0 0 26px -6px var(--ice-blue-glow);
+}
+.upf-node--dim { opacity: 0.32; }
+.upf-handle { background: rgba(143, 216, 255, 0.55); }
+
+.upf-panel {
+  border: 1px solid var(--moon-border);
+  border-radius: 12px;
+  background: var(--moon-panel-strong);
+  padding: 18px 18px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 100%;
+}
+.upf-panel__eyebrow {
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ice-blue);
+  margin: 0;
+}
+.upf-panel__title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--silver-bright);
+  letter-spacing: 0.01em;
+  margin: 2px 0 0;
+}
+.upf-panel__sub {
+  font-size: 0.82rem;
+  color: var(--silver);
+  margin: 0 0 6px;
+  line-height: 1.5;
+}
+.upf-panel__dl {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px 0;
+  margin: 4px 0 0;
+}
+.upf-panel__dl dt {
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-top: 6px;
+}
+.upf-panel__dl dd {
+  font-size: 0.78rem;
+  line-height: 1.55;
+  color: var(--silver-bright);
+  margin: 2px 0 0;
+}
+.upf-panel__hint {
+  font-size: 0.7rem;
+  color: var(--muted);
+  margin-top: 10px;
+}
+.upf-panel__legend {
+  list-style: none;
+  padding: 0;
+  margin: 8px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.74rem;
+  color: var(--silver);
+}
+.upf-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  margin-right: 8px;
+  vertical-align: middle;
+}
+.upf-dot--failure { background: var(--blocked-red); box-shadow: 0 0 8px rgba(252, 165, 165, 0.4); }
+.upf-dot--gate { background: var(--ice-blue); box-shadow: 0 0 8px var(--ice-blue-glow); }
+.upf-dot--boundary { background: var(--ceiling-amber); box-shadow: 0 0 8px rgba(224, 189, 99, 0.4); }
+
+/* ─── RepoAuthorityFlow ───────────────────────────────────────────── */
+
+.raf-shell {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: 1fr;
+}
+@media (min-width: 1100px) {
+  .raf-shell {
+    grid-template-columns: minmax(0, 1.7fr) minmax(280px, 0.9fr);
+    gap: 22px;
+  }
+}
+.raf-canvas {
+  position: relative;
+  width: 100%;
+  height: 540px;
+  border: 1px solid var(--moon-border);
+  border-radius: 12px;
+  background: linear-gradient(180deg, rgba(16, 16, 18, 0.78), rgba(10, 10, 12, 0.92));
+  overflow: hidden;
+}
+.raf-node {
+  position: relative;
+  width: 220px;
+  padding: 12px 14px 14px;
+  border-radius: 8px;
+  border: 1.4px solid var(--moon-border);
+  background: linear-gradient(180deg, rgba(16, 16, 20, 0.96), rgba(10, 10, 12, 0.96));
+  color: var(--silver-bright);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  cursor: pointer;
+  transition: border-color 200ms ease, transform 200ms ease, box-shadow 220ms ease, opacity 200ms ease;
+}
+.raf-node__num {
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+}
+.raf-node__name {
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+.raf-node__role {
+  font-size: 0.72rem;
+  line-height: 1.4;
+  color: var(--silver);
+}
+.raf-node__plane {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.55rem;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+}
+.raf-node--governance,
+.raf-node--runtime { border-color: rgba(220, 224, 232, 0.45); }
+.raf-node--governance .raf-node__plane,
+.raf-node--runtime .raf-node__plane { color: var(--silver-bright); }
+.raf-node--authority { border-color: rgba(96, 165, 250, 0.55); }
+.raf-node--authority .raf-node__plane { color: var(--electric-blue-bright); }
+.raf-node--rendering { border-color: rgba(143, 216, 255, 0.55); }
+.raf-node--rendering .raf-node__plane { color: var(--ice-blue); }
+.raf-node--active {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.55), 0 0 0 1px var(--ice-blue-soft) inset, 0 0 26px -6px var(--ice-blue-glow);
+}
+.raf-node--dim { opacity: 0.34; }
+.raf-handle { background: rgba(143, 216, 255, 0.55); }
+
+.raf-panel {
+  border: 1px solid var(--moon-border);
+  border-radius: 12px;
+  background: var(--moon-panel-strong);
+  padding: 18px 18px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 100%;
+}
+.raf-panel__eyebrow {
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ice-blue);
+  margin: 0;
+}
+.raf-panel__title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--silver-bright);
+  margin: 2px 0 0;
+}
+.raf-panel__role {
+  font-size: 0.82rem;
+  color: var(--silver);
+  margin: 0;
+  line-height: 1.5;
+}
+.raf-panel__dl {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px 0;
+  margin: 4px 0 0;
+}
+.raf-panel__dl dt {
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-top: 6px;
+}
+.raf-panel__dl dd {
+  font-size: 0.78rem;
+  line-height: 1.55;
+  color: var(--silver-bright);
+  margin: 2px 0 0;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -106,13 +106,30 @@ main { overflow: hidden; }
 }
 
 .container {
-  width: min(1200px, calc(100vw - 32px));
+  width: min(1280px, calc(100vw - 32px));
   margin: 0 auto;
 }
 
 .container-wide {
-  width: min(1320px, calc(100vw - 32px));
+  width: min(1480px, calc(100vw - 40px));
   margin: 0 auto;
+}
+
+.container-cockpit {
+  width: min(1640px, calc(100vw - 48px));
+  margin: 0 auto;
+}
+
+@media (min-width: 1920px) {
+  .container {
+    width: min(1360px, calc(100vw - 64px));
+  }
+  .container-wide {
+    width: min(1640px, calc(100vw - 80px));
+  }
+  .container-cockpit {
+    width: min(1800px, calc(100vw - 96px));
+  }
 }
 
 .section { padding: 96px 0; }
@@ -8453,3 +8470,160 @@ body::after {
 }
 .review-route-selector__route--loop:hover  { box-shadow: 0 16px 40px rgba(0, 0, 0, 0.45), 0 0 22px rgba(96, 165, 250, 0.32); }
 .review-route-selector__route--split:hover { box-shadow: 0 16px 40px rgba(0, 0, 0, 0.45), 0 0 22px rgba(224, 189, 99, 0.35); }
+
+/* ─── Operator page · failure ladder, built grid, resume snapshot ──── */
+
+.operator-failure {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 1fr;
+}
+@media (min-width: 768px) {
+  .operator-failure { grid-template-columns: repeat(5, 1fr); gap: 14px; }
+}
+.operator-failure__step {
+  position: relative;
+  border: 1px solid var(--moon-border);
+  border-left: 3px solid var(--blocked-red);
+  border-radius: 8px;
+  background: linear-gradient(180deg, rgba(11, 17, 27, 0.7), rgba(7, 11, 18, 0.86));
+  padding: 14px 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  transition: border-color 200ms ease, transform 200ms ease, box-shadow 240ms ease;
+}
+.operator-failure__step:hover {
+  border-color: var(--blocked-red);
+  transform: translateY(-2px);
+  box-shadow: 0 14px 40px rgba(0, 0, 0, 0.48), 0 0 0 1px rgba(252, 165, 165, 0.18) inset;
+}
+.operator-failure__num {
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.18em;
+  color: var(--blocked-red);
+  text-transform: uppercase;
+}
+.operator-failure__label {
+  font-size: 0.92rem;
+  font-weight: 700;
+  color: var(--silver-bright);
+  letter-spacing: 0.04em;
+}
+.operator-failure__why {
+  font-size: 0.78rem;
+  line-height: 1.5;
+  color: var(--silver);
+}
+
+/* what I built · responsive grid */
+.operator-built {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: 1fr;
+}
+@media (min-width: 640px)  { .operator-built { grid-template-columns: repeat(2, 1fr); } }
+@media (min-width: 1100px) { .operator-built { grid-template-columns: repeat(3, 1fr); } }
+.operator-built__card {
+  border: 1px solid var(--moon-border);
+  border-radius: 10px;
+  background: var(--moon-panel);
+  padding: 16px 16px 18px;
+  transition: border-color 200ms ease, transform 200ms ease, box-shadow 240ms ease;
+}
+.operator-built__card:hover {
+  border-color: var(--moon-border-bright);
+  transform: translateY(-2px);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.48), 0 0 0 1px var(--ice-blue-soft) inset;
+}
+.operator-built__label {
+  font-size: 0.92rem;
+  font-weight: 700;
+  color: var(--silver-bright);
+  letter-spacing: 0.02em;
+  margin: 0 0 6px;
+}
+.operator-built__detail {
+  font-size: 0.8rem;
+  line-height: 1.55;
+  color: var(--silver);
+  margin: 0;
+}
+
+/* resume snapshot · bounded rows */
+.operator-resume {
+  border: 1px solid var(--moon-border);
+  border-radius: 10px;
+  background: var(--moon-panel-strong);
+  overflow: hidden;
+}
+.operator-resume__row {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 4px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--moon-border);
+}
+.operator-resume__row:last-child { border-bottom: 0; }
+@media (min-width: 768px) {
+  .operator-resume__row {
+    grid-template-columns: 0.9fr 1.1fr 1.4fr;
+    gap: 18px;
+    align-items: baseline;
+  }
+}
+.operator-resume__label {
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.operator-resume__value {
+  font-size: 0.92rem;
+  font-weight: 700;
+  color: var(--silver-bright);
+  letter-spacing: 0.01em;
+}
+.operator-resume__note {
+  font-size: 0.75rem;
+  line-height: 1.5;
+  color: var(--silver);
+}
+.operator-stack {
+  margin-top: 18px;
+  border: 1px dashed var(--moon-border);
+  border-radius: 10px;
+  background: rgba(7, 11, 18, 0.5);
+  padding: 14px 16px;
+}
+.operator-stack__eyebrow {
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ice-blue);
+  margin: 0 0 8px;
+}
+.operator-stack__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 10px;
+}
+.operator-stack__item {
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  color: var(--silver);
+  padding: 6px 10px;
+  border: 1px solid var(--moon-border);
+  border-radius: 999px;
+  background: rgba(13, 19, 30, 0.6);
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,13 +3,13 @@
 :root {
   color-scheme: dark;
 
-  /* Original tokens preserved for legacy pages */
-  --bg: #03060B;
-  --bg-elevated: #0c1119;
-  --panel: #0b111b;
-  --panel-strong: #111827;
-  --line: rgba(201, 211, 223, 0.18);
-  --line-strong: rgba(201, 211, 223, 0.32);
+  /* Neutral charcoal base · navy killed · accents preserved */
+  --bg: #000000;
+  --bg-elevated: #0a0a0c;
+  --panel: #0d0d10;
+  --panel-strong: #141418;
+  --line: rgba(220, 224, 232, 0.18);
+  --line-strong: rgba(220, 224, 232, 0.32);
   --text: #f8fbff;
   --muted: #b7c4d6;
   --subtle: #94a3b8;
@@ -17,20 +17,20 @@
   --accent-2: #93c5fd;
   --warning: #facc15;
   --danger: #ff9baa;
-  --shadow: 0 24px 80px rgba(0, 0, 0, 0.45);
+  --shadow: 0 24px 80px rgba(0, 0, 0, 0.55);
 
-  /* Moonlit command-surface palette */
+  /* Surface palette · accent tones preserved · navy stripped */
   --silver: #C9D3DF;
   --silver-bright: #EEF4FA;
   --ice-blue: #8FD8FF;
   --ice-blue-soft: rgba(143, 216, 255, 0.24);
   --ice-blue-glow: rgba(143, 216, 255, 0.55);
-  --moon-border: rgba(201, 211, 223, 0.22);
-  --moon-border-bright: rgba(201, 211, 223, 0.42);
-  --moon-panel: rgba(9, 14, 24, 0.72);
-  --moon-panel-strong: rgba(11, 18, 32, 0.92);
-  --deep-black: #03060B;
-  --panel-black: #090E18;
+  --moon-border: rgba(220, 224, 232, 0.20);
+  --moon-border-bright: rgba(220, 224, 232, 0.38);
+  --moon-panel: rgba(12, 12, 14, 0.72);
+  --moon-panel-strong: rgba(16, 16, 20, 0.92);
+  --deep-black: #000000;
+  --panel-black: #060608;
 
   /* Reviewer-cockpit primary accents (design/black-blue-reviewer-cockpit) */
   --electric-blue: #3B82F6;
@@ -54,37 +54,35 @@ body {
   position: relative;
   margin: 0;
   min-height: 100vh;
-  background:
-    radial-gradient(circle at 16% 6%, rgba(37, 99, 235, 0.065), transparent 32rem),
-    radial-gradient(circle at 84% 12%, rgba(201, 211, 223, 0.045), transparent 32rem),
-    radial-gradient(circle at 50% 52%, rgba(9, 14, 24, 0.78), transparent 40rem),
-    linear-gradient(150deg, rgba(8, 13, 22, 0.92) 0%, rgba(3, 6, 11, 0.98) 46%, rgba(3, 6, 11, 1) 100%),
-    var(--deep-black);
+  background: var(--deep-black);
   color: var(--text);
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   letter-spacing: 0;
 }
 
-body::before,
-body::after {
+/* Faint static dot field · sits beneath canvas constellations as a low-noise fallback */
+body::before {
   content: "";
   position: fixed;
   inset: 0;
   pointer-events: none;
-}
-
-body::before {
-  background-image: radial-gradient(circle at center, rgba(255, 255, 255, 0.18) 0.8px, transparent 0.9px);
+  background-image: radial-gradient(circle at center, rgba(255, 255, 255, 0.16) 0.8px, transparent 0.9px);
   background-size: 32px 32px;
-  opacity: 0.055;
-  mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.85), rgba(0, 0, 0, 0.4) 44%, transparent 84%);
+  opacity: 0.035;
+  mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.32) 44%, transparent 84%);
+  z-index: 0;
 }
 
-body::after {
-  background: linear-gradient(180deg, transparent 0%, rgba(37, 99, 235, 0.035) 52%, transparent 100%);
-  background-size: 100% 9rem;
-  opacity: 0.12;
-  mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.55), transparent 78%);
+/* Canvas constellation layer · positioned by the React BackgroundDepth island */
+.bg-depth {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bg-depth { opacity: 0.6; }
 }
 
 a { color: inherit; text-decoration: none; }
@@ -149,7 +147,7 @@ main { overflow: hidden; }
   border: 1px solid var(--moon-border);
   border-radius: 14px;
   background:
-    linear-gradient(180deg, rgba(13, 19, 30, 0.78), rgba(7, 11, 18, 0.92));
+    linear-gradient(180deg, rgba(16, 16, 18$1 0.78), rgba(10, 10, 12$1 0.92));
   box-shadow:
     0 0 0 1px rgba(143, 216, 255, 0.04) inset,
     0 28px 88px rgba(0, 0, 0, 0.55);
@@ -160,7 +158,7 @@ main { overflow: hidden; }
   border: 1px solid var(--moon-border-bright);
   border-radius: 14px;
   background:
-    linear-gradient(180deg, rgba(15, 22, 36, 0.86), rgba(7, 11, 18, 0.96));
+    linear-gradient(180deg, rgba(18, 18, 22$1 0.86), rgba(10, 10, 12$1 0.96));
   box-shadow:
     0 0 0 1px rgba(143, 216, 255, 0.08) inset,
     0 32px 96px rgba(0, 0, 0, 0.6);
@@ -178,7 +176,7 @@ main { overflow: hidden; }
 .surface {
   border: 1px solid var(--moon-border);
   border-radius: 12px;
-  background: linear-gradient(180deg, rgba(11, 17, 27, 0.82), rgba(7, 11, 18, 0.92));
+  background: linear-gradient(180deg, rgba(14, 14, 16$1 0.82), rgba(10, 10, 12$1 0.92));
   box-shadow: var(--shadow);
 }
 
@@ -186,13 +184,13 @@ main { overflow: hidden; }
   position: relative;
   border: 1px solid var(--moon-border);
   border-radius: 12px;
-  background: rgba(7, 11, 18, 0.66);
+  background: rgba(10, 10, 12$1 0.66);
   transition: border-color 200ms ease, transform 200ms ease, background 200ms ease, box-shadow 240ms ease;
 }
 
 .card:hover {
   border-color: var(--moon-border-bright);
-  background: rgba(12, 18, 28, 0.86);
+  background: rgba(15, 15, 18$1 0.86);
   transform: translateY(-3px);
   box-shadow: 0 18px 40px rgba(0, 0, 0, 0.4), 0 0 0 1px var(--ice-blue-soft) inset;
 }
@@ -201,7 +199,7 @@ main { overflow: hidden; }
   position: relative;
   border: 1px solid var(--moon-border);
   border-radius: 14px;
-  background: linear-gradient(180deg, rgba(13, 19, 30, 0.82), rgba(6, 10, 18, 0.94));
+  background: linear-gradient(180deg, rgba(16, 16, 18$1 0.82), rgba(8, 8, 10$1 0.94));
   transition: border-color 240ms ease, transform 240ms ease, box-shadow 280ms ease;
 }
 
@@ -238,7 +236,7 @@ main { overflow: hidden; }
   padding: 0.36rem 0.72rem;
   border: 1px solid var(--moon-border);
   border-radius: 999px;
-  background: rgba(13, 19, 30, 0.6);
+  background: rgba(16, 16, 18$1 0.6);
   color: var(--silver);
   font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
   font-size: 0.68rem;
@@ -299,7 +297,7 @@ main { overflow: hidden; }
   padding: 0.85rem 1.2rem;
   border: 1px solid var(--moon-border-bright);
   border-radius: 4px;
-  background: rgba(11, 17, 28, 0.65);
+  background: rgba(14, 14, 16$1 0.65);
   color: var(--silver-bright);
   font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
   font-size: 0.72rem;
@@ -311,7 +309,7 @@ main { overflow: hidden; }
 
 .cta:hover {
   border-color: var(--ice-blue);
-  background: rgba(15, 23, 36, 0.85);
+  background: rgba(18, 18, 22$1 0.85);
   color: var(--ice-blue);
   transform: translateY(-1px);
   box-shadow: 0 0 0 1px var(--ice-blue-soft) inset, 0 0 28px -10px var(--ice-blue-glow);
@@ -461,7 +459,7 @@ main { overflow: hidden; }
   padding: 0;
   border: 1px solid rgba(201, 211, 223, 0.32);
   border-radius: 4px;
-  background: linear-gradient(180deg, rgba(13, 19, 30, 0.5), rgba(6, 10, 18, 0.85));
+  background: linear-gradient(180deg, rgba(16, 16, 18$1 0.5), rgba(8, 8, 10$1 0.85));
   box-shadow:
     0 0 0 1px rgba(143, 216, 255, 0.05) inset,
     0 32px 80px rgba(0, 0, 0, 0.55);
@@ -498,7 +496,7 @@ main { overflow: hidden; }
   position: absolute;
   inset: 0;
   background:
-    linear-gradient(180deg, rgba(3, 6, 11, 0) 60%, rgba(3, 6, 11, 0.5) 100%),
+    linear-gradient(180deg, rgba(0, 0, 0$1 0) 60%, rgba(0, 0, 0$1 0.5) 100%),
     radial-gradient(140% 80% at 50% -10%, rgba(143, 216, 255, 0.05), transparent 60%);
   pointer-events: none;
 }
@@ -601,9 +599,9 @@ main { overflow: hidden; }
   width: 16px;
   height: 16px;
   border-radius: 999px;
-  background: rgba(7, 11, 18, 1);
+  background: rgba(10, 10, 12$1 1);
   border: 1px solid var(--moon-border);
-  box-shadow: 0 0 0 5px rgba(7, 11, 18, 1);
+  box-shadow: 0 0 0 5px rgba(10, 10, 12$1 1);
   transition: border-color 240ms ease, box-shadow 240ms ease;
   position: relative;
 }
@@ -613,13 +611,13 @@ main { overflow: hidden; }
   background: var(--ice-blue);
   border-color: var(--ice-blue);
   box-shadow:
-    0 0 0 5px rgba(7, 11, 18, 1),
+    0 0 0 5px rgba(10, 10, 12$1 1),
     0 0 18px var(--ice-blue-glow);
 }
 
 .truth-node--inactive .truth-node__dot {
   border-color: rgba(201, 211, 223, 0.28);
-  background: rgba(7, 11, 18, 1);
+  background: rgba(10, 10, 12$1 1);
 }
 .truth-node--inactive .truth-node__dot::after {
   content: "";
@@ -689,14 +687,14 @@ main { overflow: hidden; }
   border: 1px solid var(--moon-border);
   border-radius: 8px;
   overflow: hidden;
-  background: linear-gradient(180deg, rgba(13, 19, 30, 0.6), rgba(6, 10, 18, 0.86));
+  background: linear-gradient(180deg, rgba(16, 16, 18$1 0.6), rgba(8, 8, 10$1 0.86));
 }
 .ledger__head {
   display: grid;
   grid-template-columns: var(--ledger-cols, 0.6fr 1.4fr 1fr 1fr);
   gap: 16px;
   padding: 12px 20px;
-  background: rgba(13, 19, 30, 0.6);
+  background: rgba(16, 16, 18$1 0.6);
   border-bottom: 1px solid var(--moon-border);
   font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
   font-size: 0.6rem;
@@ -731,7 +729,7 @@ main { overflow: hidden; }
 
 .ledger--blocked {
   border-color: rgba(255, 155, 170, 0.18);
-  background: linear-gradient(180deg, rgba(255, 155, 170, 0.035), rgba(6, 10, 18, 0.86));
+  background: linear-gradient(180deg, rgba(255, 155, 170, 0.035), rgba(8, 8, 10$1 0.86));
 }
 
 .ledger--blocked .ledger__head { color: #d5b7c0; }
@@ -793,7 +791,7 @@ main { overflow: hidden; }
   padding: 16px 18px;
   border: 1px solid var(--moon-border);
   border-radius: 6px;
-  background: rgba(11, 17, 28, 0.5);
+  background: rgba(14, 14, 16$1 0.5);
   align-items: center;
 }
 .status-band__rule { width: 4px; height: 100%; min-height: 32px; border-radius: 2px; background: var(--ice-blue); box-shadow: 0 0 12px var(--ice-blue-glow); }
@@ -846,7 +844,7 @@ main { overflow: hidden; }
   padding: 16px 16px 18px;
   border: 1px solid var(--moon-border);
   border-radius: 8px;
-  background: linear-gradient(180deg, rgba(11, 17, 28, 0.5), rgba(6, 10, 18, 0.78));
+  background: linear-gradient(180deg, rgba(14, 14, 16$1 0.5), rgba(8, 8, 10$1 0.78));
   color: inherit;
   cursor: pointer;
   transition: border-color 200ms ease, transform 200ms ease, box-shadow 240ms ease;
@@ -897,7 +895,7 @@ main { overflow: hidden; }
   border: 1px solid var(--moon-border-bright);
   border-radius: 12px;
   overflow: hidden;
-  background: linear-gradient(140deg, rgba(15, 22, 36, 0.92), rgba(6, 10, 18, 0.96));
+  background: linear-gradient(140deg, rgba(18, 18, 22$1 0.92), rgba(8, 8, 10$1 0.96));
   color: inherit;
   cursor: pointer;
   transition: border-color 220ms ease, transform 240ms ease, box-shadow 280ms ease;
@@ -915,7 +913,7 @@ main { overflow: hidden; }
   padding: 24px;
   background:
     radial-gradient(120% 80% at 0% 0%, rgba(143, 216, 255, 0.12), transparent 55%),
-    linear-gradient(180deg, rgba(13, 19, 30, 0.6), rgba(6, 10, 18, 0.85));
+    linear-gradient(180deg, rgba(16, 16, 18$1 0.6), rgba(8, 8, 10$1 0.85));
   border-right: 1px solid var(--moon-border);
   display: flex;
   flex-direction: column;
@@ -934,7 +932,7 @@ main { overflow: hidden; }
   border: 1px dashed rgba(201, 211, 223, 0.18);
   border-radius: 8px;
   padding: 14px 16px;
-  background: linear-gradient(180deg, rgba(11, 17, 28, 0.26), rgba(6, 10, 18, 0.46));
+  background: linear-gradient(180deg, rgba(14, 14, 16$1 0.26), rgba(8, 8, 10$1 0.46));
   color: var(--muted);
   font-size: 0.85rem;
   display: flex;
@@ -968,7 +966,7 @@ main { overflow: hidden; }
   padding: 18px 18px 20px;
   border: 1px solid var(--moon-border);
   border-radius: 12px;
-  background: linear-gradient(180deg, rgba(13, 19, 30, 0.76), rgba(7, 11, 18, 0.92));
+  background: linear-gradient(180deg, rgba(16, 16, 18$1 0.76), rgba(10, 10, 12$1 0.92));
 }
 
 .loop-step__num {
@@ -1002,7 +1000,7 @@ main { overflow: hidden; }
   padding: 22px 22px 20px;
   border: 1px solid var(--moon-border);
   border-radius: 14px;
-  background: linear-gradient(180deg, rgba(13, 19, 30, 0.78), rgba(6, 10, 18, 0.94));
+  background: linear-gradient(180deg, rgba(16, 16, 18$1 0.78), rgba(8, 8, 10$1 0.94));
   color: var(--silver);
   transition: border-color 240ms ease, transform 260ms ease, box-shadow 280ms ease;
   position: relative;
@@ -1102,21 +1100,21 @@ main { overflow: hidden; }
   border-color: var(--moon-border-bright);
   background:
     radial-gradient(120% 80% at 0% 0%, rgba(143, 216, 255, 0.1), transparent 55%),
-    linear-gradient(180deg, rgba(15, 22, 36, 0.86), rgba(6, 10, 18, 0.96));
+    linear-gradient(180deg, rgba(18, 18, 22$1 0.86), rgba(8, 8, 10$1 0.96));
 }
 
 .artifact-card--flagship .artifact-card__title { font-size: 1.5rem; }
 
 .artifact-card--legacy {
   border-style: dashed;
-  background: linear-gradient(180deg, rgba(13, 17, 24, 0.6), rgba(5, 8, 14, 0.8));
+  background: linear-gradient(180deg, rgba(14, 14, 16$1 0.6), rgba(6, 6, 8$1 0.8));
 }
 
 .artifact-card--blocked {
   border-color: rgba(251, 113, 133, 0.28);
   background:
     radial-gradient(140% 100% at 100% 0%, rgba(251, 113, 133, 0.08), transparent 55%),
-    linear-gradient(180deg, rgba(13, 19, 30, 0.78), rgba(6, 10, 18, 0.94));
+    linear-gradient(180deg, rgba(16, 16, 18$1 0.78), rgba(8, 8, 10$1 0.94));
 }
 
 /* ─── Boundary notice ─────────────────────────────────────────────── */
@@ -1129,7 +1127,7 @@ main { overflow: hidden; }
   padding: 18px 22px;
   border-radius: 10px;
   border: 1px solid var(--moon-border);
-  background: linear-gradient(90deg, rgba(143, 216, 255, 0.07), rgba(11, 17, 28, 0.4) 60%);
+  background: linear-gradient(90deg, rgba(143, 216, 255, 0.07), rgba(14, 14, 16$1 0.4) 60%);
   color: var(--silver);
 }
 
@@ -1171,7 +1169,7 @@ main { overflow: hidden; }
   padding: 12px 14px 12px 34px;
   border: 1px solid rgba(201, 211, 223, 0.16);
   border-radius: 8px;
-  background: rgba(7, 11, 18, 0.44);
+  background: rgba(10, 10, 12$1 0.44);
   color: var(--silver);
   font-size: 0.94rem;
   line-height: 1.45;
@@ -1198,7 +1196,7 @@ main { overflow: hidden; }
 .plain-glossary details {
   border: 1px solid var(--moon-border);
   border-radius: 8px;
-  background: linear-gradient(180deg, rgba(13, 19, 30, 0.58), rgba(7, 11, 18, 0.82));
+  background: linear-gradient(180deg, rgba(16, 16, 18$1 0.58), rgba(10, 10, 12$1 0.82));
   color: #c1cede;
   overflow: hidden;
 }
@@ -1308,12 +1306,12 @@ main { overflow: hidden; }
   height: 26px;
   border: 1px solid rgba(143, 216, 255, 0.32);
   border-radius: 999px;
-  background: rgba(3, 6, 11, 1);
+  background: rgba(0, 0, 0$1 1);
   color: var(--ice-blue);
   font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
   font-size: 0.58rem;
   letter-spacing: 0.1em;
-  box-shadow: 0 0 0 4px rgba(3, 6, 11, 1);
+  box-shadow: 0 0 0 4px rgba(0, 0, 0$1 1);
 }
 
 .truth-plane__body {
@@ -1321,7 +1319,7 @@ main { overflow: hidden; }
   padding: 18px 16px;
   border: 1px solid var(--moon-border);
   border-radius: 8px;
-  background: linear-gradient(180deg, rgba(11, 17, 28, 0.72), rgba(5, 9, 15, 0.92));
+  background: linear-gradient(180deg, rgba(14, 14, 16$1 0.72), rgba(5, 9, 15, 0.92));
 }
 
 .truth-plane__body h3 {
@@ -1363,7 +1361,7 @@ main { overflow: hidden; }
 .truth-plane--6 .truth-plane__index {
   border-color: rgba(251, 113, 133, 0.26);
   color: #ffbdc7;
-  box-shadow: 0 0 0 4px rgba(3, 6, 11, 1);
+  box-shadow: 0 0 0 4px rgba(0, 0, 0$1 1);
 }
 
 /* ─── Footer and mobile navigation readability ───────────────────── */
@@ -1509,7 +1507,7 @@ main { overflow: hidden; }
 .hero-ceiling {
   position: relative;
   border-left: 2px solid rgba(143, 216, 255, 0.55);
-  background: linear-gradient(90deg, rgba(13, 19, 30, 0.55), rgba(7, 11, 18, 0.2) 75%, transparent);
+  background: linear-gradient(90deg, rgba(16, 16, 18$1 0.55), rgba(10, 10, 12$1 0.2) 75%, transparent);
   border-radius: 0 6px 6px 0;
 }
 
@@ -1561,7 +1559,7 @@ main { overflow: hidden; }
   border: 1px solid var(--moon-border);
   border-top: 2px solid rgba(143, 216, 255, 0.45);
   border-radius: 4px;
-  background: linear-gradient(180deg, rgba(13, 19, 30, 0.7), rgba(7, 11, 18, 0.92));
+  background: linear-gradient(180deg, rgba(16, 16, 18$1 0.7), rgba(10, 10, 12$1 0.92));
 }
 
 .snapshot-card__num {
@@ -1850,7 +1848,7 @@ main { overflow: hidden; }
   padding: 20px 20px 18px;
   border: 1px solid var(--moon-border);
   border-radius: 8px;
-  background: linear-gradient(180deg, rgba(13, 19, 30, 0.75), rgba(7, 11, 18, 0.92));
+  background: linear-gradient(180deg, rgba(16, 16, 18$1 0.75), rgba(10, 10, 12$1 0.92));
   position: relative;
   overflow: hidden;
 }
@@ -2304,7 +2302,7 @@ body::after {
   border-radius: 12px;
   padding: clamp(20px, 3vw, 32px);
   background:
-    linear-gradient(180deg, rgba(15, 22, 36, 0.86), rgba(7, 11, 18, 0.96));
+    linear-gradient(180deg, rgba(18, 18, 22$1 0.86), rgba(10, 10, 12$1 0.96));
   box-shadow:
     0 0 0 1px rgba(143, 216, 255, 0.08) inset,
     0 32px 96px rgba(0, 0, 0, 0.6);
@@ -2348,7 +2346,7 @@ body::after {
   padding: 12px 14px;
   border: 1px solid var(--moon-border);
   border-radius: 8px;
-  background: rgba(5, 8, 14, 0.7);
+  background: rgba(6, 6, 8$1 0.7);
   transition: border-color 200ms ease, transform 200ms ease;
 }
 
@@ -2390,7 +2388,7 @@ body::after {
   padding: 6px;
   border: 1px solid var(--moon-border);
   border-radius: 8px;
-  background: rgba(5, 8, 14, 0.65);
+  background: rgba(6, 6, 8$1 0.65);
   margin-bottom: 18px;
 }
 
@@ -2416,7 +2414,7 @@ body::after {
 .cockpit-tabs__label:hover {
   color: var(--silver-bright);
   border-color: var(--moon-border);
-  background: rgba(13, 19, 30, 0.6);
+  background: rgba(16, 16, 18$1 0.6);
 }
 
 .cockpit-tabs__dot {
@@ -2463,7 +2461,7 @@ body::after {
   padding: 8px 12px;
   border: 1px solid var(--moon-border);
   border-radius: 999px;
-  background: rgba(13, 19, 30, 0.6);
+  background: rgba(16, 16, 18$1 0.6);
   font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
   font-size: 0.66rem;
   font-weight: 600;
@@ -2538,7 +2536,7 @@ body::after {
   border: 1px solid var(--moon-border);
   border-radius: 10px;
   background:
-    linear-gradient(180deg, rgba(11, 17, 27, 0.86), rgba(5, 8, 14, 0.96));
+    linear-gradient(180deg, rgba(14, 14, 16$1 0.86), rgba(6, 6, 8$1 0.96));
   transition: border-color 220ms ease, transform 220ms ease, box-shadow 240ms ease, background 220ms ease;
 }
 
@@ -2546,7 +2544,7 @@ body::after {
   border-color: var(--moon-border-bright);
   transform: translateY(-3px);
   background:
-    linear-gradient(180deg, rgba(15, 22, 36, 0.92), rgba(7, 11, 18, 1));
+    linear-gradient(180deg, rgba(18, 18, 22$1 0.92), rgba(10, 10, 12$1 1));
   box-shadow:
     0 0 0 1px rgba(143, 216, 255, 0.16) inset,
     0 18px 40px rgba(0, 0, 0, 0.45),
@@ -2635,7 +2633,7 @@ body::after {
   border: 1px solid var(--moon-border);
   border-radius: 10px;
   background:
-    linear-gradient(180deg, rgba(11, 17, 27, 0.86), rgba(5, 8, 14, 0.96));
+    linear-gradient(180deg, rgba(14, 14, 16$1 0.86), rgba(6, 6, 8$1 0.96));
   transition: border-color 220ms ease, transform 220ms ease, box-shadow 240ms ease;
 }
 
@@ -2712,7 +2710,7 @@ body::after {
   padding: 12px;
   border: 1px solid var(--moon-border);
   border-radius: 8px;
-  background: rgba(5, 8, 14, 0.55);
+  background: rgba(6, 6, 8$1 0.55);
 }
 
 .lane-card__meta > div {
@@ -2753,7 +2751,7 @@ body::after {
   border: 1px dashed var(--moon-border);
   border-radius: 6px;
   padding: 8px 12px;
-  background: rgba(5, 8, 14, 0.4);
+  background: rgba(6, 6, 8$1 0.4);
   opacity: 0.78;
   transition: opacity 200ms ease, border-color 200ms ease;
 }
@@ -2862,7 +2860,7 @@ body::after {
   border: 1px solid rgba(143, 216, 255, 0.4);
   border-radius: 8px;
   background:
-    linear-gradient(90deg, rgba(143, 216, 255, 0.1), rgba(5, 8, 14, 0.85));
+    linear-gradient(90deg, rgba(143, 216, 255, 0.1), rgba(6, 6, 8$1 0.85));
   font-size: 0.68rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -3036,7 +3034,7 @@ body::after {
   border: 1px solid var(--moon-border);
   border-radius: 10px;
   background:
-    linear-gradient(180deg, rgba(11, 17, 27, 0.86), rgba(5, 8, 14, 0.96));
+    linear-gradient(180deg, rgba(14, 14, 16$1 0.86), rgba(6, 6, 8$1 0.96));
   text-align: left;
   font: inherit;
   color: inherit;
@@ -3048,7 +3046,7 @@ body::after {
   border-color: var(--moon-border-bright);
   transform: translateY(-3px);
   background:
-    linear-gradient(180deg, rgba(15, 22, 36, 0.92), rgba(7, 11, 18, 1));
+    linear-gradient(180deg, rgba(18, 18, 22$1 0.92), rgba(10, 10, 12$1 1));
   box-shadow:
     0 0 0 1px rgba(143, 216, 255, 0.16) inset,
     0 18px 40px rgba(0, 0, 0, 0.45),
@@ -3063,7 +3061,7 @@ body::after {
 .pipeline__node.is-active {
   border-color: rgba(143, 216, 255, 0.55);
   background:
-    linear-gradient(180deg, rgba(20, 34, 56, 0.95), rgba(7, 11, 18, 1));
+    linear-gradient(180deg, rgba(20, 34, 56, 0.95), rgba(10, 10, 12$1 1));
   box-shadow:
     0 0 0 1px rgba(143, 216, 255, 0.45) inset,
     0 0 36px -8px var(--ice-blue-glow);
@@ -3102,7 +3100,7 @@ body::after {
   border-radius: 10px;
   padding: 20px;
   background:
-    linear-gradient(180deg, rgba(15, 22, 36, 0.92), rgba(7, 11, 18, 0.98));
+    linear-gradient(180deg, rgba(18, 18, 22$1 0.92), rgba(10, 10, 12$1 0.98));
   box-shadow:
     0 0 0 1px rgba(143, 216, 255, 0.1) inset,
     0 16px 40px rgba(0, 0, 0, 0.5);
@@ -3224,7 +3222,7 @@ body::after {
   border: 1px solid var(--moon-border);
   border-radius: 10px;
   background:
-    linear-gradient(180deg, rgba(11, 17, 27, 0.86), rgba(5, 8, 14, 0.96));
+    linear-gradient(180deg, rgba(14, 14, 16$1 0.86), rgba(6, 6, 8$1 0.96));
   transition: border-color 220ms ease, box-shadow 240ms ease, transform 220ms ease;
 }
 
@@ -3404,7 +3402,7 @@ body::after {
   padding: 14px;
   border: 1px solid var(--moon-border);
   border-radius: 8px;
-  background: rgba(5, 8, 14, 0.55);
+  background: rgba(6, 6, 8$1 0.55);
 }
 
 .lane-card__meta > div { display: grid; gap: 4px; }
@@ -3442,7 +3440,7 @@ body::after {
   border: 1px dashed var(--moon-border);
   border-radius: 6px;
   padding: 8px 12px;
-  background: rgba(5, 8, 14, 0.4);
+  background: rgba(6, 6, 8$1 0.4);
   opacity: 0.78;
   transition: opacity 200ms ease, border-color 200ms ease;
 }
@@ -3540,7 +3538,7 @@ body::after {
   padding: 6px 12px;
   border: 1px solid var(--moon-border);
   border-radius: 999px;
-  background: rgba(5, 8, 14, 0.6);
+  background: rgba(6, 6, 8$1 0.6);
   font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
   font-size: 0.6rem;
   letter-spacing: 0.16em;
@@ -3590,7 +3588,7 @@ body::after {
   padding: 8px 14px;
   border: 1px solid var(--moon-border);
   border-radius: 999px;
-  background: rgba(5, 8, 14, 0.6);
+  background: rgba(6, 6, 8$1 0.6);
   font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
   font-size: 0.64rem;
   letter-spacing: 0.16em;
@@ -3733,7 +3731,7 @@ body[data-active-surface] .lane-card__details.is-surface-match {
 .cockpit {
   border-radius: 8px;
   background:
-    linear-gradient(180deg, rgba(8, 13, 22, 0.92), rgba(4, 7, 12, 0.98));
+    linear-gradient(180deg, rgba(11, 11, 13$1 0.92), rgba(4, 7, 12, 0.98));
 }
 
 .cockpit-tabs__bar {
@@ -3755,7 +3753,7 @@ body[data-active-surface] .lane-card__details.is-surface-match {
   border: 1px solid var(--moon-border);
   border-radius: 8px;
   background:
-    linear-gradient(180deg, rgba(6, 10, 17, 0.82), rgba(3, 6, 11, 0.94));
+    linear-gradient(180deg, rgba(6, 10, 17, 0.82), rgba(0, 0, 0$1 0.94));
 }
 
 .cockpit-tabs:has(#cockpit-mode-exec:checked) .command-panel[data-mode="exec"],
@@ -3997,7 +3995,7 @@ body[data-active-surface] .lane-card__details.is-surface-match {
   border: 1px solid var(--moon-border-bright);
   border-radius: 8px;
   background:
-    linear-gradient(180deg, rgba(8, 13, 22, 0.94), rgba(3, 6, 11, 0.98));
+    linear-gradient(180deg, rgba(11, 11, 13$1 0.94), rgba(0, 0, 0$1 0.98));
   box-shadow:
     0 0 0 1px rgba(143, 216, 255, 0.08) inset,
     0 28px 70px rgba(0, 0, 0, 0.48);
@@ -4022,7 +4020,7 @@ body[data-active-surface] .lane-card__details.is-surface-match {
   padding: 0 12px;
   border: 1px solid var(--moon-border);
   border-radius: 4px;
-  background: rgba(5, 8, 14, 0.65);
+  background: rgba(6, 6, 8$1 0.65);
   font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
   font-size: 0.62rem;
   letter-spacing: 0.16em;
@@ -4055,7 +4053,7 @@ body[data-active-surface] .lane-card__details.is-surface-match {
   padding: 0 12px;
   border: 1px solid var(--moon-border);
   border-radius: 4px;
-  background: rgba(5, 8, 14, 0.72);
+  background: rgba(6, 6, 8$1 0.72);
   font: inherit;
   font-size: 0.86rem;
   color: var(--silver);
@@ -4367,7 +4365,7 @@ body[data-active-surface] .truth-board__status {
   border: 1px solid var(--moon-border);
   border-radius: 8px;
   background:
-    linear-gradient(180deg, rgba(8, 13, 22, 0.84), rgba(4, 7, 12, 0.96));
+    linear-gradient(180deg, rgba(11, 11, 13$1 0.84), rgba(4, 7, 12, 0.96));
 }
 
 .qc-map__rows {
@@ -4509,14 +4507,14 @@ body[data-active-surface] .truth-board__status {
   border: 1px solid var(--moon-border);
   border-radius: 6px;
   background:
-    linear-gradient(180deg, rgba(143, 216, 255, 0.05), rgba(6, 10, 18, 0.82));
+    linear-gradient(180deg, rgba(143, 216, 255, 0.05), rgba(8, 8, 10$1 0.82));
 }
 
 .scoreboard__cell--quiet { opacity: 0.86; }
 .scoreboard__cell--pass { border-color: rgba(143, 216, 255, 0.34); }
 .scoreboard__cell--block {
   border-color: rgba(255, 155, 170, 0.36);
-  background: linear-gradient(180deg, rgba(255, 155, 170, 0.07), rgba(6, 10, 18, 0.82));
+  background: linear-gradient(180deg, rgba(255, 155, 170, 0.07), rgba(8, 8, 10$1 0.82));
 }
 
 .scoreboard__value {
@@ -4565,7 +4563,7 @@ body[data-active-surface] .truth-board__status {
   padding: 24px;
   border: 1px solid var(--moon-border);
   border-radius: 6px;
-  background: linear-gradient(180deg, rgba(11, 17, 28, 0.66), rgba(4, 7, 12, 0.92));
+  background: linear-gradient(180deg, rgba(14, 14, 16$1 0.66), rgba(4, 7, 12, 0.92));
 }
 
 .proof-split__panel--block {
@@ -4797,7 +4795,7 @@ body {
 
 body {
   background:
-    linear-gradient(180deg, rgba(8, 13, 22, 0.9), #02050a 34rem),
+    linear-gradient(180deg, rgba(11, 11, 13$1 0.9), #02050a 34rem),
     #02050a;
 }
 
@@ -4825,7 +4823,7 @@ body::after {
 .doctrine-strip,
 .moon-panel,
 .moon-panel-strong {
-  background-image: linear-gradient(180deg, rgba(8, 13, 22, 0.92), rgba(3, 6, 11, 0.98));
+  background-image: linear-gradient(180deg, rgba(11, 11, 13$1 0.92), rgba(0, 0, 0$1 0.98));
 }
 
 /* Homepage refinement pass: readable story, controlled promotion, quiet boundaries. */
@@ -4876,7 +4874,7 @@ body::after {
   gap: 14px;
   align-items: baseline;
   padding: 12px 14px;
-  background: rgba(8, 13, 22, 0.72);
+  background: rgba(11, 11, 13$1 0.72);
 }
 
 .prior-evidence__metrics strong {
@@ -4991,7 +4989,7 @@ body::after {
   border: 1px solid var(--moon-border);
   border-radius: 6px;
   padding: 14px;
-  background: rgba(3, 6, 11, 0.62);
+  background: rgba(0, 0, 0$1 0.62);
 }
 
 .promotion-system__footer p {
@@ -5030,7 +5028,7 @@ body::after {
 .boundary-drawer {
   border: 1px solid rgba(201, 211, 223, 0.14);
   border-radius: 8px;
-  background: rgba(3, 6, 11, 0.68);
+  background: rgba(0, 0, 0$1 0.68);
 }
 
 .boundary-drawer summary {
@@ -5153,7 +5151,7 @@ body::after {
   padding: 20px 22px;
   border: 1px solid var(--diagram-line);
   border-radius: 10px;
-  background: linear-gradient(180deg, rgba(7, 12, 22, 0.96), rgba(3, 6, 11, 0.98));
+  background: linear-gradient(180deg, rgba(7, 12, 22, 0.96), rgba(0, 0, 0$1 0.98));
   box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.06) inset, 0 24px 56px rgba(0, 0, 0, 0.55);
   font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
   color: var(--silver);
@@ -5175,7 +5173,7 @@ body::after {
   width: 100%;
   border: 1px solid var(--diagram-line);
   border-radius: 14px;
-  background: linear-gradient(180deg, rgba(8, 13, 22, 0.92), rgba(3, 6, 11, 0.98));
+  background: linear-gradient(180deg, rgba(11, 11, 13$1 0.92), rgba(0, 0, 0$1 0.98));
   box-shadow: 0 24px 80px rgba(0, 0, 0, 0.55);
   overflow: hidden;
 }
@@ -5215,7 +5213,7 @@ body::after {
   position: relative;
   border: 1px solid var(--diagram-line);
   border-radius: 14px;
-  background: linear-gradient(180deg, rgba(7, 12, 22, 0.94), rgba(3, 6, 11, 0.98));
+  background: linear-gradient(180deg, rgba(7, 12, 22, 0.94), rgba(0, 0, 0$1 0.98));
   padding: 28px 22px;
 }
 .proof-loop-diagram__svg { width: 100%; height: auto; display: block; max-width: 920px; margin: 0 auto; }
@@ -5229,7 +5227,7 @@ body::after {
   padding: 14px 16px;
   border: 1px solid var(--moon-border);
   border-radius: 10px;
-  background: rgba(8, 13, 22, 0.7);
+  background: rgba(11, 11, 13$1 0.7);
 }
 .proof-loop-diagram__phase {
   font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
@@ -5245,7 +5243,7 @@ body::after {
 .truth-infographic {
   border: 1px solid var(--diagram-line);
   border-radius: 14px;
-  background: linear-gradient(180deg, rgba(7, 12, 22, 0.94), rgba(3, 6, 11, 0.98));
+  background: linear-gradient(180deg, rgba(7, 12, 22, 0.94), rgba(0, 0, 0$1 0.98));
   padding: 22px;
   display: flex;
   flex-direction: column;
@@ -5259,7 +5257,7 @@ body::after {
   padding: 14px 18px;
   border: 1px solid var(--moon-border);
   border-radius: 10px;
-  background: rgba(8, 13, 22, 0.6);
+  background: rgba(11, 11, 13$1 0.6);
   position: relative;
 }
 .truth-infographic__gate {
@@ -5293,7 +5291,7 @@ body::after {
 .repo-dag {
   border: 1px solid var(--diagram-line);
   border-radius: 14px;
-  background: linear-gradient(180deg, rgba(7, 12, 22, 0.94), rgba(3, 6, 11, 0.98));
+  background: linear-gradient(180deg, rgba(7, 12, 22, 0.94), rgba(0, 0, 0$1 0.98));
   padding: 22px;
   overflow: hidden;
 }
@@ -5309,7 +5307,7 @@ body::after {
 .artifact-matrix {
   border: 1px solid var(--diagram-line);
   border-radius: 14px;
-  background: linear-gradient(180deg, rgba(7, 12, 22, 0.94), rgba(3, 6, 11, 0.98));
+  background: linear-gradient(180deg, rgba(7, 12, 22, 0.94), rgba(0, 0, 0$1 0.98));
   padding: 22px;
   overflow-x: auto;
 }
@@ -5324,7 +5322,7 @@ body::after {
 /* Inline row highlight on hover/focus — no floating tooltip. */
 .artifact-matrix__row:hover .artifact-matrix__cell,
 .artifact-matrix__row:focus-within .artifact-matrix__cell {
-  background-color: rgba(15, 22, 36, 0.7);
+  background-color: rgba(18, 18, 22$1 0.7);
   outline: 1px solid rgba(143, 216, 255, 0.18);
   outline-offset: -1px;
 }
@@ -5336,10 +5334,10 @@ body::after {
   font-size: 0.72rem;
   letter-spacing: 0.06em;
   color: var(--muted);
-  background: rgba(8, 13, 22, 0.55);
+  background: rgba(11, 11, 13$1 0.55);
 }
-.artifact-matrix__cell--head { color: var(--electric-blue-bright); text-transform: uppercase; letter-spacing: 0.18em; font-size: 0.62rem; background: rgba(3, 6, 11, 0.8); }
-.artifact-matrix__cell--row-head { color: var(--silver-bright); font-weight: 600; text-transform: none; letter-spacing: 0.02em; font-size: 0.85rem; background: rgba(3, 6, 11, 0.5); }
+.artifact-matrix__cell--head { color: var(--electric-blue-bright); text-transform: uppercase; letter-spacing: 0.18em; font-size: 0.62rem; background: rgba(0, 0, 0$1 0.8); }
+.artifact-matrix__cell--row-head { color: var(--silver-bright); font-weight: 600; text-transform: none; letter-spacing: 0.02em; font-size: 0.85rem; background: rgba(0, 0, 0$1 0.5); }
 .artifact-matrix__cell--filled { color: var(--electric-blue-bright); background: linear-gradient(180deg, rgba(59, 130, 246, 0.22), rgba(59, 130, 246, 0.06)); text-align: center; font-size: 1rem; }
 .artifact-matrix__cell--gated { color: var(--ice-blue); text-align: center; font-size: 1rem; }
 .artifact-matrix__cell--empty { color: var(--muted); text-align: center; }
@@ -5359,7 +5357,7 @@ body::after {
 .review-route-selector__route {
   border: 1px solid var(--diagram-line);
   border-radius: 14px;
-  background: linear-gradient(180deg, rgba(7, 12, 22, 0.94), rgba(3, 6, 11, 0.98));
+  background: linear-gradient(180deg, rgba(7, 12, 22, 0.94), rgba(0, 0, 0$1 0.98));
   padding: 22px;
   display: flex;
   flex-direction: column;
@@ -5378,7 +5376,7 @@ body::after {
 .proof-path-timeline {
   border: 1px solid var(--diagram-line);
   border-radius: 14px;
-  background: linear-gradient(180deg, rgba(7, 12, 22, 0.94), rgba(3, 6, 11, 0.98));
+  background: linear-gradient(180deg, rgba(7, 12, 22, 0.94), rgba(0, 0, 0$1 0.98));
   padding: 28px 22px;
   display: flex;
   flex-direction: column;
@@ -5390,7 +5388,7 @@ body::after {
 .proof-path-timeline__ceiling { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; color: var(--ice-blue); font-size: 0.72rem; letter-spacing: 0.18em; text-transform: uppercase; padding: 6px 10px; border: 1px solid var(--ice-blue-soft); border-radius: 4px; }
 .proof-path-timeline__svg { width: 100%; height: auto; display: block; }
 .proof-path-timeline__rows { display: grid; grid-template-columns: 1fr; gap: 10px; }
-.proof-path-timeline__row { display: grid; grid-template-columns: 44px 200px 1fr auto; gap: 16px; align-items: center; padding: 12px 14px; border: 1px solid var(--moon-border); border-radius: 8px; background: rgba(8, 13, 22, 0.55); }
+.proof-path-timeline__row { display: grid; grid-template-columns: 44px 200px 1fr auto; gap: 16px; align-items: center; padding: 12px 14px; border: 1px solid var(--moon-border); border-radius: 8px; background: rgba(11, 11, 13$1 0.55); }
 .proof-path-timeline__row-num { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; color: var(--electric-blue); font-weight: 700; }
 .proof-path-timeline__row-code { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; color: var(--ice-blue); font-size: 0.72rem; letter-spacing: 0.16em; text-transform: uppercase; }
 .proof-path-timeline__row-text { color: var(--silver); font-size: 0.86rem; line-height: 1.5; }
@@ -5406,7 +5404,7 @@ body::after {
 .claim-firewall-panel {
   border: 1px solid var(--moon-border-bright);
   border-radius: 12px;
-  background: linear-gradient(180deg, rgba(11, 18, 32, 0.92), rgba(3, 6, 11, 0.98));
+  background: linear-gradient(180deg, rgba(11, 18, 32, 0.92), rgba(0, 0, 0$1 0.98));
   padding: 22px;
   display: grid;
   gap: 18px;
@@ -5465,7 +5463,7 @@ body::after {
   border: 1px solid var(--moon-border-bright);
   border-radius: 14px;
   background:
-    linear-gradient(180deg, rgba(15, 22, 36, 0.86), rgba(7, 11, 18, 0.96));
+    linear-gradient(180deg, rgba(18, 18, 22$1 0.86), rgba(10, 10, 12$1 0.96));
   box-shadow:
     0 0 0 1px rgba(143, 216, 255, 0.08) inset,
     0 32px 96px rgba(0, 0, 0, 0.6);
@@ -5526,7 +5524,7 @@ body::after {
   padding: 18px 18px 16px;
   border: 1px solid var(--moon-border);
   border-radius: 12px;
-  background: linear-gradient(180deg, rgba(11, 17, 27, 0.82), rgba(6, 10, 18, 0.94));
+  background: linear-gradient(180deg, rgba(14, 14, 16$1 0.82), rgba(8, 8, 10$1 0.94));
   transition: border-color 200ms ease, box-shadow 200ms ease, transform 200ms ease;
 }
 .claim-route-card:hover {
@@ -5563,7 +5561,7 @@ body::after {
   border: 1px solid rgba(252, 165, 165, 0.28);
   border-left: 3px solid rgba(252, 165, 165, 0.6);
   border-radius: 10px;
-  background: linear-gradient(180deg, rgba(28, 12, 16, 0.4), rgba(7, 11, 18, 0.92));
+  background: linear-gradient(180deg, rgba(28, 12, 16, 0.4), rgba(10, 10, 12$1 0.92));
 }
 .blocked-category__head { display: flex; flex-direction: column; gap: 6px; }
 .blocked-category__title { color: var(--silver-bright); font-weight: 700; font-size: 1.05rem; }
@@ -5583,7 +5581,7 @@ body::after {
   position: relative;
   border: 1px solid var(--moon-border-bright);
   border-radius: 14px;
-  background: linear-gradient(180deg, rgba(15, 22, 36, 0.86), rgba(7, 11, 18, 0.96));
+  background: linear-gradient(180deg, rgba(18, 18, 22$1 0.86), rgba(10, 10, 12$1 0.96));
   box-shadow: 0 0 0 1px rgba(143, 216, 255, 0.08) inset, 0 28px 80px rgba(0, 0, 0, 0.55);
   overflow: hidden;
 }
@@ -5632,7 +5630,7 @@ body::after {
 .gate-ladder__node {
   position: relative; z-index: 1;
   width: 28px; height: 28px; border-radius: 999px;
-  border: 1px solid var(--electric-blue); background: rgba(8, 13, 22, 0.96);
+  border: 1px solid var(--electric-blue); background: rgba(11, 11, 13$1 0.96);
   display: flex; align-items: center; justify-content: center;
   margin-top: 4px; box-shadow: 0 0 16px rgba(59,130,246,0.25);
 }
@@ -5647,18 +5645,18 @@ body::after {
   position: relative;
   display: flex; gap: 10px; flex-wrap: wrap; padding: 14px;
   border: 1px solid var(--moon-border); border-radius: 12px;
-  background: linear-gradient(180deg, rgba(11, 17, 27, 0.7), rgba(6, 10, 18, 0.92));
+  background: linear-gradient(180deg, rgba(14, 14, 16$1 0.7), rgba(8, 8, 10$1 0.92));
   box-shadow: 0 0 0 1px rgba(143, 216, 255, 0.06) inset;
 }
 .vault-shelf__rail { position: absolute; left: 14px; right: 14px; bottom: 0; height: 1px; background: linear-gradient(to right, transparent, var(--diagram-line-strong), transparent); }
 .vault-shelf__slot {
   flex: 1 1 130px; position: relative;
   padding: 10px 12px 12px; border: 1px solid transparent; border-radius: 8px;
-  background: rgba(8, 13, 22, 0.6);
+  background: rgba(11, 11, 13$1 0.6);
   display: flex; flex-direction: column; gap: 4px;
   transition: border-color 180ms ease, background 180ms ease, color 180ms ease, transform 180ms ease;
 }
-.vault-shelf__slot:hover { border-color: var(--moon-border-bright); background: rgba(15, 22, 36, 0.86); transform: translateY(-1px); }
+.vault-shelf__slot:hover { border-color: var(--moon-border-bright); background: rgba(18, 18, 22$1 0.86); transform: translateY(-1px); }
 .vault-shelf__cat { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; font-size: 0.58rem; letter-spacing: 0.2em; text-transform: uppercase; color: var(--ice-blue); }
 .vault-shelf__label { color: var(--silver-bright); font-size: 0.9rem; line-height: 1.3; font-weight: 600; }
 .vault-shelf__count { color: var(--muted); font-size: 0.72rem; }
@@ -5668,7 +5666,7 @@ body::after {
 .anchor-spread {
   position: relative; display: grid; gap: 16px;
   padding: 22px 24px; border: 1px solid var(--moon-border-bright); border-radius: 14px;
-  background: linear-gradient(180deg, rgba(15, 22, 36, 0.86), rgba(7, 11, 18, 0.96));
+  background: linear-gradient(180deg, rgba(18, 18, 22$1 0.86), rgba(10, 10, 12$1 0.96));
   box-shadow: 0 0 0 1px rgba(143, 216, 255, 0.08) inset, 0 32px 96px rgba(0, 0, 0, 0.55);
   transition: transform 200ms ease, border-color 200ms ease, box-shadow 200ms ease;
 }
@@ -5699,7 +5697,7 @@ body::after {
 .record-row {
   display: grid; gap: 12px; grid-template-columns: 1fr;
   padding: 18px 20px; border: 1px solid var(--moon-border); border-radius: 12px;
-  background: linear-gradient(180deg, rgba(11, 17, 27, 0.8), rgba(6, 10, 18, 0.92));
+  background: linear-gradient(180deg, rgba(14, 14, 16$1 0.8), rgba(8, 8, 10$1 0.92));
   transition: border-color 200ms ease, transform 200ms ease, box-shadow 200ms ease;
 }
 .record-row:hover { border-color: var(--moon-border-bright); transform: translateY(-2px); box-shadow: 0 16px 40px rgba(0,0,0,0.4), 0 0 0 1px var(--ice-blue-soft) inset; }
@@ -5714,21 +5712,21 @@ body::after {
 .record-row__meta-value { color: var(--muted); line-height: 1.45; font-size: 0.82rem; }
 
 /* ── Artifacts: receipt conveyor ───────────────────────────────────── */
-.receipt-conveyor { display: grid; gap: 0; grid-template-columns: 1fr; border: 1px solid var(--moon-border); border-radius: 12px; background: linear-gradient(180deg, rgba(11, 17, 27, 0.7), rgba(6, 10, 18, 0.92)); overflow: hidden; }
+.receipt-conveyor { display: grid; gap: 0; grid-template-columns: 1fr; border: 1px solid var(--moon-border); border-radius: 12px; background: linear-gradient(180deg, rgba(14, 14, 16$1 0.7), rgba(8, 8, 10$1 0.92)); overflow: hidden; }
 @media (min-width: 800px) { .receipt-conveyor { grid-template-columns: 1fr 1fr; } }
 @media (min-width: 1100px) { .receipt-conveyor { grid-template-columns: 1fr 1fr 1fr 1fr; } }
 .receipt-conveyor__cell { display: flex; flex-direction: column; gap: 6px; padding: 16px 18px; border-right: 1px solid var(--moon-border); border-bottom: 1px solid var(--moon-border); transition: background 180ms ease, color 180ms ease; }
 .receipt-conveyor__cell:last-child { border-right: 0; }
-.receipt-conveyor__cell:hover { background: rgba(15, 22, 36, 0.7); }
+.receipt-conveyor__cell:hover { background: rgba(18, 18, 22$1 0.7); }
 .receipt-conveyor__cat { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; font-size: 0.58rem; letter-spacing: 0.2em; text-transform: uppercase; color: var(--electric-blue-bright); }
 .receipt-conveyor__title { color: var(--silver-bright); font-weight: 600; font-size: 0.96rem; line-height: 1.3; }
 .receipt-conveyor__desc { color: var(--muted); line-height: 1.5; font-size: 0.82rem; }
 .receipt-conveyor__link { color: var(--ice-blue); font-family: "JetBrains Mono", monospace; font-size: 0.66rem; letter-spacing: 0.16em; text-transform: uppercase; margin-top: 4px; }
 
 /* ── Artifacts: archive isolation strip ────────────────────────────── */
-.archive-strip { position: relative; display: grid; gap: 10px; grid-template-columns: 1fr; padding: 16px 18px; border-top: 1px dashed rgba(201, 211, 223, 0.36); border-bottom: 1px dashed rgba(201, 211, 223, 0.36); background: rgba(8, 13, 22, 0.4); }
+.archive-strip { position: relative; display: grid; gap: 10px; grid-template-columns: 1fr; padding: 16px 18px; border-top: 1px dashed rgba(201, 211, 223, 0.36); border-bottom: 1px dashed rgba(201, 211, 223, 0.36); background: rgba(11, 11, 13$1 0.4); }
 .archive-strip__label { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; font-size: 0.6rem; letter-spacing: 0.22em; text-transform: uppercase; color: var(--muted); }
-.archive-row { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: 10px; padding: 8px 12px; border: 1px dashed var(--moon-border); border-radius: 8px; background: rgba(8, 13, 22, 0.5); color: var(--silver); }
+.archive-row { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: 10px; padding: 8px 12px; border: 1px dashed var(--moon-border); border-radius: 8px; background: rgba(11, 11, 13$1 0.5); color: var(--silver); }
 .archive-row:hover { color: var(--silver-bright); border-color: var(--moon-border-bright); }
 .archive-row__tag { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; font-size: 0.6rem; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ice-blue); }
 
@@ -5738,7 +5736,7 @@ body::after {
 .operator-lane {
   position: relative; display: flex; flex-direction: column; gap: 10px;
   padding: 20px 20px 18px; border: 1px solid var(--moon-border-bright); border-radius: 14px;
-  background: linear-gradient(180deg, rgba(15, 22, 36, 0.86), rgba(7, 11, 18, 0.96)); overflow: hidden;
+  background: linear-gradient(180deg, rgba(18, 18, 22$1 0.86), rgba(10, 10, 12$1 0.96)); overflow: hidden;
 }
 .operator-lane::before { content: ""; position: absolute; left: 0; top: 18%; bottom: 18%; width: 2px; background: linear-gradient(to bottom, var(--electric-blue), var(--ice-blue)); }
 .operator-lane__eyebrow { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; font-size: 0.62rem; letter-spacing: 0.2em; text-transform: uppercase; color: var(--ice-blue); }
@@ -5751,15 +5749,15 @@ body::after {
 .operator-lane__note { color: var(--muted); font-size: 0.86rem; line-height: 1.55; margin-top: 6px; }
 
 /* ── About: methodology translation map ────────────────────────────── */
-.translation-map { position: relative; display: grid; gap: 0; grid-template-columns: 1fr; border: 1px solid var(--moon-border-bright); border-radius: 14px; background: linear-gradient(180deg, rgba(15, 22, 36, 0.86), rgba(7, 11, 18, 0.96)); overflow: hidden; }
-.translation-map__head { display: grid; grid-template-columns: 1fr 28px 1fr 1.2fr; align-items: center; gap: 10px; padding: 12px 18px; border-bottom: 1px solid var(--moon-border); background: rgba(8, 13, 22, 0.6); }
+.translation-map { position: relative; display: grid; gap: 0; grid-template-columns: 1fr; border: 1px solid var(--moon-border-bright); border-radius: 14px; background: linear-gradient(180deg, rgba(18, 18, 22$1 0.86), rgba(10, 10, 12$1 0.96)); overflow: hidden; }
+.translation-map__head { display: grid; grid-template-columns: 1fr 28px 1fr 1.2fr; align-items: center; gap: 10px; padding: 12px 18px; border-bottom: 1px solid var(--moon-border); background: rgba(11, 11, 13$1 0.6); }
 .translation-map__head-cell,
 .translation-map__head-spacer { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; font-size: 0.6rem; letter-spacing: 0.2em; text-transform: uppercase; color: var(--muted); }
 .translation-map__row { display: grid; grid-template-columns: 1fr 28px 1fr 1.2fr; align-items: center; gap: 10px; padding: 14px 18px; border-bottom: 1px solid var(--moon-border); }
 .translation-map__row:last-child { border-bottom: 0; }
-.translation-map__row:hover { background: rgba(15, 22, 36, 0.6); }
+.translation-map__row:hover { background: rgba(18, 18, 22$1 0.6); }
 .translation-map__left { color: var(--silver); font-size: 0.94rem; }
-.translation-map__arrow { width: 28px; height: 28px; border: 1px solid var(--electric-blue); border-radius: 999px; display: flex; align-items: center; justify-content: center; color: var(--electric-blue-bright); font-family: "JetBrains Mono", monospace; font-size: 0.86rem; background: rgba(8, 13, 22, 0.94); box-shadow: 0 0 12px rgba(59,130,246,0.2); }
+.translation-map__arrow { width: 28px; height: 28px; border: 1px solid var(--electric-blue); border-radius: 999px; display: flex; align-items: center; justify-content: center; color: var(--electric-blue-bright); font-family: "JetBrains Mono", monospace; font-size: 0.86rem; background: rgba(11, 11, 13$1 0.94); box-shadow: 0 0 12px rgba(59,130,246,0.2); }
 .translation-map__right { color: var(--silver-bright); font-weight: 600; font-size: 0.96rem; }
 .translation-map__note { color: var(--muted); font-size: 0.82rem; line-height: 1.45; }
 @media (max-width: 700px) {
@@ -5771,7 +5769,7 @@ body::after {
 }
 
 /* ── About: AI governance flow diagram ─────────────────────────────── */
-.ai-flow { position: relative; display: grid; gap: 18px; grid-template-columns: 1fr; padding: 22px 24px; border: 1px solid var(--moon-border-bright); border-radius: 14px; background: linear-gradient(180deg, rgba(15, 22, 36, 0.86), rgba(7, 11, 18, 0.96)); box-shadow: 0 0 0 1px rgba(143, 216, 255, 0.08) inset, 0 28px 80px rgba(0, 0, 0, 0.55); overflow: hidden; }
+.ai-flow { position: relative; display: grid; gap: 18px; grid-template-columns: 1fr; padding: 22px 24px; border: 1px solid var(--moon-border-bright); border-radius: 14px; background: linear-gradient(180deg, rgba(18, 18, 22$1 0.86), rgba(10, 10, 12$1 0.96)); box-shadow: 0 0 0 1px rgba(143, 216, 255, 0.08) inset, 0 28px 80px rgba(0, 0, 0, 0.55); overflow: hidden; }
 .ai-flow::before { content: ""; position: absolute; inset: 0; background: radial-gradient(120% 110% at 100% 0%, rgba(59,130,246,0.10), transparent 55%); pointer-events: none; }
 @media (min-width: 900px) { .ai-flow { grid-template-columns: 1fr 1.1fr; align-items: center; } }
 .ai-flow__copy { position: relative; }
@@ -5784,7 +5782,7 @@ body::after {
 /* ── About: opposing is/is-not panels ──────────────────────────────── */
 .boundary-panels { display: grid; gap: 12px; grid-template-columns: 1fr; }
 @media (min-width: 900px) { .boundary-panels { grid-template-columns: 1fr 1fr; } }
-.boundary-panel { position: relative; padding: 22px 24px; border: 1px solid var(--moon-border-bright); border-radius: 14px; background: linear-gradient(180deg, rgba(15, 22, 36, 0.86), rgba(7, 11, 18, 0.96)); }
+.boundary-panel { position: relative; padding: 22px 24px; border: 1px solid var(--moon-border-bright); border-radius: 14px; background: linear-gradient(180deg, rgba(18, 18, 22$1 0.86), rgba(10, 10, 12$1 0.96)); }
 .boundary-panel--is { border-left: 3px solid var(--electric-blue); }
 .boundary-panel--isnot { border-left: 3px solid var(--blocked-red); }
 .boundary-panel__title { color: var(--silver-bright); font-size: 1.3rem; font-weight: 700; margin-top: 6px; }
@@ -5795,11 +5793,11 @@ body::after {
 .boundary-panel--isnot .boundary-panel__item::before { background: var(--blocked-red); box-shadow: 0 0 8px rgba(252, 165, 165, 0.5); }
 
 /* ── About: route dock ─────────────────────────────────────────────── */
-.route-dock { display: grid; gap: 0; grid-template-columns: 1fr; border: 1px solid var(--moon-border); border-radius: 12px; background: linear-gradient(180deg, rgba(11, 17, 27, 0.78), rgba(6, 10, 18, 0.92)); overflow: hidden; }
+.route-dock { display: grid; gap: 0; grid-template-columns: 1fr; border: 1px solid var(--moon-border); border-radius: 12px; background: linear-gradient(180deg, rgba(14, 14, 16$1 0.78), rgba(8, 8, 10$1 0.92)); overflow: hidden; }
 @media (min-width: 700px) { .route-dock { grid-template-columns: 1fr 1fr; } }
 @media (min-width: 1100px) { .route-dock { grid-template-columns: repeat(4, 1fr); } }
 .route-dock__slot { position: relative; display: flex; flex-direction: column; gap: 6px; padding: 16px 18px; border-right: 1px solid var(--moon-border); border-bottom: 1px solid var(--moon-border); transition: background 180ms ease, color 180ms ease; }
-.route-dock__slot:hover { background: rgba(15, 22, 36, 0.7); }
+.route-dock__slot:hover { background: rgba(18, 18, 22$1 0.7); }
 .route-dock__slot:last-child { border-right: 0; }
 .route-dock__cat { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; font-size: 0.6rem; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ice-blue); }
 .route-dock__label { color: var(--silver-bright); font-weight: 700; font-size: 1rem; }
@@ -5815,7 +5813,7 @@ body::after {
 .metric-clusters { display: grid; gap: 14px; grid-template-columns: 1fr; }
 @media (min-width: 800px) { .metric-clusters { grid-template-columns: 1fr 1fr; } }
 @media (min-width: 1100px) { .metric-clusters { grid-template-columns: repeat(4, 1fr); } }
-.metric-cluster { position: relative; display: flex; flex-direction: column; gap: 8px; padding: 18px 18px 16px; border: 1px solid var(--moon-border-bright); border-radius: 12px; background: linear-gradient(180deg, rgba(15, 22, 36, 0.86), rgba(7, 11, 18, 0.96)); overflow: hidden; }
+.metric-cluster { position: relative; display: flex; flex-direction: column; gap: 8px; padding: 18px 18px 16px; border: 1px solid var(--moon-border-bright); border-radius: 12px; background: linear-gradient(180deg, rgba(18, 18, 22$1 0.86), rgba(10, 10, 12$1 0.96)); overflow: hidden; }
 .metric-cluster::before { content: ""; position: absolute; left: 0; top: 18%; bottom: 18%; width: 2px; background: var(--electric-blue-bright); }
 .metric-cluster--block::before { background: var(--blocked-red); }
 .metric-cluster__eyebrow { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; font-size: 0.6rem; letter-spacing: 0.2em; text-transform: uppercase; color: var(--ice-blue); }
@@ -5828,13 +5826,13 @@ body::after {
 .metric-cluster__label { color: var(--muted); font-size: 0.78rem; line-height: 1.4; text-align: right; }
 
 /* Pipeline machine strip variant */
-.pipeline-machine { position: relative; border: 1px solid var(--moon-border-bright); border-radius: 14px; background: linear-gradient(180deg, rgba(15, 22, 36, 0.86), rgba(7, 11, 18, 0.96)); box-shadow: 0 0 0 1px rgba(143, 216, 255, 0.08) inset, 0 28px 80px rgba(0, 0, 0, 0.55); padding: 18px; overflow: hidden; }
+.pipeline-machine { position: relative; border: 1px solid var(--moon-border-bright); border-radius: 14px; background: linear-gradient(180deg, rgba(18, 18, 22$1 0.86), rgba(10, 10, 12$1 0.96)); box-shadow: 0 0 0 1px rgba(143, 216, 255, 0.08) inset, 0 28px 80px rgba(0, 0, 0, 0.55); padding: 18px; overflow: hidden; }
 .pipeline-machine__viewport { overflow-x: auto; overflow-y: hidden; -webkit-overflow-scrolling: touch; }
 .pipeline-machine__stages { list-style: none; margin: 0; padding: 4px 4px 8px; display: flex; gap: 14px; min-width: max-content; }
-.pipeline-machine__stage { position: relative; flex: 0 0 220px; display: flex; flex-direction: column; gap: 8px; padding: 14px 16px; border: 1px solid var(--moon-border); border-radius: 10px; background: linear-gradient(180deg, rgba(13, 19, 30, 0.86), rgba(7, 11, 18, 0.96)); color: var(--silver); transition: border-color 200ms ease, transform 200ms ease; }
+.pipeline-machine__stage { position: relative; flex: 0 0 220px; display: flex; flex-direction: column; gap: 8px; padding: 14px 16px; border: 1px solid var(--moon-border); border-radius: 10px; background: linear-gradient(180deg, rgba(16, 16, 18$1 0.86), rgba(10, 10, 12$1 0.96)); color: var(--silver); transition: border-color 200ms ease, transform 200ms ease; }
 .pipeline-machine__stage:hover { border-color: var(--moon-border-bright); transform: translateY(-2px); }
-.pipeline-machine__stage--final { border-color: var(--silver-bright); background: linear-gradient(180deg, rgba(22, 30, 46, 0.92), rgba(7, 11, 18, 0.98)); }
-.pipeline-machine__stage--block { border-color: rgba(252, 165, 165, 0.42); background: linear-gradient(180deg, rgba(28, 12, 16, 0.55), rgba(7, 11, 18, 0.92)); }
+.pipeline-machine__stage--final { border-color: var(--silver-bright); background: linear-gradient(180deg, rgba(22, 30, 46, 0.92), rgba(10, 10, 12$1 0.98)); }
+.pipeline-machine__stage--block { border-color: rgba(252, 165, 165, 0.42); background: linear-gradient(180deg, rgba(28, 12, 16, 0.55), rgba(10, 10, 12$1 0.92)); }
 .pipeline-machine__stage::after { content: "→"; position: absolute; right: -14px; top: 50%; transform: translateY(-50%); color: var(--electric-blue-bright); font-family: "JetBrains Mono", monospace; font-size: 1rem; }
 .pipeline-machine__stage:last-child::after { content: ""; }
 .pipeline-machine__num { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; font-size: 0.62rem; letter-spacing: 0.2em; color: var(--electric-blue-bright); }
@@ -5851,7 +5849,7 @@ body::after {
 /* Pipeline: receipt route lanes */
 .receipt-lanes { display: grid; gap: 14px; grid-template-columns: 1fr; }
 @media (min-width: 900px) { .receipt-lanes { grid-template-columns: 1fr 1fr; } }
-.receipt-lane { position: relative; display: flex; flex-direction: column; gap: 4px; padding: 14px 18px; border: 1px solid var(--moon-border); border-radius: 10px; background: linear-gradient(180deg, rgba(11, 17, 27, 0.82), rgba(6, 10, 18, 0.94)); transition: border-color 180ms ease, transform 180ms ease, box-shadow 180ms ease; }
+.receipt-lane { position: relative; display: flex; flex-direction: column; gap: 4px; padding: 14px 18px; border: 1px solid var(--moon-border); border-radius: 10px; background: linear-gradient(180deg, rgba(14, 14, 16$1 0.82), rgba(8, 8, 10$1 0.94)); transition: border-color 180ms ease, transform 180ms ease, box-shadow 180ms ease; }
 .receipt-lane:hover { border-color: var(--moon-border-bright); transform: translateY(-2px); box-shadow: 0 16px 36px rgba(0,0,0,0.4), 0 0 0 1px var(--ice-blue-soft) inset; }
 .receipt-lane__route { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; font-size: 0.58rem; letter-spacing: 0.2em; text-transform: uppercase; color: var(--electric-blue-bright); }
 .receipt-lane__title { color: var(--silver-bright); font-weight: 700; font-size: 1rem; }
@@ -5859,7 +5857,7 @@ body::after {
 .receipt-lane__inspect { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; color: var(--ice-blue); letter-spacing: 0.16em; text-transform: uppercase; font-size: 0.66rem; margin-top: 6px; }
 
 /* Pipeline: reviewer takeaway final panel */
-.reviewer-takeaway { position: relative; padding: 28px 28px 24px; border: 1px solid var(--moon-border-bright); border-radius: 14px; background: linear-gradient(180deg, rgba(15, 22, 36, 0.9), rgba(7, 11, 18, 0.97)); box-shadow: 0 0 0 1px rgba(143, 216, 255, 0.08) inset, 0 32px 96px rgba(0, 0, 0, 0.6); overflow: hidden; }
+.reviewer-takeaway { position: relative; padding: 28px 28px 24px; border: 1px solid var(--moon-border-bright); border-radius: 14px; background: linear-gradient(180deg, rgba(18, 18, 22$1 0.9), rgba(10, 10, 12$1 0.97)); box-shadow: 0 0 0 1px rgba(143, 216, 255, 0.08) inset, 0 32px 96px rgba(0, 0, 0, 0.6); overflow: hidden; }
 .reviewer-takeaway::before { content: ""; position: absolute; left: 0; top: 16%; bottom: 16%; width: 3px; background: linear-gradient(to bottom, var(--electric-blue), var(--ice-blue)); }
 .reviewer-takeaway__eyebrow { font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace; font-size: 0.66rem; letter-spacing: 0.22em; text-transform: uppercase; color: var(--ice-blue); }
 .reviewer-takeaway__title { color: var(--silver-bright); font-size: 1.45rem; font-weight: 700; line-height: 1.25; margin-top: 8px; }
@@ -5872,7 +5870,7 @@ body::after {
   padding: 24px 26px 22px;
   border: 1px solid var(--moon-border-bright);
   border-radius: 14px;
-  background: linear-gradient(180deg, rgba(15, 22, 36, 0.92), rgba(7, 11, 18, 0.98));
+  background: linear-gradient(180deg, rgba(18, 18, 22$1 0.92), rgba(10, 10, 12$1 0.98));
   box-shadow: 0 0 0 1px rgba(143, 216, 255, 0.08) inset, 0 32px 80px rgba(0, 0, 0, 0.55);
   overflow: hidden;
 }
@@ -5938,7 +5936,7 @@ body::after {
   padding: 12px 14px;
   border: 1px solid var(--moon-border);
   border-radius: 10px;
-  background: linear-gradient(180deg, rgba(11, 17, 27, 0.82), rgba(6, 10, 18, 0.94));
+  background: linear-gradient(180deg, rgba(14, 14, 16$1 0.82), rgba(8, 8, 10$1 0.94));
 }
 .proof-pack-console__cell dt {
   font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
@@ -5977,7 +5975,7 @@ body::after {
   padding: 6px;
   border: 1px solid var(--moon-border-bright);
   border-radius: 14px;
-  background: linear-gradient(180deg, rgba(15, 22, 36, 0.86), rgba(7, 11, 18, 0.96));
+  background: linear-gradient(180deg, rgba(18, 18, 22$1 0.86), rgba(10, 10, 12$1 0.96));
   box-shadow: 0 0 0 1px rgba(143, 216, 255, 0.06) inset, 0 30px 80px rgba(0, 0, 0, 0.55);
   overflow-x: auto;
 }
@@ -6007,7 +6005,7 @@ body::after {
 }
 .coverage-matrix__row:hover {
   border-color: var(--moon-border-bright);
-  background: rgba(15, 22, 36, 0.5);
+  background: rgba(18, 18, 22$1 0.5);
 }
 .coverage-matrix__family {
   color: var(--silver-bright);
@@ -6027,7 +6025,7 @@ body::after {
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--silver);
-  background: rgba(11, 17, 27, 0.6);
+  background: rgba(14, 14, 16$1 0.6);
 }
 .coverage-matrix__cell--present {
   color: var(--silver-bright);
@@ -6074,7 +6072,7 @@ body::after {
 .coverage-matrix__cell--reference {
   color: var(--silver);
   border-color: var(--moon-border);
-  background: rgba(15, 22, 36, 0.55);
+  background: rgba(18, 18, 22$1 0.55);
 }
 .coverage-matrix__cell[data-value="—"] {
   border-style: dashed;
@@ -6144,7 +6142,7 @@ body::after {
   border: 1px solid var(--moon-border-bright);
   border-top: 1.5px solid var(--ice-blue);
   border-bottom: 1.5px solid var(--ice-blue);
-  background: rgba(3, 6, 11, 0.6);
+  background: rgba(0, 0, 0$1 0.6);
   font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
   font-size: 0.78rem;
   font-weight: 700;
@@ -6167,7 +6165,7 @@ body::after {
   color: var(--silver);
   transition: background 160ms ease;
 }
-.ledger-row:hover { background: rgba(15, 22, 36, 0.6); }
+.ledger-row:hover { background: rgba(18, 18, 22$1 0.6); }
 .ledger-row__date { color: var(--electric-blue-bright); letter-spacing: 0.12em; }
 .ledger-row__repo {
   color: var(--silver);
@@ -6244,8 +6242,8 @@ body::after {
   border: 1px solid rgba(252, 165, 165, 0.32);
   border-radius: 10px;
   background:
-    linear-gradient(180deg, rgba(252, 165, 165, 0.04), rgba(3, 6, 11, 0)),
-    rgba(11, 17, 28, 0.65);
+    linear-gradient(180deg, rgba(252, 165, 165, 0.04), rgba(0, 0, 0$1 0)),
+    rgba(14, 14, 16$1 0.65);
   padding: 1.8rem;
 }
 .failure-strip__head {
@@ -6287,9 +6285,9 @@ body::after {
     repeating-linear-gradient(
       135deg,
       rgba(143, 216, 255, 0.06) 0 8px,
-      rgba(3, 6, 11, 0) 8px 16px
+      rgba(0, 0, 0$1 0) 8px 16px
     ),
-    rgba(8, 13, 22, 0.85);
+    rgba(11, 11, 13$1 0.85);
 }
 .failure-strip__footer-stamp {
   font-family: "JetBrains Mono", monospace;
@@ -6327,13 +6325,13 @@ body::after {
   padding: 1rem 1.2rem;
   border: 1px solid var(--moon-border);
   border-radius: 8px;
-  background: rgba(11, 17, 28, 0.65);
+  background: rgba(14, 14, 16$1 0.65);
 }
 .promo-ladder__rung--top {
   border-color: var(--ceiling-amber);
   background:
     linear-gradient(180deg, rgba(224, 189, 99, 0.08), transparent),
-    rgba(11, 17, 28, 0.85);
+    rgba(14, 14, 16$1 0.85);
 }
 .promo-ladder__rung-num {
   font-family: "JetBrains Mono", monospace;
@@ -6397,7 +6395,7 @@ body::after {
   padding: 1rem 1.1rem;
   border: 1px solid var(--moon-border);
   border-radius: 8px;
-  background: rgba(11, 17, 28, 0.7);
+  background: rgba(14, 14, 16$1 0.7);
 }
 .promo-ladder__card--rule { border-color: var(--ceiling-amber-soft); }
 .promo-ladder__card--prev { border-color: rgba(252, 165, 165, 0.32); }
@@ -6418,7 +6416,7 @@ body::after {
   overflow-x: auto;
   border: 1px solid var(--moon-border);
   border-radius: 10px;
-  background: rgba(11, 17, 28, 0.6);
+  background: rgba(14, 14, 16$1 0.6);
 }
 .truth-matrix__table {
   width: 100%;
@@ -6440,7 +6438,7 @@ body::after {
   text-transform: uppercase;
   font-size: 0.66rem;
   text-align: center;
-  background: rgba(8, 13, 22, 0.7);
+  background: rgba(11, 11, 13$1 0.7);
   position: sticky;
   top: 0;
 }
@@ -6470,7 +6468,7 @@ body::after {
   gap: 0.7rem 1.4rem;
   padding: 1rem 1.2rem;
   border-top: 1px solid var(--moon-border);
-  background: rgba(8, 13, 22, 0.5);
+  background: rgba(11, 11, 13$1 0.5);
   font-family: "JetBrains Mono", monospace;
   font-size: 0.7rem;
   letter-spacing: 0.1em;
@@ -6482,7 +6480,7 @@ body::after {
 .activity-ledger {
   border: 1px solid var(--moon-border);
   border-radius: 10px;
-  background: rgba(11, 17, 28, 0.6);
+  background: rgba(14, 14, 16$1 0.6);
 }
 .activity-ledger__head {
   display: flex;
@@ -6537,7 +6535,7 @@ body::after {
   gap: 0.8rem;
   padding: 1rem 1.4rem;
   border-top: 1px solid var(--moon-border);
-  background: rgba(8, 13, 22, 0.5);
+  background: rgba(11, 11, 13$1 0.5);
 }
 .activity-ledger__foot-note {
   color: var(--muted);
@@ -6674,7 +6672,7 @@ body::after {
   border-radius: 12px;
   background:
     radial-gradient(120% 100% at 100% 0%, rgba(143, 216, 255, 0.06), transparent 60%),
-    linear-gradient(180deg, rgba(15, 22, 36, 0.92), rgba(3, 6, 11, 0.96));
+    linear-gradient(180deg, rgba(18, 18, 22$1 0.92), rgba(0, 0, 0$1 0.96));
   box-shadow: 0 28px 80px rgba(0, 0, 0, 0.55), 0 0 0 1px rgba(143, 216, 255, 0.06) inset;
   overflow: hidden;
 }
@@ -6781,7 +6779,7 @@ body::after {
   border-top: 2px solid var(--electric-blue);
   border-radius: 10px;
   background:
-    linear-gradient(180deg, rgba(15, 22, 36, 0.82), rgba(3, 6, 11, 0.95));
+    linear-gradient(180deg, rgba(18, 18, 22$1 0.82), rgba(0, 0, 0$1 0.95));
   transition: transform 200ms ease, border-color 200ms ease, box-shadow 220ms ease;
 }
 .prevention-card:hover {
@@ -6868,7 +6866,7 @@ body::after {
   margin-top: 0.6rem;
   padding: 0.8rem 1rem;
   border-left: 2px solid var(--electric-blue);
-  background: rgba(8, 13, 22, 0.7);
+  background: rgba(11, 11, 13$1 0.7);
   border-radius: 0 4px 4px 0;
   font-size: 0.88rem;
   line-height: 1.55;
@@ -6949,12 +6947,12 @@ body::after {
   transition: background 140ms ease;
 }
 .truth-matrix__table tbody tr:hover {
-  background: rgba(15, 22, 36, 0.6);
+  background: rgba(18, 18, 22$1 0.6);
 }
 .truth-matrix__details {
   border-top: 1px solid var(--moon-border);
   padding: 1rem 1.2rem 1.2rem;
-  background: rgba(8, 13, 22, 0.55);
+  background: rgba(11, 11, 13$1 0.55);
 }
 .truth-matrix__details-grid {
   display: grid;
@@ -6966,7 +6964,7 @@ body::after {
   padding: 0.7rem 0.9rem;
   border: 1px solid var(--moon-border);
   border-radius: 4px;
-  background: rgba(11, 17, 28, 0.7);
+  background: rgba(14, 14, 16$1 0.7);
   font-family: "JetBrains Mono", monospace;
   font-size: 0.74rem;
   letter-spacing: 0.04em;
@@ -6977,7 +6975,7 @@ body::after {
 /* Activity ledger row hover route emphasis */
 .ledger-row { transition: background 140ms ease, box-shadow 200ms ease; }
 .ledger-row:hover {
-  background: rgba(15, 22, 36, 0.7);
+  background: rgba(18, 18, 22$1 0.7);
   box-shadow: inset 4px 0 0 var(--electric-blue);
 }
 .ledger-row__title { transition: color 140ms ease; }
@@ -7076,7 +7074,7 @@ body::after {
   background:
     radial-gradient(120% 100% at 100% 0%, rgba(143, 216, 255, 0.08), transparent 60%),
     radial-gradient(60% 60% at 50% 100%, rgba(59, 130, 246, 0.08), transparent 70%),
-    linear-gradient(180deg, rgba(15, 22, 36, 0.94), rgba(3, 6, 11, 0.98));
+    linear-gradient(180deg, rgba(18, 18, 22$1 0.94), rgba(0, 0, 0$1 0.98));
   box-shadow:
     0 32px 100px rgba(0, 0, 0, 0.65),
     0 0 0 1px rgba(143, 216, 255, 0.08) inset,
@@ -7197,7 +7195,7 @@ body::after {
   border: 1px dashed var(--moon-border);
   border-left: 3px solid var(--ice-blue);
   border-radius: 4px;
-  background: rgba(8, 13, 22, 0.55);
+  background: rgba(11, 11, 13$1 0.55);
   font-size: 0.92rem;
   line-height: 1.5;
   color: var(--silver);
@@ -7309,7 +7307,7 @@ body::after {
   width: 1.1rem;
   height: 1.1rem;
   border-radius: 50%;
-  background: rgba(3, 6, 11, 0.95);
+  background: rgba(0, 0, 0$1 0.95);
   border: 2px solid var(--electric-blue);
   box-shadow: 0 0 12px rgba(59, 130, 246, 0.4);
 }
@@ -7352,7 +7350,7 @@ body::after {
   padding: 1rem 1.1rem;
   border: 1px solid var(--moon-border);
   border-radius: 8px;
-  background: rgba(11, 17, 28, 0.7);
+  background: rgba(14, 14, 16$1 0.7);
   margin-bottom: 0.7rem;
 }
 .truth-matrix__mobile-card-id {
@@ -7428,7 +7426,7 @@ body::after {
 .rga {
   border: 1px solid var(--moon-border);
   border-radius: 10px;
-  background: rgba(11, 17, 28, 0.6);
+  background: rgba(14, 14, 16$1 0.6);
 }
 .rga__head {
   display: flex;
@@ -7487,7 +7485,7 @@ body::after {
   position: relative;
   border: 1px solid var(--moon-border);
   border-radius: 8px;
-  background: linear-gradient(180deg, rgba(15, 22, 36, 0.85), rgba(3, 6, 11, 0.96));
+  background: linear-gradient(180deg, rgba(18, 18, 22$1 0.85), rgba(0, 0, 0$1 0.96));
   transition: transform 200ms ease, border-color 200ms ease, box-shadow 220ms ease;
 }
 .rga__card:hover {
@@ -7568,7 +7566,7 @@ body::after {
   gap: 0.8rem;
   padding: 1rem 1.4rem;
   border-top: 1px solid var(--moon-border);
-  background: rgba(8, 13, 22, 0.5);
+  background: rgba(11, 11, 13$1 0.5);
 }
 .rga__foot-note {
   color: var(--muted);
@@ -7605,7 +7603,7 @@ body::after {
   padding: 0.9rem 1.1rem;
   border: 1px solid var(--moon-border-bright);
   border-radius: 4px;
-  background: rgba(11, 17, 28, 0.7);
+  background: rgba(14, 14, 16$1 0.7);
   font-family: "JetBrains Mono", monospace;
   font-size: 0.7rem;
   letter-spacing: 0.12em;
@@ -7627,7 +7625,7 @@ body::after {
   border: 1px solid var(--moon-border);
   border-top: 3px solid var(--electric-blue);
   border-radius: 8px;
-  background: linear-gradient(180deg, rgba(15, 22, 36, 0.85), rgba(3, 6, 11, 0.95));
+  background: linear-gradient(180deg, rgba(18, 18, 22$1 0.85), rgba(0, 0, 0$1 0.95));
   transition: transform 200ms ease, box-shadow 200ms ease;
 }
 .artifact-review__field:hover { transform: translateY(-2px); box-shadow: 0 14px 36px rgba(0,0,0,0.45), var(--route-glow); }
@@ -7656,8 +7654,8 @@ body::after {
   border-left: 4px solid var(--ceiling-amber);
   border-radius: 8px;
   background:
-    linear-gradient(180deg, rgba(224, 189, 99, 0.05), rgba(3, 6, 11, 0)),
-    rgba(11, 17, 28, 0.8);
+    linear-gradient(180deg, rgba(224, 189, 99, 0.05), rgba(0, 0, 0$1 0)),
+    rgba(14, 14, 16$1 0.8);
 }
 .artifact-review__boundary-label {
   font-family: "JetBrains Mono", monospace;
@@ -7710,7 +7708,7 @@ body::after {
   border: 1px solid var(--moon-border);
   border-top: 2px solid var(--electric-blue);
   border-radius: 10px;
-  background: linear-gradient(180deg, rgba(15, 22, 36, 0.85), rgba(3, 6, 11, 0.95));
+  background: linear-gradient(180deg, rgba(18, 18, 22$1 0.85), rgba(0, 0, 0$1 0.95));
   transition: transform 200ms ease, box-shadow 200ms ease, border-color 200ms ease;
   text-decoration: none;
   color: inherit;
@@ -7771,7 +7769,7 @@ body::after {
   border-radius: 10px;
   background:
     radial-gradient(80% 60% at 50% 0%, rgba(59, 130, 246, 0.08), transparent 60%),
-    linear-gradient(180deg, rgba(15, 22, 36, 0.9), rgba(3, 6, 11, 0.97));
+    linear-gradient(180deg, rgba(18, 18, 22$1 0.9), rgba(0, 0, 0$1 0.97));
   box-shadow: 0 26px 80px rgba(0, 0, 0, 0.5);
 }
 .gate-flow__svg-wrap { overflow-x: auto; }
@@ -7801,7 +7799,7 @@ body::after {
   padding: 0.7rem 0.9rem;
   border: 1px solid var(--moon-border);
   border-radius: 4px;
-  background: rgba(8, 13, 22, 0.85);
+  background: rgba(11, 11, 13$1 0.85);
 }
 .gate-flow__node > summary {
   display: inline-flex; align-items: center; gap: 0.5rem;
@@ -7832,7 +7830,7 @@ body::after {
   border: 1px solid var(--moon-border);
   border-top: 2px solid var(--electric-blue);
   border-radius: 10px;
-  background: linear-gradient(180deg, rgba(15, 22, 36, 0.85), rgba(3, 6, 11, 0.95));
+  background: linear-gradient(180deg, rgba(18, 18, 22$1 0.85), rgba(0, 0, 0$1 0.95));
   transition: transform 200ms ease, box-shadow 220ms ease, border-color 200ms ease;
 }
 .gh-gate-card:hover {
@@ -7894,7 +7892,7 @@ body::after {
   border-radius: 10px;
   background:
     radial-gradient(80% 60% at 100% 0%, rgba(224, 189, 99, 0.07), transparent 60%),
-    linear-gradient(180deg, rgba(15, 22, 36, 0.9), rgba(3, 6, 11, 0.97));
+    linear-gradient(180deg, rgba(18, 18, 22$1 0.9), rgba(0, 0, 0$1 0.97));
   box-shadow: 0 22px 70px rgba(0, 0, 0, 0.5);
 }
 .gpu-lane__head {
@@ -7953,7 +7951,7 @@ body::after {
   padding: 1rem 1.1rem 1.05rem;
   border: 1px solid var(--moon-border);
   border-radius: 8px;
-  background: linear-gradient(180deg, rgba(15, 22, 36, 0.92), rgba(3, 6, 11, 0.98));
+  background: linear-gradient(180deg, rgba(18, 18, 22$1 0.92), rgba(0, 0, 0$1 0.98));
   color: inherit;
   text-decoration: none;
   display: block;
@@ -8034,7 +8032,7 @@ body::after {
   padding: 1.4rem 1.3rem 1.3rem;
   border: 1px solid var(--moon-border);
   border-radius: 10px;
-  background: linear-gradient(180deg, rgba(15, 22, 36, 0.85), rgba(3, 6, 11, 0.95));
+  background: linear-gradient(180deg, rgba(18, 18, 22$1 0.85), rgba(0, 0, 0$1 0.95));
   transition: transform 200ms ease, border-color 200ms ease, box-shadow 220ms ease;
 }
 .v1-v2__card:hover,
@@ -8110,7 +8108,7 @@ body::after {
   padding: 1.4rem 1.4rem 1.4rem;
   border: 1px solid var(--moon-border-bright);
   border-radius: 10px;
-  background: linear-gradient(180deg, rgba(15, 22, 36, 0.85), rgba(3, 6, 11, 0.95));
+  background: linear-gradient(180deg, rgba(18, 18, 22$1 0.85), rgba(0, 0, 0$1 0.95));
 }
 @media (max-width: 760px) { .operator-profile { grid-template-columns: 1fr; } }
 .operator-profile__eyebrow {
@@ -8212,7 +8210,7 @@ body::after {
   font-size: 0.72rem;
   letter-spacing: 0.12em;
   font-weight: 600;
-  background: rgba(8, 13, 22, 0.85);
+  background: rgba(11, 11, 13$1 0.85);
   border: 1px solid rgba(96, 165, 250, 0.35);
   color: var(--silver-bright);
 }
@@ -8489,7 +8487,7 @@ body::after {
   border: 1px solid var(--moon-border);
   border-left: 3px solid var(--blocked-red);
   border-radius: 8px;
-  background: linear-gradient(180deg, rgba(11, 17, 27, 0.7), rgba(7, 11, 18, 0.86));
+  background: linear-gradient(180deg, rgba(14, 14, 16$1 0.7), rgba(10, 10, 12$1 0.86));
   padding: 14px 14px 16px;
   display: flex;
   flex-direction: column;
@@ -8598,7 +8596,7 @@ body::after {
   margin-top: 18px;
   border: 1px dashed var(--moon-border);
   border-radius: 10px;
-  background: rgba(7, 11, 18, 0.5);
+  background: rgba(10, 10, 12$1 0.5);
   padding: 14px 16px;
 }
 .operator-stack__eyebrow {
@@ -8625,5 +8623,5 @@ body::after {
   padding: 6px 10px;
   border: 1px solid var(--moon-border);
   border-radius: 999px;
-  background: rgba(13, 19, 30, 0.6);
+  background: rgba(16, 16, 18$1 0.6);
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from "next";
+import BackgroundDepth from "@components/BackgroundDepth";
 import Header from "@components/Header";
 import Footer from "@components/Footer";
 import "./globals.css";
@@ -52,13 +53,13 @@ export const metadata: Metadata = {
     images: [socialImage],
   },
   other: {
-    "msapplication-TileColor": "#000205",
+    "msapplication-TileColor": "#000000",
     "apple-mobile-web-app-title": "HawkinsOperations",
   },
 };
 
 export const viewport: Viewport = {
-  themeColor: "#000205",
+  themeColor: "#000000",
   colorScheme: "dark",
   width: "device-width",
   initialScale: 1,
@@ -116,6 +117,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body>
         <a className="skip-link" href="#main-content">Skip to content</a>
+        <BackgroundDepth />
         <div className="site-shell">
           <Header />
           <main id="main-content" tabIndex={-1}>{children}</main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -105,7 +105,12 @@ export default function HomePage() {
               <span className="hero-status__chip hero-status__chip--ceiling">
                 CONTROLLED_TEST_VALIDATED
               </span>
-              <span className="hero-status__chip hero-status__chip--blocked">
+              <span
+                className="hero-status__chip hero-status__chip--blocked"
+                tabIndex={0}
+                data-tooltip="Blocked: runtime evidence has not been promoted to public-safe proof at this surface."
+                aria-label="Blocked: runtime evidence has not been promoted to public-safe proof"
+              >
                 Public-safe runtime proof · BLOCKED
               </span>
             </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import ActivityLedger from "@components/ActivityLedger";
-import ArtifactMachine from "@components/ArtifactMachine";
 import ClaimFirewallPanel from "@components/ClaimFirewallPanel";
 import FailureModeStrip from "@components/FailureModeStrip";
 import HeroControlConsole from "@components/HeroControlConsole";
@@ -9,14 +8,13 @@ import PromotionLadderHomepage from "@components/PromotionLadderHomepage";
 import ProofPathTimeline, { type ProofPathStep } from "@components/ProofPathTimeline";
 import RepoAuthorityDAG from "@components/RepoAuthorityDAG";
 import ReviewRouteSelector from "@components/ReviewRouteSelector";
-import TruthSurfaceInfographic from "@components/TruthSurfaceInfographic";
 import TruthTelemetryMatrix from "@components/TruthTelemetryMatrix";
 import { externalLinks } from "@data/navigation";
 
 export const metadata: Metadata = {
   title: "HawkinsOperations",
   description:
-    "HawkinsOperations is a governed detection-engineering control layer that keeps AI-generated security work from becoming public or operational truth until validation, evidence, and human review authorize the claim. Website rendering is not proof.",
+    "HawkinsOperations is an AI security operations control layer. AI can generate security work faster than enterprises can govern it; this framework keeps that work from becoming analyst conclusion, operational action, public claim, or executive truth before validation, evidence, CI controls, and human review authorize it. Website rendering is not proof.",
 };
 
 const traceSteps: ProofPathStep[] = [
@@ -77,24 +75,25 @@ const traceSteps: ProofPathStep[] = [
 export default function HomePage() {
   return (
     <>
-      {/* ── 01 · Hero ─ enterprise statement + system identity ──────── */}
+      {/* ── 01 · Hero ─ enterprise problem + control surface identity ─── */}
       <section className="relative overflow-hidden cockpit-section hero-cockpit">
         <div className="hero-backdrop" aria-hidden="true" />
-        <div className="container grid gap-14 lg:grid-cols-[1.05fr_0.95fr] lg:gap-16 items-start">
+        <div className="container-cockpit grid gap-14 lg:grid-cols-[1.05fr_0.95fr] lg:gap-16 items-start">
           <div className="reveal reveal--up">
             <p className="hero-cockpit__eyebrow">
-              Governed detection-engineering control layer
+              AI Security Operations Control Layer
             </p>
             <h1 className="hero-cockpit__headline">
-              AI can accelerate security work.
+              AI can generate security work faster than enterprises can govern it.
               <span className="hero-cockpit__headline-emph">
-                It cannot authorize the truth.
+                HawkinsOperations decides what becomes truth.
               </span>
             </h1>
             <p className="hero-cockpit__lede">
-              HawkinsOperations is a governed detection-engineering control layer that keeps
-              AI-generated security work from becoming public or operational truth until
-              validation, evidence, and human review authorize the claim.
+              A governed framework that stops AI-assisted security output from becoming
+              analyst conclusion, operational action, public claim, or executive truth
+              before validation, evidence, CI controls, and human review authorize it.
+              AI accelerates the work. Evidence and human review authorize the claim.
             </p>
 
             <div className="hero-status" role="note" aria-label="Release and ceiling status">
@@ -118,10 +117,10 @@ export default function HomePage() {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                Open GitHub Release ↗
+                Inspect Proof Pack 001 ↗
               </a>
               <a className="hero-cockpit__secondary" href="/proof/ho-det-001/">
-                Inspect proof route →
+                Trace HO-DET-001 →
               </a>
               <a
                 className="hero-cockpit__secondary"
@@ -129,15 +128,10 @@ export default function HomePage() {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                Open GitHub org ↗
+                View GitHub Org ↗
               </a>
-              <a
-                className="hero-cockpit__tertiary"
-                href={externalLinks.proofPack001Discussion}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Discussion ↗
+              <a className="hero-cockpit__tertiary" href="/about/">
+                Read Operator page →
               </a>
             </div>
           </div>
@@ -148,23 +142,41 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* ── 02 · Proof Pack 001 release receipt · above the fold ────── */}
+      {/* ── 02 · Proof-now strip · Release 001 receipt above the fold ── */}
       <section id="release-001" className="cockpit-section--tight">
-        <div className="container reveal reveal--up">
+        <div className="container-cockpit reveal reveal--up">
           <ProofPackReceipt />
         </div>
       </section>
 
-      {/* ── 03 · Enterprise failure mode ─────────────────────────────── */}
+      {/* ── 03 · What shipped · receipts, not roadmap ───────────────── */}
+      <section id="release-sprint" className="cockpit-section--tight">
+        <div className="container-cockpit">
+          <div className="mb-6">
+            <p className="cockpit-eyebrow">What exists now</p>
+            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
+              Receipts that already shipped in Release 001.
+            </h2>
+            <p className="muted mt-3 text-sm leading-6 max-w-3xl">
+              Proof record, validation result, detection source, deterministic verifier, CI workflow,
+              and the public claim ceiling. Each item is a link to the artifact in the repo, not a
+              promise on this page.
+            </p>
+          </div>
+          <ActivityLedger />
+        </div>
+      </section>
+
+      {/* ── 04 · Enterprise failure mode · why this exists ──────────── */}
       <section id="failure-mode" className="cockpit-section--tight">
-        <div className="container reveal reveal--up">
+        <div className="container-cockpit reveal reveal--up">
           <FailureModeStrip />
         </div>
       </section>
 
-      {/* ── 04 · HawkinsOperations control route · promotion ladder ──── */}
+      {/* ── 05 · HawkinsOperations control route · promotion ladder ── */}
       <section id="control-route" className="cockpit-section--tight">
-        <div className="container">
+        <div className="container-cockpit">
           <div className="mb-6">
             <p className="cockpit-eyebrow">HawkinsOperations control route</p>
             <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
@@ -191,60 +203,9 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* ── 05 · Proof ceiling chart · supported vs blocked lanes ────── */}
-      <section id="proof-ceiling" className="cockpit-section--tight">
-        <div className="container">
-          <div className="mb-6">
-            <p className="cockpit-eyebrow">Proof ceiling</p>
-            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
-              Supported lanes are filled. Blocked lanes stay blocked.
-            </h2>
-            <p className="muted mt-3 text-sm leading-6 max-w-3xl">
-              Source, controlled validation, and bounded public-claim lanes are filled at the
-              current public ceiling. Runtime-active and signal-observed lanes are blocked at this
-              surface — those claims require a separate evidence-backed promotion gate.
-            </p>
-          </div>
-          <TruthTelemetryMatrix />
-          <div className="biz-translate" role="note" aria-label="Business translation">
-            <span className="biz-translate__label">In plain English</span>
-            <span>
-              <span className="biz-translate__text">
-                Every row shows what HawkinsOperations can prove today and what it cannot. The
-                ceiling is a vertical line in this grid.
-              </span>
-            </span>
-          </div>
-        </div>
-      </section>
-
-      {/* ── 06 · Reviewer routes · four audiences ────────────────────── */}
-      <section id="reviewer-routes" className="cockpit-section--tight">
-        <div className="container">
-          <div className="mb-6">
-            <p className="cockpit-eyebrow">Reviewer routes</p>
-            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
-              Four audiences. Four inspection paths.
-            </h2>
-            <p className="muted mt-3 text-sm leading-6 max-w-3xl">
-              The route changes how you read the system. It does not change the underlying proof
-              state. Each route lists what to inspect first and what not to infer.
-            </p>
-          </div>
-          <ReviewRouteSelector />
-        </div>
-      </section>
-
-      {/* ── 07 · What shipped in Release 001 · sprint strip ──────────── */}
-      <section id="release-sprint" className="cockpit-section--tight">
-        <div className="container">
-          <ActivityLedger />
-        </div>
-      </section>
-
-      {/* ── 08 · HO-DET-001 flagship proof path ──────────────────────── */}
+      {/* ── 06 · HO-DET-001 flagship proof path ─────────────────────── */}
       <section id="flagship" className="cockpit-section--tight">
-        <div className="container">
+        <div className="container-cockpit">
           <div className="mb-6">
             <p className="cockpit-eyebrow">Flagship proof path</p>
             <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
@@ -259,64 +220,66 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* ── 09 · Artifact machine ────────────────────────────────────── */}
-      <section id="artifact-machine" className="cockpit-section--tight">
-        <div className="container">
-          <div className="flex flex-wrap items-baseline justify-between gap-3 mb-6">
-            <div>
-              <p className="cockpit-eyebrow">Artifact machine</p>
-              <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
-                Eight stages. One direction. Source to public boundary.
-              </h2>
-            </div>
-            <p className="muted max-w-md text-sm leading-6">
-              Each stage produces a named receipt; the next stage requires it. Receipts live in the repos, not on this page.
-            </p>
-          </div>
-          <ArtifactMachine />
-        </div>
-      </section>
-
-      {/* ── 10 · Repository authority ────────────────────────────────── */}
+      {/* ── 07 · Repository authority ───────────────────────────────── */}
       <section id="repo-authority" className="cockpit-section--tight">
-        <div className="container">
+        <div className="container-cockpit">
           <div className="mb-6">
             <p className="cockpit-eyebrow">Repository authority</p>
             <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
               Six repositories. Three planes. Authority flows down only.
             </h2>
             <p className="muted mt-3 text-sm leading-6 max-w-3xl">
-              detections → validation → proof feeds the chain. .github and platform overlay it. website renders the receipts; it does not author them.
+              detections → validation → proof feeds the chain. .github and platform overlay it.
+              website renders the receipts; it does not author them.
             </p>
           </div>
           <RepoAuthorityDAG />
         </div>
       </section>
 
-      {/* ── 11 · Six truth surfaces ──────────────────────────────────── */}
-      <section id="truth-surfaces" className="cockpit-section--tight">
-        <div className="container">
+      {/* ── 08 · Proof ceiling chart · supported vs blocked lanes ──── */}
+      <section id="proof-ceiling" className="cockpit-section--tight">
+        <div className="container-cockpit">
           <div className="mb-6">
-            <p className="cockpit-eyebrow">Truth surfaces</p>
+            <p className="cockpit-eyebrow">Proof ceiling</p>
             <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
-              Six surfaces. Each one supports its own claims, nothing more.
+              Supported lanes are filled. Blocked lanes stay blocked.
             </h2>
             <p className="muted mt-3 text-sm leading-6 max-w-3xl">
-              Promotion is always upward and gated. The surfaces describe what each layer can prove and the receipt the next layer requires.
+              Source, controlled validation, and bounded public-claim lanes are filled at the
+              current public ceiling. Runtime-active and signal-observed lanes are blocked at this
+              surface — those claims require a separate evidence-backed promotion gate.
             </p>
           </div>
-          <TruthSurfaceInfographic />
+          <TruthTelemetryMatrix />
         </div>
       </section>
 
-      {/* ── 12 · Claim firewall ──────────────────────────────────────── */}
+      {/* ── 09 · Reviewer routes · four audiences ───────────────────── */}
+      <section id="reviewer-routes" className="cockpit-section--tight">
+        <div className="container-cockpit">
+          <div className="mb-6">
+            <p className="cockpit-eyebrow">Reviewer routes</p>
+            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
+              Four audiences. Four inspection paths.
+            </h2>
+            <p className="muted mt-3 text-sm leading-6 max-w-3xl">
+              The route changes how you read the system. It does not change the underlying proof
+              state. Each route lists what to inspect first and what not to infer.
+            </p>
+          </div>
+          <ReviewRouteSelector />
+        </div>
+      </section>
+
+      {/* ── 10 · Claim firewall · compact boundary panel ────────────── */}
       <section id="claim-firewall" className="cockpit-section--tight">
-        <div className="container">
+        <div className="container-cockpit">
           <ClaimFirewallPanel />
         </div>
       </section>
 
-      {/* ── 13 · Doctrine closer ─────────────────────────────────────── */}
+      {/* ── 11 · Doctrine closer ────────────────────────────────────── */}
       <section className="cockpit-section">
         <div className="container">
           <div className="grid gap-8 md:grid-cols-[1.4fr_1fr] md:items-center">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,14 @@
 import type { Metadata } from "next";
 import ActivityLedger from "@components/ActivityLedger";
 import ClaimFirewallPanel from "@components/ClaimFirewallPanel";
-import FailureModeStrip from "@components/FailureModeStrip";
 import HeroControlConsole from "@components/HeroControlConsole";
 import ProofPackReceipt from "@components/ProofPackReceipt";
 import PromotionLadderHomepage from "@components/PromotionLadderHomepage";
 import ProofPathTimeline, { type ProofPathStep } from "@components/ProofPathTimeline";
-import RepoAuthorityDAG from "@components/RepoAuthorityDAG";
+import RepoAuthorityFlow from "@components/RepoAuthorityFlow";
 import ReviewRouteSelector from "@components/ReviewRouteSelector";
 import TruthTelemetryMatrix from "@components/TruthTelemetryMatrix";
+import UncontrolledPromotionFlow from "@components/UncontrolledPromotionFlow";
 import { externalLinks } from "@data/navigation";
 
 export const metadata: Metadata = {
@@ -167,10 +167,24 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* ── 04 · Enterprise failure mode · why this exists ──────────── */}
+      {/* ── 04 · Enterprise failure mode · interactive React Flow ───── */}
       <section id="failure-mode" className="cockpit-section--tight">
         <div className="container-cockpit reveal reveal--up">
-          <FailureModeStrip />
+          <div className="mb-6">
+            <p className="cockpit-eyebrow" style={{ color: "var(--blocked-red)" }}>
+              Enterprise failure mode
+            </p>
+            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
+              Uncontrolled AI promotion gets blocked here.
+            </h2>
+            <p className="muted mt-3 text-sm leading-6 max-w-3xl">
+              The top red path is the enterprise failure mode: AI output becomes analyst
+              conclusion, operational action, public claim, and executive truth without
+              authorization. The bottom ice-blue path is the HawkinsOperations control route
+              through deterministic gates to the public boundary. Click a node to inspect.
+            </p>
+          </div>
+          <UncontrolledPromotionFlow />
         </div>
       </section>
 
@@ -233,7 +247,7 @@ export default function HomePage() {
               website renders the receipts; it does not author them.
             </p>
           </div>
-          <RepoAuthorityDAG />
+          <RepoAuthorityFlow />
         </div>
       </section>
 

--- a/components/BackgroundDepth.tsx
+++ b/components/BackgroundDepth.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * BackgroundDepth
+ *
+ * Slow-moving constellation/node-link mesh rendered to a fixed canvas behind
+ * the entire site. Pure black base, transparent baby-blue + white nodes and
+ * faint connecting traces. Opacity stays in the 5-15% band so high-contrast
+ * white and ice-blue foreground text reads cleanly on top.
+ *
+ * Behavior:
+ *  - prefers-reduced-motion: reduce -> renders one static dot field, no rAF.
+ *  - device pixel ratio aware; capped at 1.75 to keep paint cheap on hi-DPI.
+ *  - pauses rAF when document is hidden.
+ */
+export default function BackgroundDepth() {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const dpr = Math.min(window.devicePixelRatio || 1, 1.75);
+
+    type Node = { x: number; y: number; vx: number; vy: number; r: number; warm: boolean };
+    let nodes: Node[] = [];
+    let width = 0;
+    let height = 0;
+    let frame = 0;
+    let running = true;
+
+    const seed = () => {
+      width = canvas.clientWidth;
+      height = canvas.clientHeight;
+      canvas.width = Math.round(width * dpr);
+      canvas.height = Math.round(height * dpr);
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+      // Density tuned for sparse / professional feel: ~ 1 node per 18,000 px^2
+      const target = Math.max(28, Math.min(110, Math.round((width * height) / 18000)));
+      nodes = Array.from({ length: target }, () => ({
+        x: Math.random() * width,
+        y: Math.random() * height,
+        // Slow drift; baseline ~6-12 seconds across one viewport
+        vx: (Math.random() - 0.5) * 0.18,
+        vy: (Math.random() - 0.5) * 0.18,
+        r: 0.6 + Math.random() * 1.1,
+        warm: Math.random() < 0.18, // ~18% pure white, rest ice-blue
+      }));
+    };
+
+    const drawStatic = () => {
+      ctx.clearRect(0, 0, width, height);
+      for (const n of nodes) {
+        ctx.beginPath();
+        ctx.arc(n.x, n.y, n.r, 0, Math.PI * 2);
+        ctx.fillStyle = n.warm ? "rgba(238, 244, 250, 0.55)" : "rgba(143, 216, 255, 0.55)";
+        ctx.fill();
+      }
+    };
+
+    const drawAnimated = () => {
+      ctx.clearRect(0, 0, width, height);
+
+      // Faint connecting traces — only close pairs, low alpha
+      const linkDistance = 130;
+      const linkDistSq = linkDistance * linkDistance;
+      for (let i = 0; i < nodes.length; i++) {
+        const a = nodes[i];
+        for (let j = i + 1; j < nodes.length; j++) {
+          const b = nodes[j];
+          const dx = a.x - b.x;
+          const dy = a.y - b.y;
+          const dsq = dx * dx + dy * dy;
+          if (dsq < linkDistSq) {
+            const alpha = (1 - dsq / linkDistSq) * 0.085;
+            ctx.strokeStyle = `rgba(143, 216, 255, ${alpha.toFixed(3)})`;
+            ctx.lineWidth = 0.6;
+            ctx.beginPath();
+            ctx.moveTo(a.x, a.y);
+            ctx.lineTo(b.x, b.y);
+            ctx.stroke();
+          }
+        }
+      }
+
+      // Nodes
+      for (const n of nodes) {
+        n.x += n.vx;
+        n.y += n.vy;
+        if (n.x < -20) n.x = width + 20;
+        else if (n.x > width + 20) n.x = -20;
+        if (n.y < -20) n.y = height + 20;
+        else if (n.y > height + 20) n.y = -20;
+
+        ctx.beginPath();
+        ctx.arc(n.x, n.y, n.r, 0, Math.PI * 2);
+        ctx.fillStyle = n.warm
+          ? "rgba(238, 244, 250, 0.55)"
+          : "rgba(143, 216, 255, 0.55)";
+        ctx.fill();
+      }
+    };
+
+    seed();
+    if (reducedMotion) {
+      drawStatic();
+    } else {
+      const tick = () => {
+        if (!running) return;
+        drawAnimated();
+        frame = window.requestAnimationFrame(tick);
+      };
+      frame = window.requestAnimationFrame(tick);
+    }
+
+    const handleResize = () => {
+      seed();
+      if (reducedMotion) drawStatic();
+    };
+
+    const handleVisibility = () => {
+      if (document.hidden) {
+        running = false;
+        if (frame) window.cancelAnimationFrame(frame);
+      } else if (!reducedMotion && !running) {
+        running = true;
+        const tick = () => {
+          if (!running) return;
+          drawAnimated();
+          frame = window.requestAnimationFrame(tick);
+        };
+        frame = window.requestAnimationFrame(tick);
+      }
+    };
+
+    window.addEventListener("resize", handleResize);
+    document.addEventListener("visibilitychange", handleVisibility);
+
+    return () => {
+      running = false;
+      if (frame) window.cancelAnimationFrame(frame);
+      window.removeEventListener("resize", handleResize);
+      document.removeEventListener("visibilitychange", handleVisibility);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="bg-depth"
+      aria-hidden="true"
+      style={{ opacity: 0.11 }}
+    />
+  );
+}

--- a/components/ClaimFirewallPanel.tsx
+++ b/components/ClaimFirewallPanel.tsx
@@ -22,7 +22,7 @@ export default function ClaimFirewallPanel({
   line?: string;
 } = {}) {
   return (
-    <section className="claim-firewall-panel" aria-label={title}>
+    <section className="claim-firewall-panel scan-sweep" aria-label={title}>
       <div className="claim-firewall-panel__intro">
         <p className="cockpit-eyebrow">Precision boundary</p>
         <h3 className="claim-firewall-panel__title">{title}</h3>
@@ -69,7 +69,16 @@ export default function ClaimFirewallPanel({
 
         <div className="claim-firewall-panel__chips" aria-label="Blocked terms">
           {blockedClaims.map((claim) => (
-            <span key={claim} className="claim-firewall-panel__chip" title={`${claim} is blocked from public wording`}>{claim}</span>
+            <span
+              key={claim}
+              className="claim-firewall-panel__chip"
+              tabIndex={0}
+              role="note"
+              aria-label={`Blocked: ${claim} is blocked from public wording`}
+              data-tooltip={`Blocked: ${claim} is not permitted in public wording at this surface.`}
+            >
+              {claim}
+            </span>
           ))}
         </div>
       </div>

--- a/components/RepoAuthorityFlow.tsx
+++ b/components/RepoAuthorityFlow.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import {
+  Background,
+  BackgroundVariant,
+  Controls,
+  Handle,
+  Position,
+  ReactFlow,
+  ReactFlowProvider,
+  type Edge,
+  type Node,
+  type NodeProps,
+  type NodeTypes,
+} from "@xyflow/react";
+
+import "@xyflow/react/dist/style.css";
+
+/**
+ * RepoAuthorityFlow
+ *
+ * Interactive React Flow diagram for the repository authority section.
+ *
+ * Six repositories. Three planes. Authority flows down only.
+ *   .github         · governance and reviewer routing
+ *   platform        · runtime contracts, no fantasy claims
+ *   detections      · source logic exists, but source is not proof
+ *   validation      · deterministic checks, fixtures, verifier language
+ *   proof           · evidence boundary, claim ceiling
+ *   website         · rendering only, not proof
+ */
+
+type RepoMeta = {
+  id: string;
+  plane: "governance" | "runtime" | "authority" | "rendering";
+  num: string;
+  name: string;
+  role: string;
+  owns: string;
+  neverOwns: string;
+  claimBoundary: string;
+  inspectNext: string;
+};
+
+const REPOS: Record<string, RepoMeta> = {
+  github: {
+    id: "github",
+    plane: "governance",
+    num: "01",
+    name: ".github",
+    role: "governance · reviewer routing",
+    owns: "PR templates · CODEOWNERS · required checks · visible human review routing.",
+    neverOwns: "Detection logic · validation results · evidence records · public claim wording.",
+    claimBoundary: "Governance metadata does not promote any downstream claim.",
+    inspectNext: "Visible human review before merge for claim-bearing changes.",
+  },
+  platform: {
+    id: "platform",
+    plane: "runtime",
+    num: "02",
+    name: "platform",
+    role: "runtime contracts · no fantasy claims",
+    owns: "Execution boundaries · runtime handling contracts · self-hosted runner config for CI.",
+    neverOwns: "Source detection logic · proof records · public-facing wording.",
+    claimBoundary:
+      "Runtime-active, signal-observed, GPU CI proven, and model execution in CI remain blocked at this surface.",
+    inspectNext: "Repository authority map · platform contract notes.",
+  },
+  detections: {
+    id: "detections",
+    plane: "authority",
+    num: "03",
+    name: "detections",
+    role: "source logic · source is not proof",
+    owns: "Detection rule, SPL, mapping source under version control with a stated owner.",
+    neverOwns: "Test results · evidence records · public claim wording.",
+    claimBoundary:
+      "Source presence is not proof of runtime activity, fired signal, or production deployment.",
+    inspectNext: "HO-DET-001 rule.yml · splunk.spl.",
+  },
+  validation: {
+    id: "validation",
+    plane: "authority",
+    num: "04",
+    name: "validation",
+    role: "deterministic checks · fixtures · verifier language",
+    owns: "Controlled positive and negative test cases · validator scripts · CI workflow.",
+    neverOwns: "Public claim wording · runtime evidence beyond the controlled cycle.",
+    claimBoundary:
+      "Test passage does not prove runtime activity, observed signal, or public-safe runtime proof.",
+    inspectNext: "HO-DET-001 validation-result.md · validation-cases.json.",
+  },
+  proof: {
+    id: "proof",
+    plane: "authority",
+    num: "05",
+    name: "proof",
+    role: "evidence boundary · claim ceiling",
+    owns: "Proof records · stated ceilings · supported wording · blocked wording.",
+    neverOwns: "Detection logic · validation source · website rendering.",
+    claimBoundary:
+      "Evidence-linked is not automatically public-safe; promotion to public requires human review.",
+    inspectNext: "HO-DET-001 proof record · Proof Pack 001 release.",
+  },
+  website: {
+    id: "website",
+    plane: "rendering",
+    num: "06",
+    name: "website",
+    role: "rendering only · not proof",
+    owns: "Bounded public wording · reviewer-visible routes · pointers back to repo evidence.",
+    neverOwns: "Source · validation · runtime · evidence · disposition authority.",
+    claimBoundary:
+      "Website rendering is not proof. Stronger wording requires a separate evidence-backed promotion gate.",
+    inspectNext: "Site contract verifier · blocked-claim scanner.",
+  },
+};
+
+const AUTHORITY_EDGES: Array<[string, string, string]> = [
+  ["detections", "validation", "feeds"],
+  ["validation", "proof", "feeds"],
+  ["proof", "website", "renders (read-only)"],
+];
+const OVERLAY_EDGES: Array<[string, string]> = [
+  ["github", "detections"],
+  ["github", "validation"],
+  ["github", "proof"],
+  ["platform", "validation"],
+  ["platform", "proof"],
+];
+
+type FlowNode = Node<{ meta: RepoMeta; dim: boolean; active: boolean }>;
+
+function RepoNode({ data, id }: NodeProps<FlowNode>) {
+  const m = data.meta;
+  const cls = [
+    "raf-node",
+    `raf-node--${m.plane}`,
+    data.active ? "raf-node--active" : "",
+    data.dim ? "raf-node--dim" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <div className={cls} data-node-id={id}>
+      <Handle type="target" position={Position.Top} className="raf-handle" />
+      <span className="raf-node__num">{m.num}</span>
+      <span className="raf-node__name">{m.name}</span>
+      <span className="raf-node__role">{m.role}</span>
+      <span className="raf-node__plane">{m.plane.toUpperCase()}</span>
+      <Handle type="source" position={Position.Bottom} className="raf-handle" />
+    </div>
+  );
+}
+
+const nodeTypes: NodeTypes = { repo: RepoNode };
+
+function FlowInner() {
+  const [selectedId, setSelectedId] = useState<string | null>("proof");
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+
+  const focusId = hoveredId ?? selectedId;
+  const focusNeighbors = useMemo(() => {
+    if (!focusId) return new Set<string>();
+    const set = new Set<string>([focusId]);
+    for (const [a, b] of [...AUTHORITY_EDGES.map(([a, b]) => [a, b] as [string, string]), ...OVERLAY_EDGES]) {
+      if (a === focusId) set.add(b);
+      if (b === focusId) set.add(a);
+    }
+    return set;
+  }, [focusId]);
+
+  const positions: Record<string, { x: number; y: number }> = {
+    github: { x: 60, y: 0 },
+    platform: { x: 760, y: 0 },
+    detections: { x: 0, y: 200 },
+    validation: { x: 420, y: 200 },
+    proof: { x: 840, y: 200 },
+    website: { x: 420, y: 400 },
+  };
+
+  const nodes = useMemo<FlowNode[]>(
+    () =>
+      Object.values(REPOS).map((meta) => ({
+        id: meta.id,
+        position: positions[meta.id],
+        type: "repo",
+        data: {
+          meta,
+          active: meta.id === selectedId || meta.id === hoveredId,
+          dim: focusId !== null && !focusNeighbors.has(meta.id),
+        },
+        draggable: false,
+        selectable: true,
+      })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [focusId, focusNeighbors, hoveredId, selectedId],
+  );
+
+  const edges = useMemo<Edge[]>(() => {
+    const authority: Edge[] = AUTHORITY_EDGES.map(([from, to, label]) => {
+      const inFocus = focusNeighbors.has(from) && focusNeighbors.has(to);
+      return {
+        id: `${from}->${to}`,
+        source: from,
+        target: to,
+        animated: true,
+        label,
+        style: {
+          stroke: inFocus || focusId === null ? "var(--ice-blue)" : "rgba(143, 216, 255, 0.32)",
+          strokeWidth: inFocus ? 2 : 1.6,
+        },
+        labelStyle: { fill: "var(--silver)", fontSize: 10, fontFamily: '"JetBrains Mono", monospace' },
+        labelBgStyle: { fill: "rgba(8, 8, 10, 0.85)" },
+        markerEnd: { type: "arrowclosed" as const, width: 14, height: 14, color: "var(--ice-blue)" },
+        className: focusId !== null && !inFocus ? "raf-edge raf-edge--dim" : "raf-edge",
+      };
+    });
+    const overlay: Edge[] = OVERLAY_EDGES.map(([from, to]) => {
+      const inFocus = focusNeighbors.has(from) && focusNeighbors.has(to);
+      return {
+        id: `${from}->${to}`,
+        source: from,
+        target: to,
+        type: "straight",
+        style: {
+          stroke: inFocus || focusId === null ? "rgba(220, 224, 232, 0.45)" : "rgba(220, 224, 232, 0.16)",
+          strokeWidth: 1,
+          strokeDasharray: "4 4",
+        },
+        className: focusId !== null && !inFocus ? "raf-edge raf-edge--dim" : "raf-edge raf-edge--overlay",
+      };
+    });
+    return [...authority, ...overlay];
+  }, [focusId, focusNeighbors]);
+
+  const handleNodeClick = useCallback((_: unknown, node: Node) => {
+    setSelectedId((prev) => (prev === node.id ? null : node.id));
+  }, []);
+  const handlePaneClick = useCallback(() => setSelectedId(null), []);
+  const handleNodeMouseEnter = useCallback((_: unknown, node: Node) => setHoveredId(node.id), []);
+  const handleNodeMouseLeave = useCallback(() => setHoveredId(null), []);
+
+  const inspected = selectedId ? REPOS[selectedId] : null;
+
+  return (
+    <div className="raf-shell" aria-label="Repository authority directed graph">
+      <div className="raf-canvas">
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={nodeTypes}
+          onNodeClick={handleNodeClick}
+          onPaneClick={handlePaneClick}
+          onNodeMouseEnter={handleNodeMouseEnter}
+          onNodeMouseLeave={handleNodeMouseLeave}
+          panOnDrag
+          panOnScroll={false}
+          zoomOnScroll={false}
+          zoomOnPinch
+          zoomOnDoubleClick={false}
+          fitView
+          fitViewOptions={{ padding: 0.18 }}
+          proOptions={{ hideAttribution: true }}
+          minZoom={0.45}
+          maxZoom={1.35}
+          nodesDraggable={false}
+          nodesConnectable={false}
+          elementsSelectable
+        >
+          <Background variant={BackgroundVariant.Dots} gap={28} size={1} color="rgba(143, 216, 255, 0.10)" />
+          <Controls showInteractive={false} className="raf-controls" />
+        </ReactFlow>
+      </div>
+
+      <aside className="raf-panel" aria-live="polite">
+        {inspected ? (
+          <>
+            <p className="raf-panel__eyebrow">
+              {inspected.num} · {inspected.plane}
+            </p>
+            <h3 className="raf-panel__title">{inspected.name}</h3>
+            <p className="raf-panel__role">{inspected.role}</p>
+
+            <dl className="raf-panel__dl">
+              <dt>Owns</dt>
+              <dd>{inspected.owns}</dd>
+              <dt>Must never own</dt>
+              <dd>{inspected.neverOwns}</dd>
+              <dt>Claim boundary</dt>
+              <dd>{inspected.claimBoundary}</dd>
+              <dt>Inspect next</dt>
+              <dd>{inspected.inspectNext}</dd>
+            </dl>
+          </>
+        ) : (
+          <>
+            <p className="raf-panel__eyebrow">Inspection panel</p>
+            <h3 className="raf-panel__title">Click a repository to inspect.</h3>
+            <p className="raf-panel__role">
+              Six repositories. Three planes. Authority flows down only. detections → validation →
+              proof feeds the chain. .github and platform overlay it. website renders the receipts;
+              it does not author them.
+            </p>
+          </>
+        )}
+      </aside>
+    </div>
+  );
+}
+
+export default function RepoAuthorityFlow() {
+  return (
+    <ReactFlowProvider>
+      <FlowInner />
+    </ReactFlowProvider>
+  );
+}

--- a/components/TruthTelemetryMatrix.tsx
+++ b/components/TruthTelemetryMatrix.tsx
@@ -43,7 +43,7 @@ const ceilingBoundaryIndex = matrixColumns.findIndex((c) => c.boundary === "abov
 
 export default function TruthTelemetryMatrix() {
   return (
-    <div className="truth-matrix" role="region" aria-label="Truth vs telemetry matrix">
+    <div className="truth-matrix scan-sweep" role="region" aria-label="Truth vs telemetry matrix">
       <p className="truth-matrix__why">
         <strong>Why this matters · </strong>
         Recruiters and security leaders can read claim discipline in one glance. Filled cells say what is

--- a/components/UncontrolledPromotionFlow.tsx
+++ b/components/UncontrolledPromotionFlow.tsx
@@ -1,0 +1,398 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import {
+  Background,
+  BackgroundVariant,
+  Controls,
+  Handle,
+  Position,
+  ReactFlow,
+  ReactFlowProvider,
+  type Edge,
+  type EdgeTypes,
+  type Node,
+  type NodeProps,
+  type NodeTypes,
+} from "@xyflow/react";
+
+import "@xyflow/react/dist/style.css";
+
+/**
+ * UncontrolledPromotionFlow
+ *
+ * Interactive React Flow diagram for the homepage.
+ *
+ *   AI Output  ──(uncontrolled, dashed red, blocked)─►  Analyst → Action → Public Claim → Executive Truth
+ *              ──(controlled, ice-blue, gated)──────►   Validation → Evidence → Claim Firewall → Human Review → Public Boundary
+ *
+ * Hover highlights the connected path, click opens an inspection panel.
+ * Reduced motion: edge animation disabled by CSS.
+ */
+
+type NodeKind = "origin" | "failure" | "gate" | "boundary";
+
+type NodeMeta = {
+  id: string;
+  kind: NodeKind;
+  title: string;
+  sub: string;
+  whyDangerous?: string;
+  howBlocked?: string;
+  proofOrGate?: string;
+  inspectNext?: string;
+};
+
+const META: Record<string, NodeMeta> = {
+  "ai-output": {
+    id: "ai-output",
+    kind: "origin",
+    title: "AI Output",
+    sub: "Unrestricted generation",
+    whyDangerous:
+      "Model output is cheap to produce and hard to govern. Without a gate the next surface treats it as fact.",
+    howBlocked:
+      "HawkinsOperations keeps AI output inside a labor lane. Promotion requires deterministic receipts from downstream surfaces.",
+    proofOrGate: "Source lane only. No claim promotion without downstream receipts.",
+    inspectNext: "Validation Gate · how controlled tests pass before any claim moves.",
+  },
+  "fail-analyst": {
+    id: "fail-analyst",
+    kind: "failure",
+    title: "Analyst Conclusion",
+    sub: "Opinion without bounded evidence",
+    whyDangerous:
+      "Once AI wording is pasted into a ticket, brief, or chat thread, it becomes a claim with someone's name on it — usually without the evidence chain attached.",
+    howBlocked:
+      "Analyst-approved disposition remains blocked at the claim firewall unless an evidence-linked record is present.",
+    proofOrGate: "Blocked at validation/evidence surface.",
+    inspectNext: "Claim firewall · what wording is blocked vs supported.",
+  },
+  "fail-action": {
+    id: "fail-action",
+    kind: "failure",
+    title: "Operational Action",
+    sub: "Action taken on unverified claim",
+    whyDangerous:
+      "Operational systems act on inputs they trust. If an unverified claim reaches an action surface, the action itself becomes downstream proof the claim was real.",
+    howBlocked:
+      "Runtime-active state is blocked from public rendering and gated behind a separate evidence-backed promotion path.",
+    proofOrGate: "Blocked at runtime surface · not promoted publicly.",
+    inspectNext: "Repository authority · where runtime contracts live.",
+  },
+  "fail-public": {
+    id: "fail-public",
+    kind: "failure",
+    title: "Public Claim",
+    sub: "Marketing / public statement",
+    whyDangerous:
+      "Public statements are the hardest to retract. Once a claim ships to a website, deck, or press surface, it becomes the new baseline for everything downstream.",
+    howBlocked:
+      "Claim firewall blocks runtime-active, signal-observed, public-safe runtime proof, autonomous SOC, AI-approved disposition, and analyst-approved disposition wording.",
+    proofOrGate: "Site contract verifier · blocked-claim scanner · CI enforcement.",
+    inspectNext: "Site contract verifier · the deterministic gate that blocks wording.",
+  },
+  "fail-exec": {
+    id: "fail-exec",
+    kind: "failure",
+    title: "Executive Truth",
+    sub: "Becomes organizational truth",
+    whyDangerous:
+      "Once enough downstream surfaces repeat a claim, executives treat it as established truth. The original AI-generated origin is gone from view.",
+    howBlocked:
+      "Public claims stay capped at CONTROLLED_TEST_VALIDATED. Stronger wording requires a separate evidence-backed promotion gate.",
+    proofOrGate: "Public ceiling held · stronger wording requires promotion.",
+    inspectNext: "Proof ledger · what each proof record asserts and refuses.",
+  },
+  "gate-validation": {
+    id: "gate-validation",
+    kind: "gate",
+    title: "Validation Gate",
+    sub: "Deterministic checks",
+    whyDangerous:
+      "Without a validation gate, source presence is treated as runtime truth. Source is not proof.",
+    howBlocked:
+      "Controlled positive and negative test cases produce deterministic pass/fail receipts the next surface can require.",
+    proofOrGate: "HO-DET-001 validation result · validation-cases.json · CI run.",
+    inspectNext: "HO-DET-001 validation result · public validation receipt.",
+  },
+  "gate-evidence": {
+    id: "gate-evidence",
+    kind: "gate",
+    title: "Evidence Record",
+    sub: "Bounded receipts retained",
+    whyDangerous:
+      "Without an evidence record the chain dissolves and any downstream surface can claim what it likes.",
+    howBlocked:
+      "Proof records carry stated ceilings, evidence pointers, supported wording, and blocked wording.",
+    proofOrGate: "HO-DET-001 proof record · evidence pointers · stated ceiling.",
+    inspectNext: "HO-DET-001 proof record.",
+  },
+  "gate-firewall": {
+    id: "gate-firewall",
+    kind: "gate",
+    title: "Claim Firewall",
+    sub: "Blocked-claim scanner",
+    whyDangerous:
+      "Marketing language drifts; engineering claims drift. Without a firewall, drift becomes the public surface.",
+    howBlocked:
+      "Site contract verifier scans for blocked terms. CI fails the build when a term lands outside allowed context.",
+    proofOrGate: "scripts/verify-site-contract.mjs · blocked-claim list · CI required check.",
+    inspectNext: "Claim firewall page · allowed vs blocked wording.",
+  },
+  "gate-review": {
+    id: "gate-review",
+    kind: "gate",
+    title: "Human Review",
+    sub: "Authority decision · gate",
+    whyDangerous:
+      "AI does not own promotion. Without a human authority gate, nothing in the chain decides what becomes public truth.",
+    howBlocked:
+      "Visible human review on GitHub before merge for claim-bearing, governance, validation, proof, detection, CI, and website wording changes.",
+    proofOrGate: "MERGE_APPROVED · visible GitHub review · explicit operator authority.",
+    inspectNext: "Repo rules · visible human review before merge.",
+  },
+  "public-boundary": {
+    id: "public-boundary",
+    kind: "boundary",
+    title: "Public Boundary",
+    sub: "Ceiling held",
+    whyDangerous:
+      "Without a stated ceiling the public surface inherits whatever the loudest internal voice says.",
+    howBlocked:
+      "Public ceiling holds at CONTROLLED_TEST_VALIDATED. Website rendering is not proof.",
+    proofOrGate: "CONTROLLED_TEST_VALIDATED · NOT_PUBLIC_SAFE · rendering ≠ proof.",
+    inspectNext: "Proof Pack 001 release · what is actually shipped.",
+  },
+};
+
+const FAILURE_PATH = ["ai-output", "fail-analyst", "fail-action", "fail-public", "fail-exec"];
+const CONTROL_PATH = [
+  "ai-output",
+  "gate-validation",
+  "gate-evidence",
+  "gate-firewall",
+  "gate-review",
+  "public-boundary",
+];
+
+// ─── Custom node ──────────────────────────────────────────────────────
+
+type FlowNode = Node<{ meta: NodeMeta; dim: boolean; active: boolean }>;
+
+function PromotionNode({ data, id }: NodeProps<FlowNode>) {
+  const m = data.meta;
+  const tone =
+    m.kind === "origin"
+      ? "origin"
+      : m.kind === "failure"
+        ? "failure"
+        : m.kind === "boundary"
+          ? "boundary"
+          : "gate";
+  const cls = [
+    "upf-node",
+    `upf-node--${tone}`,
+    data.active ? "upf-node--active" : "",
+    data.dim ? "upf-node--dim" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <div className={cls} data-node-id={id}>
+      <Handle type="target" position={Position.Left} className="upf-handle" />
+      <span className="upf-node__kind">
+        {m.kind === "failure" ? "BLOCKED PATH" : m.kind === "gate" ? "CONTROL GATE" : m.kind === "boundary" ? "PUBLIC BOUNDARY" : "SOURCE"}
+      </span>
+      <span className="upf-node__title">{m.title}</span>
+      <span className="upf-node__sub">{m.sub}</span>
+      <Handle type="source" position={Position.Right} className="upf-handle" />
+    </div>
+  );
+}
+
+const nodeTypes: NodeTypes = { promotion: PromotionNode };
+const edgeTypes: EdgeTypes = {};
+
+// ─── Inner flow ───────────────────────────────────────────────────────
+
+function FlowInner() {
+  const [selectedId, setSelectedId] = useState<string | null>("ai-output");
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+
+  const focusId = hoveredId ?? selectedId;
+  const focusPath = useMemo(() => {
+    if (!focusId) return new Set<string>();
+    if (FAILURE_PATH.includes(focusId)) return new Set(FAILURE_PATH);
+    if (CONTROL_PATH.includes(focusId)) return new Set(CONTROL_PATH);
+    return new Set<string>([focusId]);
+  }, [focusId]);
+
+  const nodes = useMemo<FlowNode[]>(() => {
+    const positions: Record<string, { x: number; y: number }> = {
+      "ai-output": { x: 0, y: 170 },
+      "fail-analyst": { x: 260, y: 30 },
+      "fail-action": { x: 480, y: 30 },
+      "fail-public": { x: 720, y: 30 },
+      "fail-exec": { x: 960, y: 30 },
+      "gate-validation": { x: 260, y: 290 },
+      "gate-evidence": { x: 480, y: 290 },
+      "gate-firewall": { x: 720, y: 290 },
+      "gate-review": { x: 960, y: 290 },
+      "public-boundary": { x: 1200, y: 170 },
+    };
+    return Object.values(META).map((meta) => {
+      const id = meta.id;
+      const inFocus = focusPath.has(id);
+      return {
+        id,
+        position: positions[id],
+        type: "promotion",
+        data: {
+          meta,
+          active: id === selectedId || id === hoveredId,
+          dim: focusId !== null && !inFocus,
+        },
+        draggable: false,
+        selectable: true,
+      };
+    });
+  }, [focusId, focusPath, hoveredId, selectedId]);
+
+  const edges = useMemo<Edge[]>(() => {
+    const make = (from: string, to: string, kind: "failure" | "control"): Edge => {
+      const inFocus = focusPath.has(from) && focusPath.has(to);
+      return {
+        id: `${from}->${to}`,
+        source: from,
+        target: to,
+        animated: kind === "control",
+        type: kind === "failure" ? "straight" : "default",
+        style:
+          kind === "failure"
+            ? {
+                stroke: inFocus ? "var(--blocked-red)" : "rgba(252, 165, 165, 0.45)",
+                strokeWidth: inFocus ? 2 : 1.4,
+                strokeDasharray: "6 6",
+              }
+            : {
+                stroke: inFocus ? "var(--ice-blue)" : "rgba(143, 216, 255, 0.45)",
+                strokeWidth: inFocus ? 2 : 1.4,
+              },
+        markerEnd: {
+          type: "arrowclosed" as const,
+          width: 16,
+          height: 16,
+          color: kind === "failure" ? "var(--blocked-red)" : "var(--ice-blue)",
+        },
+        className: focusId !== null && !inFocus ? "upf-edge upf-edge--dim" : "upf-edge",
+      };
+    };
+    const fail: Edge[] = [];
+    for (let i = 0; i < FAILURE_PATH.length - 1; i++) {
+      fail.push(make(FAILURE_PATH[i], FAILURE_PATH[i + 1], "failure"));
+    }
+    const ctrl: Edge[] = [];
+    for (let i = 0; i < CONTROL_PATH.length - 1; i++) {
+      ctrl.push(make(CONTROL_PATH[i], CONTROL_PATH[i + 1], "control"));
+    }
+    return [...fail, ...ctrl];
+  }, [focusId, focusPath]);
+
+  const handleNodeClick = useCallback((_: unknown, node: Node) => {
+    setSelectedId((prev) => (prev === node.id ? null : node.id));
+  }, []);
+
+  const handlePaneClick = useCallback(() => setSelectedId(null), []);
+  const handleNodeMouseEnter = useCallback((_: unknown, node: Node) => setHoveredId(node.id), []);
+  const handleNodeMouseLeave = useCallback(() => setHoveredId(null), []);
+
+  const inspected = selectedId ? META[selectedId] : null;
+
+  return (
+    <div className="upf-shell" aria-label="Uncontrolled vs governed AI promotion diagram">
+      <div className="upf-canvas">
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
+          onNodeClick={handleNodeClick}
+          onPaneClick={handlePaneClick}
+          onNodeMouseEnter={handleNodeMouseEnter}
+          onNodeMouseLeave={handleNodeMouseLeave}
+          panOnDrag
+          panOnScroll={false}
+          zoomOnScroll={false}
+          zoomOnPinch
+          zoomOnDoubleClick={false}
+          fitView
+          fitViewOptions={{ padding: 0.15 }}
+          proOptions={{ hideAttribution: true }}
+          minZoom={0.4}
+          maxZoom={1.4}
+          nodesDraggable={false}
+          nodesConnectable={false}
+          elementsSelectable
+        >
+          <Background variant={BackgroundVariant.Dots} gap={28} size={1} color="rgba(143, 216, 255, 0.12)" />
+          <Controls showInteractive={false} className="upf-controls" />
+        </ReactFlow>
+      </div>
+
+      <aside className="upf-panel" aria-live="polite">
+        {inspected ? (
+          <>
+            <p className="upf-panel__eyebrow">{
+              inspected.kind === "failure"
+                ? "Blocked path · uncontrolled promotion"
+                : inspected.kind === "gate"
+                  ? "Control gate · governance authority"
+                  : inspected.kind === "boundary"
+                    ? "Public boundary · ceiling"
+                    : "Source · AI labor"
+            }</p>
+            <h3 className="upf-panel__title">{inspected.title}</h3>
+            <p className="upf-panel__sub">{inspected.sub}</p>
+
+            <dl className="upf-panel__dl">
+              <dt>Why this stage is dangerous</dt>
+              <dd>{inspected.whyDangerous}</dd>
+              <dt>How HawkinsOperations blocks uncontrolled promotion</dt>
+              <dd>{inspected.howBlocked}</dd>
+              <dt>What proof or gate applies</dt>
+              <dd>{inspected.proofOrGate}</dd>
+              <dt>Inspect next</dt>
+              <dd>{inspected.inspectNext}</dd>
+            </dl>
+
+            <p className="upf-panel__hint">Click another node to inspect. Click the empty canvas to clear.</p>
+          </>
+        ) : (
+          <>
+            <p className="upf-panel__eyebrow">Inspection panel</p>
+            <h3 className="upf-panel__title">Click a node to inspect.</h3>
+            <p className="upf-panel__sub">
+              The top red path is the enterprise failure mode: uncontrolled promotion. The bottom
+              ice-blue path is the HawkinsOperations control route through deterministic gates to
+              the public boundary.
+            </p>
+            <ul className="upf-panel__legend">
+              <li><span className="upf-dot upf-dot--failure" /> Blocked path · uncontrolled promotion</li>
+              <li><span className="upf-dot upf-dot--gate" /> Control gate · governance authority</li>
+              <li><span className="upf-dot upf-dot--boundary" /> Public boundary · ceiling held</li>
+            </ul>
+          </>
+        )}
+      </aside>
+    </div>
+  );
+}
+
+export default function UncontrolledPromotionFlow() {
+  return (
+    <ReactFlowProvider>
+      <FlowInner />
+    </ReactFlowProvider>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "hawkinsoperations-website",
       "version": "0.1.0",
       "dependencies": {
+        "@xyflow/react": "^12.10.2",
         "next": "14.2.35",
         "react": "18.3.1",
         "react-dom": "18.3.1"
@@ -949,6 +950,55 @@
         "tailwindcss": "4.2.4"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
@@ -963,14 +1013,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -985,6 +1035,38 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@xyflow/react": {
+      "version": "12.10.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz",
+      "integrity": "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.76",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.76",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
+      "integrity": "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
       }
     },
     "node_modules/busboy": {
@@ -1017,6 +1099,12 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
     },
     "node_modules/client-only": {
       "version": "0.0.1",
@@ -1065,8 +1153,113 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1693,6 +1886,43 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "generate:brand-assets": "node scripts/generate-brand-assets.mjs"
   },
   "dependencies": {
+    "@xyflow/react": "^12.10.2",
     "next": "14.2.35",
     "react": "18.3.1",
     "react-dom": "18.3.1"

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -9,7 +9,7 @@ export const primaryNavigation: NavItem[] = [
   { label: "Pipeline", href: "/pipeline/", description: "HO-DET-001 proof route" },
   { label: "Proof", href: "/proof/", description: "Proof ledger" },
   { label: "Artifacts", href: "/artifacts/", description: "Evidence vault" },
-  { label: "About", href: "/about/", description: "Operator profile" },
+  { label: "Operator", href: "/about/", description: "Operator profile" },
 ];
 
 export const reviewerLinks: NavItem[] = [


### PR DESCRIPTION
## Summary

Three-phase senior-grade upgrade of the HawkinsOperations website. Each phase is one independently revertable commit on this branch.

- **Phase 1** (`eafd98b`) — Homepage narrative now leads with the enterprise AI-governance failure mode and the HawkinsOperations control-layer response. `ActivityLedger` (what shipped) moved above the failure-mode strip so the page leads with proof, not blockers. Full rewrite of `/about` as an Operator page: failure ladder, manufacturing QC → AI security operations translation map, what-I-built grid, bounded resume snapshot (`324,074 cases / ~88% auto-close / 8,574 escalations` explicitly framed inside the 8-month controlled build-and-validation cycle), is/is-not boundary panels, route dock. Container shells widened (`1280 / 1480 / 1640` + a `1920px` tier) so wide desktop reads as a reviewer cockpit. Nav label `About → Operator` (route `/about/` preserved).
- **Phase 2** (`8a02d3f`) — Audited `:root` tokens and ~232 baked-in navy `rgba()` surface values across `globals.css` and repointed them to pure black / neutral charcoal. Accent tokens (`electric-blue`, `ice-blue`, `silver`, `ceiling-amber`, `blocked-red`) intentionally preserved. Flattened the body background to pure black and dropped the blue scanline. New `components/BackgroundDepth.tsx`: fixed canvas, ice-blue + white constellations, ~28–110 auto-density nodes, DPR capped at 1.75, opacity `0.11`, `prefers-reduced-motion → static draw`, pauses on `document.hidden`. `themeColor` and `msapplication-TileColor` moved from `#000205` to `#000000`. **Note**: per operator direction during the session, the original prompt's dark/light theme toggle was replaced by this navy-kill + canvas direction. No theme-toggle UI was added.
- **Phase 3** (`e88883e`) — Added `@xyflow/react@^12.10.2` (20 transitive deps). Two interactive React Flow client islands:
  - `UncontrolledPromotionFlow` (homepage failure-mode section) — two lanes diverging from a shared *AI Output*. Top dashed-red lane → Analyst Conclusion → Operational Action → Public Claim → Executive Truth (the enterprise failure mode). Bottom animated ice-blue lane → Validation Gate → Evidence Record → Claim Firewall → Human Review → Public Boundary (the HawkinsOperations control route). Hover highlights a lane and dims the other; click opens a side panel with `whyDangerous` / `howBlocked` / `proofOrGate` / `inspectNext`.
  - `RepoAuthorityFlow` (homepage repo-authority section) — six-node three-plane DAG (`.github` + `platform` overlay; `detections → validation → proof` authority chain; `website` rendering). Click panel = owns / must never own / claim boundary / inspect next.
  - Replaces the static `FailureModeStrip` and `RepoAuthorityDAG` on the homepage. Both static component files retained in `components/` for safe revert.

## Claim boundary preserved

- Public ceiling remains `CONTROLLED_TEST_VALIDATED`.
- `NOT_PUBLIC_SAFE` preserved.
- Website-rendering-is-not-proof boundary language preserved.
- No proof-record changes, no validation-record changes, no detection logic changes.
- No resume PDF asset added (none existed in `public/`).
- Operator page resume metrics are explicitly framed as an 8-month controlled build-and-validation cycle, not an enterprise production-deployment claim.

## Local validation

- `npm run check:site` — passed (tripped once mid-session on Operator page wording, resolved by re-phrasing).
- `npm run typecheck` — passed.
- `npm run build` — passed; 34 routes generated; First Load JS shared at 87.4 kB; React Flow ships in a code-split chunk.
- `git diff --check` — clean (CRLF/LF warnings only, expected on Windows).

## Pre-existing advisories (not addressed)

`npm audit` reports pre-existing Next.js advisories (1 high + 1 moderate, all scoped to `next@<16`). Out of scope for this PR; fix requires a Next major upgrade and a separate session.

## Deferred / not in this PR (operator decision)

- **Blocked-claim instant-tooltip / cursor: not-allowed / scoped scanner sweep** on the claim firewall and proof-ceiling matrices (prompt's polish layer).
- **LED-style state indicators** on the proof-ceiling matrices.
- **One or two terminal/typewriter/scramble reveals** on small status labels.
- **Third optional React Flow diagram** ("Eight stages. Source to public boundary.") — skipped per the prompt's *optional if scope stays clean*.
- **Theme toggle UI** — replaced by navy-kill + canvas per operator direction during the session.

## Test plan

- [ ] `npm run dev` and visually verify at 390 / 768 / 1280 / 1536 / 1920 / 2560 px.
- [ ] Confirm canvas opacity (`0.11`) does not compromise foreground readability on a 27" desktop.
- [ ] Tune React Flow viewport heights if 520–560 px feels short on wide desktop.
- [ ] Keyboard pass: tab through homepage and Operator page; confirm React Flow `Controls` and node selection don't trap focus.
- [ ] `prefers-reduced-motion: reduce` — confirm canvas falls back to one static draw and React Flow edges stop animating.
- [ ] Inspect Phase 1 / 2 / 3 commits individually so each phase can be reverted in isolation if needed.
- [ ] Decide whether to delete the now-unused `components/FailureModeStrip.tsx` and `components/RepoAuthorityDAG.tsx` in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)