### PR TITLE
feat(website): add bounded ATT&CK coverage map

### DIFF
--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -30,9 +30,9 @@ const entries = [
   },
   {
     label: "PR #7",
-    title: "Astro proof codex redesign",
+    title: "Astro proof codex redesign (historical · superseded)",
     detail:
-      "Converted the website into an Astro, Tailwind CSS, and TypeScript static proof codex for public inspection.",
+      "Historical milestone: an earlier iteration built the site on Astro, Tailwind CSS, and TypeScript. The current HawkinsOperations site is a React / Next.js App Router reviewer surface; the Astro stack is superseded and retained here only as a change record.",
   },
   {
     label: "PR #6",

--- a/app/globals.css
+++ b/app/globals.css
@@ -6461,6 +6461,180 @@ body::after {
 }
 .truth-matrix__legend-item { display: inline-flex; align-items: center; gap: 0.4rem; }
 
+/* ── MITRE ATT&CK coverage map ─────────────────────────────────────── */
+.attack-map {
+  border: 1px solid var(--moon-border);
+  border-radius: 10px;
+  background: rgba(11, 17, 28, 0.6);
+  padding: 1.2rem 1.2rem 1.4rem;
+}
+.attack-map__why {
+  font-size: 0.85rem;
+  line-height: 1.55;
+  color: var(--muted);
+  margin-bottom: 1.2rem;
+  max-width: 64ch;
+}
+.attack-map__why strong { color: var(--ceiling-amber); }
+
+.attack-map__families {
+  display: grid;
+  gap: 0.9rem;
+}
+.attack-fam {
+  border: 1px solid var(--moon-border);
+  border-radius: 8px;
+  background: rgba(8, 13, 22, 0.5);
+  padding: 0.7rem 0.9rem 1rem;
+}
+.attack-fam__head {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 0.8rem;
+}
+.attack-fam__rule {
+  width: 3px;
+  height: 0.95rem;
+  background: var(--electric-blue-bright);
+  border-radius: 2px;
+}
+.attack-fam__name {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ice-blue);
+  margin: 0;
+}
+.attack-fam__count {
+  margin-left: auto;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.66rem;
+  color: var(--muted);
+  border: 1px solid var(--moon-border);
+  border-radius: 999px;
+  padding: 0.05rem 0.5rem;
+}
+.attack-fam__nodes {
+  display: grid;
+  gap: 0.7rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.attack-node {
+  border: 1px solid var(--moon-border);
+  border-left: 3px solid var(--moon-border);
+  border-radius: 7px;
+  background: rgba(11, 17, 28, 0.75);
+  padding: 0.8rem 0.9rem;
+}
+.attack-node--validated { border-left-color: var(--electric-blue-bright); }
+.attack-node--fixture   { border-left-color: var(--ice-blue); }
+.attack-node--private   { border-left-color: var(--blocked-red-strong); }
+.attack-node--planned   { border-left-color: var(--ceiling-amber); }
+.attack-node--contract  { border-left-color: var(--muted); }
+
+.attack-node__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+.attack-node__id {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  color: var(--silver-bright);
+}
+.attack-node__tone {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.58rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.attack-node__title {
+  margin: 0.35rem 0 0.6rem;
+  font-size: 0.86rem;
+  line-height: 1.35;
+  color: var(--silver);
+}
+.attack-node__rows {
+  display: grid;
+  gap: 0.35rem;
+  margin: 0;
+}
+.attack-node__row {
+  display: grid;
+  grid-template-columns: 5.2rem 1fr;
+  gap: 0.5rem;
+  font-size: 0.74rem;
+  line-height: 1.4;
+}
+.attack-node__row dt {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+  padding-top: 0.1rem;
+}
+.attack-node__row dd { margin: 0; color: var(--silver); }
+.attack-node__attack { color: var(--accent); }
+.attack-node__ceiling {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.68rem;
+  color: var(--ceiling-amber);
+  letter-spacing: 0.02em;
+}
+.attack-node__blocked {
+  margin: 0.7rem 0 0;
+  padding-top: 0.6rem;
+  border-top: 1px solid var(--moon-border);
+  font-size: 0.7rem;
+  line-height: 1.45;
+  color: var(--muted);
+}
+.attack-node__blocked-tag {
+  display: inline-block;
+  margin-right: 0.45rem;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--blocked-red-strong);
+}
+
+.attack-map__legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem 1.3rem;
+  margin-top: 1.2rem;
+  padding-top: 0.9rem;
+  border-top: 1px solid var(--moon-border);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.66rem;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+.attack-map__legend-item { display: inline-flex; align-items: center; gap: 0.4rem; }
+.attack-dot { width: 10px; height: 10px; border-radius: 2px; display: inline-block; }
+.attack-dot--validated { background: var(--electric-blue-bright); }
+.attack-dot--fixture   { background: var(--ice-blue); }
+.attack-dot--private   { background: var(--blocked-red-strong); }
+.attack-dot--planned   { background: var(--ceiling-amber); }
+.attack-dot--contract  { background: var(--muted); }
+
+.attack-map__safe {
+  margin: 1rem 0 0;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  color: var(--muted);
+  font-style: italic;
+}
+
 /* Activity Ledger */
 .activity-ledger {
   border: 1px solid var(--moon-border);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import ActivityLedger from "@components/ActivityLedger";
+import AttackCoverageMap from "@components/AttackCoverageMap";
 import ArtifactMachine from "@components/ArtifactMachine";
 import ClaimFirewallPanel from "@components/ClaimFirewallPanel";
 import FailureModeStrip from "@components/FailureModeStrip";
@@ -159,6 +160,35 @@ export default function HomePage() {
       <section id="failure-mode" className="cockpit-section--tight">
         <div className="container reveal reveal--up">
           <FailureModeStrip />
+        </div>
+      </section>
+
+      {/* ── 03b · MITRE ATT&CK-mapped detection coverage ─────────────── */}
+      <section id="attack-coverage" className="cockpit-section--tight">
+        <div className="container">
+          <div className="mb-6">
+            <p className="cockpit-eyebrow">MITRE ATT&CK-mapped detection coverage</p>
+            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
+              Detections carry an ATT&CK mapping, a proof ceiling, and a blocked runtime claim.
+            </h2>
+            <p className="muted mt-3 text-sm leading-6 max-w-3xl">
+              Detection coverage is mapped to ATT&CK techniques with explicit validation state, proof
+              ceiling, and blocked runtime/customer claims. General reviewer value for detection
+              engineering, SOC operations, identity security, and validation coverage.
+            </p>
+          </div>
+          <div className="reveal reveal--up" data-delay="1">
+            <AttackCoverageMap />
+          </div>
+          <div className="biz-translate" role="note" aria-label="Business translation">
+            <span className="biz-translate__label">In plain English</span>
+            <span>
+              <span className="biz-translate__text">
+                Each detection says which ATT&CK behavior it targets, how far its proof reaches, and what
+                it does not claim. Mapping is intent and coverage — not live telemetry or deployment.
+              </span>
+            </span>
+          </div>
         </div>
       </section>
 

--- a/components/ActivityLedger.tsx
+++ b/components/ActivityLedger.tsx
@@ -41,10 +41,11 @@ export default function ActivityLedger() {
           </h2>
           <p className="activity-ledger__sub">
             Hand-maintained snapshot of recently merged work across the HawkinsOperations organization.
-            This list is not auto-updated and does not claim runtime-active, signal-observed, public-safe
-            runtime proof, GPU CI proven, model execution in CI, AI-approved disposition, or
-            analyst-approved disposition. Claims remain bounded by the public ceiling
-            CONTROLLED_TEST_VALIDATED. Website rendering is not proof.
+            This snapshot is hand-maintained and may lag GitHub main; repo main remains source truth for
+            merged implementation. This list is not auto-updated and does not claim runtime-active,
+            signal-observed, public-safe runtime proof, GPU CI proven, model execution in CI,
+            AI-approved disposition, or analyst-approved disposition. Claims remain bounded by the public
+            ceiling CONTROLLED_TEST_VALIDATED. Website rendering is not proof.
           </p>
         </div>
         <span className="activity-ledger__snapshot">SNAPSHOT · {activityLedgerSnapshotDate}</span>

--- a/components/AttackCoverageMap.tsx
+++ b/components/AttackCoverageMap.tsx
@@ -1,0 +1,100 @@
+/**
+ * AttackCoverageMap
+ *
+ * MITRE ATT&CK-mapped detection coverage, grouped into detection families.
+ * Each node carries: detection ID, ATT&CK technique/family label, proof
+ * ceiling, validation state, and a blocked runtime/signal boundary.
+ *
+ * Claim contract:
+ *  - ATT&CK mapping describes detection intent and coverage. It does not
+ *    prove live telemetry, runtime deployment, signal observation, or use.
+ *  - Every node renders a blocked runtime/signal marker. Website rendering
+ *    does not promote any node above its stated ceiling.
+ *  - Data lives in src/data/attackCoverage.ts.
+ */
+
+import { attackFamilies, attackMapSafeCopy, type AttackTone } from "@data/attackCoverage";
+
+const toneClass: Record<AttackTone, string> = {
+  validated: "attack-node--validated",
+  fixture: "attack-node--fixture",
+  private: "attack-node--private",
+  planned: "attack-node--planned",
+  contract: "attack-node--contract",
+};
+
+const toneLabel: Record<AttackTone, string> = {
+  validated: "validated",
+  fixture: "fixture-only",
+  private: "private · not public-safe",
+  planned: "validation planned",
+  contract: "contract only",
+};
+
+export default function AttackCoverageMap() {
+  return (
+    <div className="attack-map" role="region" aria-label="MITRE ATT&CK-mapped detection coverage">
+      <p className="attack-map__why">
+        <strong>Why this matters · </strong>
+        Reviewers in detection engineering, SOC operations, identity security, and validation can read
+        coverage intent at a glance: each detection carries an ATT&CK mapping, an explicit proof ceiling,
+        a validation state, and a blocked runtime/signal boundary. The map is general reviewer value,
+        not a deployment claim.
+      </p>
+
+      <div className="attack-map__families">
+        {attackFamilies.map((fam) => (
+          <section key={fam.family} className="attack-fam" aria-label={fam.family}>
+            <header className="attack-fam__head">
+              <span className="attack-fam__rule" aria-hidden="true" />
+              <h3 className="attack-fam__name">{fam.family}</h3>
+              <span className="attack-fam__count">{fam.nodes.length}</span>
+            </header>
+
+            <div className="attack-fam__nodes">
+              {fam.nodes.map((node) => (
+                <article key={node.id} className={`attack-node ${toneClass[node.tone]}`}>
+                  <div className="attack-node__top">
+                    <span className="attack-node__id">{node.id}</span>
+                    <span className="attack-node__tone">{toneLabel[node.tone]}</span>
+                  </div>
+                  <p className="attack-node__title">{node.title}</p>
+
+                  <dl className="attack-node__rows">
+                    <div className="attack-node__row">
+                      <dt>ATT&amp;CK</dt>
+                      <dd className="attack-node__attack">{node.attack}</dd>
+                    </div>
+                    <div className="attack-node__row">
+                      <dt>Ceiling</dt>
+                      <dd className="attack-node__ceiling">{node.ceiling}</dd>
+                    </div>
+                    <div className="attack-node__row">
+                      <dt>Validation</dt>
+                      <dd>{node.validation}</dd>
+                    </div>
+                  </dl>
+
+                  <p className="attack-node__blocked" role="note">
+                    <span className="attack-node__blocked-tag">RUNTIME / SIGNAL · BLOCKED</span>
+                    {node.boundary}
+                  </p>
+                </article>
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+
+      <div className="attack-map__legend" aria-label="Coverage map legend">
+        <span className="attack-map__legend-item"><span className="attack-dot attack-dot--validated" />validated</span>
+        <span className="attack-map__legend-item"><span className="attack-dot attack-dot--fixture" />fixture-only</span>
+        <span className="attack-map__legend-item"><span className="attack-dot attack-dot--private" />private · not public-safe</span>
+        <span className="attack-map__legend-item"><span className="attack-dot attack-dot--planned" />validation planned</span>
+        <span className="attack-map__legend-item"><span className="attack-dot attack-dot--contract" />contract only</span>
+      </div>
+
+      <p className="attack-map__safe">{attackMapSafeCopy}</p>
+    </div>
+  );
+}

--- a/src/data/attackCoverage.ts
+++ b/src/data/attackCoverage.ts
@@ -1,0 +1,166 @@
+/**
+ * MITRE ATT&CK-mapped detection coverage.
+ *
+ * Reviewer value: shows that HawkinsOperations detections carry an ATT&CK
+ * mapping alongside an explicit proof ceiling, validation state, and a
+ * blocked-claim boundary. The map is general detection-engineering value —
+ * it is not tied to any single employer or deployment.
+ *
+ * Claim contract enforced in the copy below:
+ *  - ATT&CK mapping explains detection intent and coverage. It does not
+ *    prove live telemetry, runtime deployment, signal observation, or use.
+ *  - Technique IDs are only asserted where repo-backed. Where a precise ID
+ *    is not represented in source, the family/category is shown with a
+ *    "mapping in source artifact" / "mapping pending" qualifier rather than
+ *    an invented technique ID.
+ *  - Every node's runtime and signal claims are blocked at this ceiling.
+ */
+
+export type AttackTone =
+  | "validated" // controlled-test validated at the public ceiling
+  | "fixture" // fixture-only validation, no live source
+  | "private" // private evidence captured, blocked from public proof
+  | "planned" // source exists, validation planned
+  | "contract"; // boundary/contract surface, not a coverage claim
+
+export type AttackNode = {
+  id: string;
+  title: string;
+  /** ATT&CK technique label — precise ID only where repo-backed */
+  attack: string;
+  /** status / proof ceiling label */
+  ceiling: string;
+  tone: AttackTone;
+  /** validation count line, or contract status */
+  validation: string;
+  /** what this node does NOT prove — phrased to keep runtime/signal blocked */
+  boundary: string;
+};
+
+export type AttackFamily = {
+  family: string;
+  nodes: AttackNode[];
+};
+
+export const attackFamilies: AttackFamily[] = [
+  {
+    family: "Endpoint / PowerShell",
+    nodes: [
+      {
+        id: "HO-DET-001",
+        title: "Suspicious PowerShell EncodedCommand Execution",
+        attack: "T1059.001 · Command and Scripting Interpreter: PowerShell",
+        ceiling: "CONTROLLED_TEST_VALIDATED",
+        tone: "validated",
+        validation: "14 controlled cases: 7 positive, 7 negative, 0 missed, 0 false-positive negatives",
+        boundary:
+          "Runtime and signal claims are blocked at this ceiling. No production, customer-deployment, or autonomous-resolution claim is made.",
+      },
+    ],
+  },
+  {
+    family: "Endpoint / Persistence",
+    nodes: [
+      {
+        id: "HO-DET-011",
+        title: "Windows Service Creation / Binary Change",
+        attack: "Persistence: service creation — ATT&CK mapping in source artifact",
+        ceiling: "PRIVATE_RUNTIME_EVIDENCE_CAPTURED · NOT_PUBLIC_SAFE",
+        tone: "private",
+        validation: "17 controlled cases: 7 positive, 10 negative, 0 missed, 0 false-positive negatives",
+        boundary:
+          "Private runtime evidence is held privately and is blocked from public proof; no public-safe runtime claim is made and runtime/signal stay blocked.",
+      },
+      {
+        id: "HO-DET-012",
+        title: "Suspicious Scheduled Task Creation",
+        attack: "Scheduled Task/Job: Scheduled Task — ATT&CK mapping in source artifact",
+        ceiling: "CONTROLLED_TEST_VALIDATED",
+        tone: "validated",
+        validation: "8 controlled cases: 4 positive, 4 negative, 0 missed, 0 false-positive negatives",
+        boundary:
+          "No proof record yet. Runtime, signal, public-proof, and completeness claims are blocked at this ceiling.",
+      },
+    ],
+  },
+  {
+    family: "Cloud / IAM",
+    nodes: [
+      {
+        id: "AWS-DET-001",
+        title: "CloudTrail-Style IAM Denial",
+        attack: "Cloud / IAM denial — mapping in source/proof artifacts",
+        ceiling: "CONTROLLED_TEST_VALIDATED · FIXTURE_ONLY",
+        tone: "fixture",
+        validation: "6 fixture cases: 3 positive, 3 negative",
+        boundary:
+          "Fixture-only. Live AWS and CloudTrail proof are blocked at this ceiling; no live-cloud claim is made.",
+      },
+    ],
+  },
+  {
+    family: "Identity / Access Behavior",
+    nodes: [
+      {
+        id: "ID-DET-001…004",
+        title: "Identity Detection Family",
+        attack: "ATT&CK-aligned identity behavior (mapping per detection)",
+        ceiling: "CONTROLLED_TEST_VALIDATED",
+        tone: "validated",
+        validation:
+          "ID-DET-001…004 each: 10 controlled cases — 5 positive, 5 negative, 0 missed, 0 false-positive negatives",
+        boundary:
+          "Live IdP, production identity coverage, and completeness claims are blocked at this ceiling; no live-identity claim is made.",
+      },
+    ],
+  },
+  {
+    family: "Telemetry / Defense Evasion",
+    nodes: [
+      {
+        id: "HO-DET-013",
+        title: "Defense Tool and Telemetry Tamper Attempt",
+        attack: "Defense evasion / telemetry tamper — mapping in source artifact",
+        ceiling: "SOURCE_EXISTS · VALIDATION_PLANNED",
+        tone: "planned",
+        validation: "Validation not complete.",
+        boundary:
+          "Source exists only. Validation, runtime, and signal claims are blocked at this ceiling; no validation claim is made yet.",
+      },
+    ],
+  },
+  {
+    family: "Network / Visibility Contract",
+    nodes: [
+      {
+        id: "HO-NDR-001",
+        title: "Security Onion / NDR Visibility Boundary",
+        attack: "Boundary / corroboration contract — not a coverage claim",
+        ceiling: "BOUNDARY_CONTRACT_ONLY",
+        tone: "contract",
+        validation: "Contract surface — no validation count.",
+        boundary:
+          "Security Onion observed proof is blocked; this defines a visibility boundary and makes no observed-signal claim.",
+      },
+    ],
+  },
+  {
+    family: "Pipeline / Telemetry Contract",
+    nodes: [
+      {
+        id: "HO-PIPE-001",
+        title: "Cribl / Pipeline Route Integrity",
+        attack: "Pipeline route contract — not an ATT&CK detection proof",
+        ceiling: "SOURCE_EXISTS · VALIDATION_PLANNED",
+        tone: "planned",
+        validation: "Source exists; validation planned.",
+        boundary:
+          "Cribl-routed proof is blocked at this ceiling; no Cribl-routed claim is made.",
+      },
+    ],
+  },
+];
+
+/** Section-level safe copy. Kept here so the contract scanner sees the negation. */
+export const attackMapSafeCopy =
+  "ATT&CK mapping helps reviewers understand detection intent and coverage. It does not prove live telemetry, runtime deployment, signal observation, or customer use.";


### PR DESCRIPTION
Summary:
- Adds a homepage MITRE ATT&CK-mapped detection coverage section.
- Surfaces detection families, validation counts, proof ceilings, and blocked runtime/signal claims.
- Adds bounded coverage data and a dedicated AttackCoverageMap component.
- Updates ActivityLedger snapshot caveat.
- Marks old Astro wording as historical/superseded while keeping the current site framed as React / Next.js App Router.

Scope:
- Website rendering only.
- Homepage ATT&CK coverage base only.
- No proof promotion.
- No runtime-active, signal-observed, production/customer deployment, public-safe runtime, AI-approved, analyst-approved, autonomous SOC, autonomous-resolution, Cribl-routed proof, Security Onion observed proof, live AWS, live IdP, live Splunk, or fleet-wide claim.

Validation:
- npm run check:site passed.
- npm run typecheck passed.
- npm run build passed.
- git diff --check passed.

Claim Boundary:
- Final ceiling remains CONTROLLED_TEST_VALIDATED.
- ATT&CK mapping explains detection intent and coverage; it does not prove live telemetry, runtime deployment, signal observation, or customer use.
- Website rendering routes reviewers to artifacts; it does not create proof.

Residual Caveat:
- This is a bounded homepage ATT&CK coverage base, not the full artifact-heavy reviewer cockpit.
- Future patch should deepen Validation Registry, platform contracts, proof machinery, and artifact parity across /proof, /pipeline, and /artifacts-style surfaces.