### PR TITLE
feat(website): add phase 2 reviewer cockpit surfaces

### DIFF
--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -11,6 +11,12 @@ export const metadata: Metadata = {
 
 const entries = [
   {
+    label: "2026-05-21",
+    title: "Validation Registry and Platform Contract reviewer layers added",
+    detail:
+      "Phase 2 added a Validation Registry dashboard, proof manifest console, verifier cards, platform contract blueprints, a receipt / ledger reviewer snapshot, and an expandable blocked-claim firewall. Rendering only — the website is not proof. Public ceiling remains CONTROLLED_TEST_VALIDATED; runtime, signal, and public-safe runtime proof remain blocked, and rows with no proof record stay marked NO_PROOF_RECORD.",
+  },
+  {
     label: "2026-05-17",
     title: "Proof Pack 001 official release routed",
     detail:

--- a/app/globals.css
+++ b/app/globals.css
@@ -8627,3 +8627,160 @@ body::after {
 }
 .review-route-selector__route--loop:hover  { box-shadow: 0 16px 40px rgba(0, 0, 0, 0.45), 0 0 22px rgba(96, 165, 250, 0.32); }
 .review-route-selector__route--split:hover { box-shadow: 0 16px 40px rgba(0, 0, 0, 0.45), 0 0 22px rgba(224, 189, 99, 0.35); }
+
+/* ============================================================ */
+/* Phase 2 · reviewer cockpit layers                            */
+/* ============================================================ */
+
+/* Shared compact badges */
+.p2-badge {
+  display: inline-flex; align-items: center; gap: 0.4ch;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.6rem; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 0.28rem 0.55rem; border-radius: 3px; border: 1px solid var(--moon-border);
+  background: rgba(8, 13, 22, 0.6); color: var(--silver);
+}
+.p2-badge--ceiling { color: var(--ice-blue); border-color: var(--ice-blue-soft); background: rgba(143, 216, 255, 0.07); }
+.p2-badge--block   { color: var(--blocked-red); border-color: rgba(252, 165, 165, 0.32); background: rgba(252, 165, 165, 0.06); }
+.p2-badge--drift   { color: var(--ceiling-amber); border-color: var(--ceiling-amber-soft); background: var(--ceiling-amber-soft); }
+.p2-badge--warn    { color: var(--ceiling-amber); border-color: var(--ceiling-amber-soft); background: rgba(224, 189, 99, 0.05); }
+
+/* Boundary drawer (exists / proves / does-not-prove) */
+.boundary-drawer { border: 1px solid var(--moon-border); border-radius: 6px; background: rgba(8, 13, 22, 0.45); }
+.boundary-drawer > summary {
+  cursor: pointer; list-style: none; padding: 0.7rem 0.9rem;
+  font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.7rem;
+  letter-spacing: 0.1em; text-transform: uppercase; color: var(--ice-blue);
+  display: flex; align-items: center; justify-content: space-between; gap: 0.5rem;
+}
+.boundary-drawer > summary::-webkit-details-marker { display: none; }
+.boundary-drawer > summary::after { content: "\25B8"; color: var(--muted); transition: transform 0.15s; }
+.boundary-drawer[open] > summary::after { transform: rotate(90deg); }
+.boundary-drawer__grid { display: grid; gap: 0.6rem; padding: 0 0.9rem 0.9rem; }
+@media (min-width: 800px) { .boundary-drawer__grid { grid-template-columns: repeat(3, 1fr); } }
+.boundary-drawer__col { border-top: 1px solid var(--moon-border); padding-top: 0.55rem; }
+.boundary-drawer__col h4 {
+  font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.58rem;
+  letter-spacing: 0.16em; text-transform: uppercase; margin: 0 0 0.4rem;
+}
+.boundary-drawer__col--exists h4  { color: var(--silver); }
+.boundary-drawer__col--proves h4  { color: var(--ice-blue); }
+.boundary-drawer__col--block h4   { color: var(--blocked-red); }
+.boundary-drawer__col ul { margin: 0; padding: 0; list-style: none; display: grid; gap: 0.35rem; }
+.boundary-drawer__col li { font-size: 0.78rem; line-height: 1.45; color: var(--muted); padding-left: 0.9rem; position: relative; }
+.boundary-drawer__col li::before { content: "\00B7"; position: absolute; left: 0; color: var(--moon-border-bright); }
+.boundary-drawer__col--block li::before { content: "\2298"; color: var(--blocked-red); font-size: 0.7rem; }
+
+/* Validation registry dashboard */
+.vr-stats { display: grid; grid-template-columns: repeat(2, 1fr); gap: 0.6rem; margin-bottom: 1.1rem; }
+@media (min-width: 720px) { .vr-stats { grid-template-columns: repeat(5, 1fr); } }
+.vr-stat { border: 1px solid var(--moon-border); border-radius: 6px; padding: 0.7rem 0.8rem; background: rgba(8, 13, 22, 0.5); }
+.vr-stat__value { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 1.5rem; color: var(--silver-bright); line-height: 1; }
+.vr-stat__value--block { color: var(--blocked-red); }
+.vr-stat__label { display: block; margin-top: 0.4rem; font-size: 0.66rem; letter-spacing: 0.04em; color: var(--muted); }
+.vr-filters { display: flex; flex-wrap: wrap; gap: 0.45rem; margin-bottom: 1rem; }
+.vr-filter {
+  font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.66rem; letter-spacing: 0.08em;
+  text-transform: uppercase; padding: 0.4rem 0.75rem; border-radius: 3px; cursor: pointer;
+  border: 1px solid var(--moon-border); background: rgba(8, 13, 22, 0.5); color: var(--muted);
+}
+.vr-filter[aria-pressed="true"] { color: var(--ice-blue); border-color: var(--ice-blue-soft); background: rgba(143, 216, 255, 0.08); }
+.vr-rows { display: grid; gap: 0.55rem; }
+.vr-row { border: 1px solid var(--moon-border); border-radius: 7px; background: rgba(8, 13, 22, 0.5); overflow: hidden; }
+.vr-row[data-no-proof="true"] { border-left: 3px solid var(--ceiling-amber); }
+.vr-row[data-contract-only="true"] { border-left: 3px solid var(--muted); border-style: dashed; }
+.vr-row__head { display: grid; gap: 0.6rem; padding: 0.8rem 0.95rem; grid-template-columns: 1fr; align-items: center; }
+@media (min-width: 760px) { .vr-row__head { grid-template-columns: 0.9fr 1.4fr auto; } }
+.vr-row__id { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.9rem; color: var(--silver-bright); }
+.vr-row__fam { display: block; margin-top: 0.2rem; font-size: 0.6rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ice-blue); }
+.vr-row__name { font-size: 0.86rem; color: var(--silver); }
+.vr-row__counts { display: flex; flex-wrap: wrap; gap: 0.3rem; margin-top: 0.35rem; }
+.vr-count { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.58rem; letter-spacing: 0.06em; color: var(--muted); border: 1px solid var(--moon-border); border-radius: 3px; padding: 0.12rem 0.4rem; }
+.vr-count--zero { color: var(--ice-blue); border-color: var(--ice-blue-soft); }
+.vr-row__badges { display: flex; flex-wrap: wrap; gap: 0.3rem; justify-content: flex-end; }
+.vr-row__drawer { border-top: 1px solid var(--moon-border); }
+.vr-row__drawer.boundary-drawer { border-radius: 0; border-left: 0; border-right: 0; border-bottom: 0; background: transparent; }
+
+/* Verifier check cards */
+.vc-grid { display: grid; gap: 0.7rem; }
+@media (min-width: 820px) { .vc-grid { grid-template-columns: repeat(3, 1fr); } }
+.vc-card { border: 1px solid var(--moon-border); border-radius: 7px; background: rgba(5, 9, 16, 0.6); padding: 0.9rem; }
+.vc-card__group { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.62rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ice-blue); }
+.vc-card__blurb { font-size: 0.78rem; color: var(--muted); margin: 0.4rem 0 0.7rem; line-height: 1.45; }
+.vc-card__list { margin: 0; padding: 0; list-style: none; display: grid; gap: 0.35rem; }
+.vc-card__script { display: flex; align-items: baseline; gap: 0.5ch; font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.72rem; color: var(--silver); }
+.vc-card__script::before { content: "\25B9"; color: var(--ice-blue); }
+
+/* Proof manifest console */
+.pm-console { border: 1px solid var(--moon-border-bright); border-radius: 8px; background: rgba(3, 6, 12, 0.78); overflow: hidden; }
+.pm-console__bar { display: flex; align-items: center; gap: 0.6rem; padding: 0.55rem 0.85rem; border-bottom: 1px solid var(--moon-border); background: rgba(8, 13, 22, 0.7); }
+.pm-console__dot { width: 9px; height: 9px; border-radius: 50%; background: var(--ice-blue); box-shadow: 0 0 8px var(--ice-blue-glow); }
+.pm-console__path { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.66rem; letter-spacing: 0.06em; color: var(--muted); }
+.pm-panel { border-bottom: 1px solid var(--moon-border); }
+.pm-panel > summary {
+  cursor: pointer; list-style: none; padding: 0.7rem 0.85rem; display: flex; align-items: center; gap: 0.6rem;
+  font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.7rem; letter-spacing: 0.08em; text-transform: uppercase;
+}
+.pm-panel > summary::-webkit-details-marker { display: none; }
+.pm-panel > summary::after { content: "+"; margin-left: auto; color: var(--muted); }
+.pm-panel[open] > summary::after { content: "\2212"; }
+.pm-panel--include > summary { color: var(--ice-blue); }
+.pm-panel--exclude > summary { color: var(--blocked-red); }
+.pm-panel__body { padding: 0 0.85rem 0.8rem; display: grid; gap: 0.4rem; }
+.pm-line { display: grid; grid-template-columns: auto 1fr; gap: 0.6ch; align-items: baseline; font-size: 0.78rem; line-height: 1.45; }
+.pm-line__name { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.72rem; color: var(--silver-bright); }
+.pm-line__note { color: var(--muted); }
+.pm-line__mark { font-family: "JetBrains Mono", ui-monospace, monospace; }
+.pm-line--in .pm-line__mark { color: var(--ice-blue); }
+.pm-line--out .pm-line__mark { color: var(--blocked-red); }
+
+/* Platform contract blueprint (asymmetric three-lane) */
+.pcb-grid { display: grid; gap: 0.9rem; }
+@media (min-width: 880px) { .pcb-grid { grid-template-columns: repeat(2, 1fr); } }
+.pcb { border: 1px solid var(--moon-border); border-radius: 9px; background: rgba(8, 13, 22, 0.5); overflow: hidden; display: flex; flex-direction: column; }
+.pcb__head { padding: 0.95rem 1rem 0.7rem; border-bottom: 1px solid var(--moon-border); }
+.pcb__type { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.6rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ice-blue); }
+.pcb__name { font-size: 1.05rem; color: var(--silver-bright); margin: 0.3rem 0; }
+.pcb__supports { font-size: 0.8rem; line-height: 1.5; color: var(--muted); margin: 0; }
+.pcb__lanes { display: grid; gap: 1px; background: var(--moon-border); }
+@media (min-width: 520px) { .pcb__lanes { grid-template-columns: repeat(3, 1fr); } }
+.pcb__lane { background: rgba(5, 9, 16, 0.6); padding: 0.65rem 0.7rem; }
+.pcb__lane-kind { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.55rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ice-blue); }
+.pcb__lane-label { font-size: 0.72rem; color: var(--silver); margin: 0.25rem 0 0.3rem; }
+.pcb__lane-path { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.62rem; color: var(--muted); word-break: break-all; }
+.pcb__fields { display: flex; flex-wrap: wrap; gap: 0.35rem; padding: 0.7rem 1rem 0; }
+.pcb__field { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.6rem; border: 1px solid var(--moon-border); border-radius: 3px; padding: 0.2rem 0.45rem; color: var(--muted); }
+.pcb__field b { color: var(--silver-bright); font-weight: 600; }
+.pcb__caveat { display: flex; gap: 0.5ch; padding: 0.7rem 1rem 0; font-size: 0.74rem; line-height: 1.45; color: var(--ceiling-amber); }
+.pcb__short { padding: 0.6rem 1rem; font-size: 0.8rem; color: var(--silver); font-style: italic; }
+.pcb__foot { margin-top: auto; border-top: 1px dashed rgba(252, 165, 165, 0.3); background: rgba(252, 165, 165, 0.04); padding: 0.7rem 1rem; }
+.pcb__foot-label { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.56rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--blocked-red); }
+.pcb__foot-list { margin: 0.4rem 0 0; padding: 0; list-style: none; display: grid; gap: 0.25rem; }
+.pcb__foot-list li { font-size: 0.74rem; color: var(--muted); padding-left: 0.95rem; position: relative; }
+.pcb__foot-list li::before { content: "\2298"; position: absolute; left: 0; color: var(--blocked-red); font-size: 0.66rem; }
+
+/* Receipt / ledger timeline */
+.rlt { border: 1px solid var(--moon-border); border-radius: 8px; background: rgba(5, 9, 16, 0.55); padding: 1rem 1.1rem; }
+.rlt__caveat { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.62rem; letter-spacing: 0.06em; color: var(--ceiling-amber); margin: 0 0 0.9rem; }
+.rlt__lanes { display: grid; gap: 0; position: relative; }
+.rlt__lane { display: grid; grid-template-columns: auto 1fr; gap: 0.85rem; padding: 0.6rem 0; border-left: 1px solid var(--moon-border); padding-left: 1rem; margin-left: 0.5rem; position: relative; }
+.rlt__lane::before { content: ""; position: absolute; left: -5px; top: 0.85rem; width: 9px; height: 9px; border-radius: 50%; background: var(--ice-blue); box-shadow: 0 0 8px var(--ice-blue-glow); }
+.rlt__marker { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.7rem; color: var(--ice-blue); }
+.rlt__kind { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.55rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--muted); }
+.rlt__title { font-size: 0.86rem; color: var(--silver-bright); margin: 0.1rem 0; }
+.rlt__line { font-size: 0.78rem; color: var(--muted); margin: 0; line-height: 1.45; }
+
+/* Blocked-claim firewall expandable strip */
+.bcf { border: 1px solid rgba(252, 165, 165, 0.3); border-radius: 8px; background: rgba(252, 165, 165, 0.03); padding: 1rem 1.1rem; }
+.bcf__head { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: 0.5rem; margin-bottom: 0.85rem; }
+.bcf__title { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.66rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--blocked-red); }
+.bcf__chips { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+.bcf__chip { border: 1px solid rgba(252, 165, 165, 0.32); border-radius: 4px; background: rgba(252, 165, 165, 0.06); overflow: hidden; }
+.bcf__chip > summary {
+  cursor: pointer; list-style: none; display: inline-flex; align-items: center; gap: 0.45ch;
+  font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 0.64rem; font-weight: 600;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--blocked-red); padding: 0.32rem 0.6rem;
+}
+.bcf__chip > summary::-webkit-details-marker { display: none; }
+.bcf__chip > summary::before { content: "\2298"; }
+.bcf__chip-detail { display: block; padding: 0 0.6rem 0.5rem; font-size: 0.72rem; color: var(--muted); max-width: 22rem; }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -189,6 +189,10 @@ export default function HomePage() {
               </span>
             </span>
           </div>
+          <div className="mt-4 flex flex-wrap items-center gap-3">
+            <a className="cta cta-quiet" href="/proof/#validation-registry">Validation registry →</a>
+            <a className="cta cta-quiet" href="/pipeline/#platform-contracts">Platform contracts →</a>
+          </div>
         </div>
       </section>
 

--- a/app/pipeline/page.tsx
+++ b/app/pipeline/page.tsx
@@ -2,8 +2,11 @@ import type { Metadata } from "next";
 import GpuFactoryLane from "@components/GpuFactoryLane";
 import PipelineGateCards from "@components/PipelineGateCards";
 import PipelineGateFlow from "@components/PipelineGateFlow";
+import PlatformContractBlueprint from "@components/PlatformContractBlueprint";
+import ReceiptLedgerTimeline from "@components/ReceiptLedgerTimeline";
 import StatusConsole from "@components/StatusConsole";
 import StatusChip from "@components/StatusChip";
+import ValidationRegistryDashboard from "@components/ValidationRegistryDashboard";
 import { externalLinks } from "@data/navigation";
 
 export const metadata: Metadata = {
@@ -204,10 +207,86 @@ export default function PipelinePage() {
         </div>
       </section>
 
+      {/* ── Validation registry dashboard ───────────────────────────── */}
+      <section id="validation-registry" className="cockpit-section--tight">
+        <div className="container">
+          <div className="mb-6">
+            <p className="cockpit-eyebrow">Validation registry</p>
+            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
+              Controlled-test packages · contract-enforced, human-review gated.
+            </h2>
+          </div>
+          <ValidationRegistryDashboard />
+        </div>
+      </section>
+
       {/* ── Local GPU Triage / Factory governed lane ────────────────── */}
       <section id="gpu-factory-lane" className="cockpit-section--tight">
         <div className="container reveal reveal--up">
           <GpuFactoryLane />
+        </div>
+      </section>
+
+      {/* ── Platform contract blueprints ────────────────────────────── */}
+      <section id="platform-contracts" className="cockpit-section--tight">
+        <div className="container">
+          <div className="mb-6">
+            <p className="cockpit-eyebrow">Platform contracts</p>
+            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
+              Schema · example · verifier. Blocked authority on every panel.
+            </h2>
+            <p className="muted mt-3 text-sm leading-6 max-w-3xl">
+              The SOAR packet models analyst support, not response authority. The AutoSOC case ledger
+              is append-only and human-review required. The controller reports state; it does not
+              promote proof.
+            </p>
+          </div>
+          <PlatformContractBlueprint
+            ids={[
+              "soar-case-packet-v0",
+              "autosoc-case-ledger-v0",
+              "detection-factory-controller-v0",
+              "ho-det-001-runtime-contract",
+              "ho-det-011-case-packet",
+            ]}
+          />
+        </div>
+      </section>
+
+      {/* ── AI / LLM support boundary ───────────────────────────────── */}
+      <section id="llm-boundary" className="cockpit-section--tight">
+        <div className="container">
+          <div className="mb-6">
+            <p className="cockpit-eyebrow">AI / LLM support boundary</p>
+            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
+              AI is labor. Evidence and human review authorize claims.
+            </h2>
+            <p className="muted mt-3 text-sm leading-6 max-w-3xl">
+              Offline LLM output may summarize sanitized facts and draft questions. It does not decide
+              disposition, approve proof, or close cases. Local GPU support is private support-only
+              infrastructure; the website describes the contract boundary, not public runtime proof.
+            </p>
+          </div>
+          <PlatformContractBlueprint
+            ids={[
+              "offline-llm-triage-support-contract",
+              "local-gpu-triage-gate",
+              "local-llm-runtime-receipt",
+            ]}
+          />
+        </div>
+      </section>
+
+      {/* ── Receipt / ledger timeline ───────────────────────────────── */}
+      <section id="receipt-lane" className="cockpit-section--tight">
+        <div className="container">
+          <div className="mb-6">
+            <p className="cockpit-eyebrow">Receipt lane</p>
+            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
+              Append-only reviewer snapshot.
+            </h2>
+          </div>
+          <ReceiptLedgerTimeline />
         </div>
       </section>
 

--- a/app/proof/page.tsx
+++ b/app/proof/page.tsx
@@ -1,15 +1,29 @@
 import type { Metadata } from "next";
 import ArtifactFamilyMatrix from "@components/ArtifactFamilyMatrix";
+import BlockedClaimFirewall from "@components/BlockedClaimFirewall";
 import RecentGovernedArtifacts from "@components/RecentGovernedArtifacts";
 import ClaimFirewallPanel from "@components/ClaimFirewallPanel";
+import PlatformContractBlueprint from "@components/PlatformContractBlueprint";
+import ProofManifestConsole from "@components/ProofManifestConsole";
 import PromotionGateLadder from "@components/PromotionGateLadder";
 import ProofPathTimeline, { type ProofPathStep } from "@components/ProofPathTimeline";
 import StatusConsole from "@components/StatusConsole";
+import ValidationRegistryDashboard from "@components/ValidationRegistryDashboard";
+import VerifierCheckCards from "@components/VerifierCheckCards";
 import { allowedClaims, promotionRequirements } from "@data/claims";
 import { blockedClaims } from "@config/blocked-claims";
 import { proofRecords } from "@data/proofRecords";
+import { proofStatusIndex } from "@data/proofPackManifest";
+import { reviewerPacket, checksumManifest } from "@data/proofPackManifest";
 import { externalLinks } from "@data/navigation";
 import { ceiling, publicSafe } from "@config/site";
+
+const proofStateBadge: Record<string, { label: string; tone: string }> = {
+  PROOF_RECORD_PRESENT: { label: "PROOF_RECORD_PRESENT", tone: "p2-badge p2-badge--ceiling" },
+  PRIVATE_RUNTIME_BOUNDARY: { label: "NOT_PUBLIC_SAFE", tone: "p2-badge p2-badge--block" },
+  NO_PROOF_RECORD: { label: "NO_PROOF_RECORD", tone: "p2-badge p2-badge--warn" },
+  BOUNDARY_CONTRACT_ONLY: { label: "BOUNDARY_CONTRACT_ONLY", tone: "p2-badge p2-badge--warn" },
+};
 
 export const metadata: Metadata = {
   title: "Proof | HawkinsOps",
@@ -206,6 +220,49 @@ export default function ProofIndexPage() {
         </div>
       </section>
 
+      {/* ── Validation registry dashboard ─────────────────────────────── */}
+      <section id="validation-registry" className="cockpit-section--tight">
+        <div className="container">
+          <div className="mb-6">
+            <p className="cockpit-eyebrow">Validation registry</p>
+            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
+              Controlled-test packages, fixture counts, blocked runtime states.
+            </h2>
+          </div>
+          <ValidationRegistryDashboard />
+        </div>
+      </section>
+
+      {/* ── Proof status index ────────────────────────────────────────── */}
+      <section id="proof-status-index" className="cockpit-section--tight">
+        <div className="container">
+          <div className="mb-6">
+            <p className="cockpit-eyebrow">Proof status index</p>
+            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
+              Per-detection proof status · human review required.
+            </h2>
+            <p className="muted mt-3 text-sm leading-6 max-w-3xl">
+              Index source · <span className="mono">{proofStatusIndex.path}</span>. Website status is{" "}
+              <span className="mono">{proofStatusIndex.websiteStatus}</span>. Some rows hold{" "}
+              <span className="mono">NO_PROOF_RECORD</span> where no proof record exists.
+            </p>
+          </div>
+          <div className="grid gap-2">
+            {proofStatusIndex.rows.map((row) => (
+              <div
+                key={row.id}
+                className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-[var(--moon-border)] bg-[rgba(8,13,22,0.5)] px-4 py-3"
+              >
+                <span className="mono text-sm text-[var(--silver-bright)]">{row.id}</span>
+                <span className="muted flex-1 text-sm">{row.note}</span>
+                <span className={`p2-badge p2-badge--${row.tone}`}>{row.status}</span>
+              </div>
+            ))}
+          </div>
+          <p className="muted mt-3 text-xs leading-5">{proofStatusIndex.humanReview} · website rendering is not proof.</p>
+        </div>
+      </section>
+
       {/* ── Supported claim routes ────────────────────────────────────── */}
       <section className="cockpit-section--tight">
         <div className="container">
@@ -255,6 +312,10 @@ export default function ProofIndexPage() {
           </div>
 
           <ClaimFirewallPanel />
+
+          <div className="mt-7">
+            <BlockedClaimFirewall />
+          </div>
 
           <div className="blocked-category-grid mt-7" data-ci-target="blocked-claims">
             {blockedCategories.map((cat) => (
@@ -336,6 +397,9 @@ export default function ProofIndexPage() {
                   <div className="proof-receipt-panel__head-right">
                     <span className="mono text-[0.6rem] tracking-[0.2em] uppercase text-[var(--silver)]">Ceiling</span>
                     <span className="proof-receipt-panel__ceiling mono">{record.proofLevel}</span>
+                    <span className={`mt-2 ${proofStateBadge[record.proofRecordState]?.tone ?? "p2-badge"}`}>
+                      {proofStateBadge[record.proofRecordState]?.label ?? record.proofRecordState}
+                    </span>
                   </div>
                 </header>
 
@@ -364,14 +428,20 @@ export default function ProofIndexPage() {
                       Open case file →
                     </a>
                   )}
-                  <a
-                    className={record.caseFileHref ? "cta cta-quiet" : "cta cta-primary"}
-                    href={record.proofRepoLink}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Proof repo record ↗
-                  </a>
+                  {record.proofRepoLink ? (
+                    <a
+                      className={record.caseFileHref ? "cta cta-quiet" : "cta cta-primary"}
+                      href={record.proofRepoLink}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Proof repo record ↗
+                    </a>
+                  ) : (
+                    <span className="cta cta-quiet" aria-disabled="true" style={{ opacity: 0.6, pointerEvents: "none" }}>
+                      No proof record
+                    </span>
+                  )}
                   <a className="cta cta-quiet" href={record.sourceRepoLink} target="_blank" rel="noopener noreferrer">
                     Source repo ↗
                   </a>
@@ -382,7 +452,71 @@ export default function ProofIndexPage() {
         </div>
       </section>
 
-      {/* ── Proof Pack 001 receipt console ─────────────────────────────── */}
+      {/* ── Proof Pack 001 manifest console ───────────────────────────── */}
+      <section id="proof-pack-001" className="cockpit-section--tight">
+        <div className="container">
+          <div className="mb-6">
+            <p className="cockpit-eyebrow">Proof pack · manifest</p>
+            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
+              Proof Pack 001 · included, excluded, and what it does not prove.
+            </h2>
+            <p className="muted mt-3 text-sm leading-6 max-w-3xl">
+              Proof Pack 001 routes a bounded HO-DET-001 reviewer packet at CONTROLLED_TEST_VALIDATED;
+              raw / private runtime evidence is excluded and remains NOT_PUBLIC_SAFE.
+            </p>
+          </div>
+          <div className="grid gap-5 lg:grid-cols-[1.2fr_0.8fr] items-start">
+            <ProofManifestConsole />
+            <div className="grid gap-3">
+              <div className="rounded-md border border-[var(--moon-border)] bg-[rgba(8,13,22,0.5)] p-4">
+                <p className="mono text-[0.62rem] tracking-[0.14em] uppercase text-[var(--ice-blue)]">{reviewerPacket.name}</p>
+                <p className="muted mt-1 text-sm leading-6">{reviewerPacket.scope}</p>
+                <p className="mono mt-3 text-[0.6rem] tracking-[0.12em] uppercase text-[var(--silver)]">Evidence chain</p>
+                <div className="mt-1 flex flex-wrap gap-1.5">
+                  {reviewerPacket.evidenceChain.map((link) => (
+                    <span key={link} className="p2-badge">{link}</span>
+                  ))}
+                </div>
+              </div>
+              <div className="rounded-md border border-[var(--moon-border)] bg-[rgba(8,13,22,0.5)] p-4">
+                <p className="mono text-[0.62rem] tracking-[0.14em] uppercase text-[var(--ice-blue)]">{checksumManifest.name}</p>
+                <p className="muted mt-1 text-sm leading-6">{checksumManifest.scope}</p>
+                <p className="muted mt-2 text-xs leading-5">{checksumManifest.doesNotProve}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Verifier check cards ──────────────────────────────────────── */}
+      <section id="verifiers" className="cockpit-section--tight">
+        <div className="container">
+          <div className="mb-6">
+            <p className="cockpit-eyebrow">Verifiers</p>
+            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
+              Verifier routes · structure, parity, boundaries, contracts.
+            </h2>
+          </div>
+          <VerifierCheckCards />
+        </div>
+      </section>
+
+      {/* ── Platform boundaries ───────────────────────────────────────── */}
+      <section id="platform-boundaries" className="cockpit-section--tight">
+        <div className="container">
+          <div className="mb-6">
+            <p className="cockpit-eyebrow">Platform boundaries</p>
+            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
+              Non-promotional guardrails · drift surfaced, not normalized.
+            </h2>
+          </div>
+          <PlatformContractBlueprint
+            ids={["ho-det-001-runtime-contract", "ho-det-011-case-packet", "local-llm-runtime-receipt"]}
+          />
+        </div>
+      </section>
+
+      {/* ── Proof Pack 001 release receipt console ─────────────────────── */}
       <section className="cockpit-section--tight">
         <div className="container">
           <div className="mb-6">

--- a/app/start/page.tsx
+++ b/app/start/page.tsx
@@ -41,6 +41,33 @@ const intakeRoutes = [
   },
 ];
 
+const phase2Routes = [
+  {
+    tag: "VALIDATION",
+    title: "Validation registry",
+    sub: "Controlled-test packages, fixture counts, and blocked runtime / signal / public-safe states.",
+    href: "/proof/#validation-registry",
+  },
+  {
+    tag: "PROOF / VERIFIER",
+    title: "Proof / verifier",
+    sub: "Proof Pack 001 manifest, included / excluded items, and verifier routes.",
+    href: "/proof/#proof-pack-001",
+  },
+  {
+    tag: "PLATFORM",
+    title: "Platform contracts",
+    sub: "SOAR packet, AutoSOC ledger, factory controller, and blocked authority footers.",
+    href: "/pipeline/#platform-contracts",
+  },
+  {
+    tag: "AI GOVERNANCE",
+    title: "AI governance boundary",
+    sub: "Offline LLM support is support-only labor; human review remains authority.",
+    href: "/pipeline/#llm-boundary",
+  },
+];
+
 export const metadata: Metadata = {
   title: "Start | HawkinsOps",
   description:
@@ -84,6 +111,26 @@ export default function StartPage() {
                 <h3 className="start-routes__title">{r.title}</h3>
                 <p className="start-routes__sub">{r.sub}</p>
                 <p className="start-routes__arrow">{r.external ? "Open ↗" : "Open →"}</p>
+              </a>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="cockpit-section--tight">
+        <div className="container reveal reveal--up">
+          <SectionHeader title="Phase 2 reviewer layers" eyebrow="Direct routes" />
+          <p className="muted mt-3 max-w-3xl text-sm leading-6">
+            Four direct entries into the Phase 2 cockpit layers. Each opens a bounded reviewer
+            surface — none promotes a stronger claim than the public ceiling allows.
+          </p>
+          <div className="start-routes mt-6">
+            {phase2Routes.map((r) => (
+              <a key={r.title} className="start-routes__card spotlight" href={r.href}>
+                <span className="start-routes__num">{r.tag}</span>
+                <h3 className="start-routes__title">{r.title}</h3>
+                <p className="start-routes__sub">{r.sub}</p>
+                <p className="start-routes__arrow">Open →</p>
               </a>
             ))}
           </div>

--- a/components/BlockedClaimFirewall.tsx
+++ b/components/BlockedClaimFirewall.tsx
@@ -1,0 +1,29 @@
+/**
+ * BlockedClaimFirewall
+ *
+ * Stronger visual blocked-claim strip. Each chip expands to show why the
+ * claim is blocked. Blocked claims stay visually separate from proof-positive
+ * content and are not presented as features. Renders
+ * src/data/blockedClaimFirewall.ts.
+ */
+
+import { blockedClaimFirewall } from "@data/blockedClaimFirewall";
+
+export default function BlockedClaimFirewall() {
+  return (
+    <div className="bcf" data-ci-target="blocked-claims" aria-label="Blocked-claim firewall">
+      <div className="bcf__head">
+        <span className="bcf__title">Blocked-claim firewall</span>
+        <span className="p2-badge p2-badge--block">{blockedClaimFirewall.length} blocked · click to expand</span>
+      </div>
+      <div className="bcf__chips">
+        {blockedClaimFirewall.map((entry) => (
+          <details key={entry.term} className="bcf__chip">
+            <summary>{entry.term}</summary>
+            <span className="bcf__chip-detail">{entry.detail}</span>
+          </details>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/BoundaryDrawer.tsx
+++ b/components/BoundaryDrawer.tsx
@@ -1,0 +1,60 @@
+/**
+ * BoundaryDrawer
+ *
+ * Reusable expandable drawer for the "what exists / what it proves / what it
+ * does not prove" pattern. One source of truth used across the validation
+ * registry, proof records, and platform contracts. Website rendering is not
+ * proof; the does-not-prove column keeps the boundary explicit.
+ */
+
+export interface BoundaryDrawerProps {
+  summary: string;
+  exists: string[];
+  proves: string[];
+  doesNotProve: string[];
+  className?: string;
+  open?: boolean;
+}
+
+export default function BoundaryDrawer({
+  summary,
+  exists,
+  proves,
+  doesNotProve,
+  className,
+  open,
+}: BoundaryDrawerProps) {
+  return (
+    <details className={`boundary-drawer ${className ?? ""}`} open={open}>
+      <summary>
+        <span>{summary}</span>
+      </summary>
+      <div className="boundary-drawer__grid">
+        <div className="boundary-drawer__col boundary-drawer__col--exists">
+          <h4>What exists</h4>
+          <ul>
+            {exists.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </div>
+        <div className="boundary-drawer__col boundary-drawer__col--proves">
+          <h4>What it proves</h4>
+          <ul>
+            {proves.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </div>
+        <div className="boundary-drawer__col boundary-drawer__col--block">
+          <h4>What it does not prove</h4>
+          <ul>
+            {doesNotProve.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/components/PlatformContractBlueprint.tsx
+++ b/components/PlatformContractBlueprint.tsx
@@ -1,0 +1,83 @@
+/**
+ * PlatformContractBlueprint
+ *
+ * Asymmetric blueprint panels for the platform contracts. Each panel carries
+ * three lanes (schema / example / verifier), optional fixed status fields,
+ * and a blocked-authority footer that states what the contract cannot do.
+ * Renders src/data/platformContracts.ts. Website rendering is not proof.
+ */
+
+import { platformContracts, type PlatformContract } from "@data/platformContracts";
+
+const laneOrder: Record<string, number> = { Schema: 0, Example: 1, Verifier: 2 };
+
+function Blueprint({ contract }: { contract: PlatformContract }) {
+  const lanes = [...contract.lanes].sort((a, b) => laneOrder[a.kind] - laneOrder[b.kind]);
+  return (
+    <article className="pcb" data-contract-id={contract.id}>
+      <header className="pcb__head">
+        <p className="pcb__type">{contract.type}</p>
+        <h3 className="pcb__name">{contract.name}</h3>
+        <p className="pcb__supports">{contract.supports}</p>
+      </header>
+
+      <div className="pcb__lanes">
+        {lanes.map((lane) => (
+          <div key={lane.path} className="pcb__lane">
+            <p className="pcb__lane-kind">{lane.kind}</p>
+            <p className="pcb__lane-label">{lane.label}</p>
+            <p className="pcb__lane-path">{lane.path}</p>
+          </div>
+        ))}
+      </div>
+
+      {contract.fields && (
+        <div className="pcb__fields">
+          {contract.fields.map((f) => (
+            <span key={f.label} className="pcb__field">
+              <b>{f.label}</b> {f.value}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {contract.caveat && (
+        <p className="pcb__caveat">
+          <span aria-hidden="true">⚠</span>
+          <span>{contract.caveat}</span>
+        </p>
+      )}
+
+      {contract.shortCopy && <p className="pcb__short">{contract.shortCopy}</p>}
+
+      <footer className="pcb__foot">
+        <p className="pcb__foot-label">Blocked authority</p>
+        <ul className="pcb__foot-list">
+          {contract.blockedAuthority.map((b) => (
+            <li key={b}>{b}</li>
+          ))}
+        </ul>
+      </footer>
+    </article>
+  );
+}
+
+export interface PlatformContractBlueprintProps {
+  /** optional subset of contract ids to render, in order */
+  ids?: string[];
+}
+
+export default function PlatformContractBlueprint({ ids }: PlatformContractBlueprintProps) {
+  const list = ids
+    ? ids
+        .map((id) => platformContracts.find((c) => c.id === id))
+        .filter((c): c is PlatformContract => Boolean(c))
+    : platformContracts;
+  return (
+    <div className="pcb-grid" aria-label="Platform contract blueprints">
+      {list.map((contract) => (
+        <Blueprint key={contract.id} contract={contract} />
+      ))}
+    </div>
+  );
+}

--- a/components/ProofManifestConsole.tsx
+++ b/components/ProofManifestConsole.tsx
@@ -1,0 +1,81 @@
+/**
+ * ProofManifestConsole
+ *
+ * Receipt-console view of Proof Pack 001: collapsible included / excluded
+ * manifest panels, the does-not-prove list, and the release-route caveat.
+ * Included items stay visually separate from excluded / blocked items.
+ * Website rendering is not proof.
+ */
+
+import {
+  proofPack,
+  manifestIncluded,
+  manifestExcluded,
+  proofPackDoesNotProve,
+  releaseRouteCaveat,
+} from "@data/proofPackManifest";
+
+export default function ProofManifestConsole() {
+  return (
+    <div className="pm-console" aria-label="Proof Pack 001 manifest console">
+      <div className="pm-console__bar">
+        <span className="pm-console__dot" aria-hidden="true" />
+        <span className="pm-console__path">{proofPack.id}</span>
+        <span className="p2-badge p2-badge--ceiling" style={{ marginLeft: "auto" }}>{proofPack.ceiling}</span>
+      </div>
+
+      <details className="pm-panel pm-panel--include" open>
+        <summary>Included · reviewer package ({manifestIncluded.length})</summary>
+        <div className="pm-panel__body">
+          {manifestIncluded.map((item) => (
+            <div key={item.name} className="pm-line pm-line--in">
+              <span className="pm-line__mark" aria-hidden="true">+</span>
+              <span>
+                <span className="pm-line__name">{item.name}</span>{" "}
+                <span className="pm-line__note">— {item.note}</span>
+              </span>
+            </div>
+          ))}
+        </div>
+      </details>
+
+      <details className="pm-panel pm-panel--exclude">
+        <summary>Excluded · blocked from public release ({manifestExcluded.length})</summary>
+        <div className="pm-panel__body">
+          {manifestExcluded.map((item) => (
+            <div key={item.name} className="pm-line pm-line--out">
+              <span className="pm-line__mark" aria-hidden="true">−</span>
+              <span>
+                <span className="pm-line__name">{item.name}</span>{" "}
+                <span className="pm-line__note">— {item.note}</span>
+              </span>
+            </div>
+          ))}
+        </div>
+      </details>
+
+      <details className="pm-panel pm-panel--exclude">
+        <summary>Does not prove</summary>
+        <div className="pm-panel__body">
+          {proofPackDoesNotProve.map((line) => (
+            <div key={line} className="pm-line pm-line--out">
+              <span className="pm-line__mark" aria-hidden="true">⊘</span>
+              <span className="pm-line__note">{line}</span>
+            </div>
+          ))}
+        </div>
+      </details>
+
+      <div className="pm-panel__body" style={{ paddingTop: "0.8rem" }}>
+        <div className="flex flex-wrap gap-2">
+          {releaseRouteCaveat.badges.map((b) => (
+            <span key={b} className="p2-badge">{b}</span>
+          ))}
+        </div>
+        <p className="pm-line__note" style={{ marginTop: "0.5rem", lineHeight: 1.5 }}>
+          {releaseRouteCaveat.note}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/components/ReceiptLedgerTimeline.tsx
+++ b/components/ReceiptLedgerTimeline.tsx
@@ -1,0 +1,29 @@
+/**
+ * ReceiptLedgerTimeline
+ *
+ * A hand-maintained reviewer snapshot of bounded packets and receipts,
+ * rendered as a small append-only timeline. This is not live runtime
+ * telemetry; the caveat states so. Renders src/data/receiptLedger.ts.
+ */
+
+import { ledgerEntries, ledgerCaveat } from "@data/receiptLedger";
+
+export default function ReceiptLedgerTimeline() {
+  return (
+    <div className="rlt" aria-label="Receipt and ledger timeline">
+      <p className="rlt__caveat">{ledgerCaveat}</p>
+      <div className="rlt__lanes">
+        {ledgerEntries.map((entry) => (
+          <div key={entry.marker} className="rlt__lane">
+            <span className="rlt__marker">{entry.marker}</span>
+            <div>
+              <span className="rlt__kind">{entry.kind}</span>
+              <h3 className="rlt__title">{entry.title}</h3>
+              <p className="rlt__line">{entry.line}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/ValidationRegistryDashboard.tsx
+++ b/components/ValidationRegistryDashboard.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+/**
+ * ValidationRegistryDashboard
+ *
+ * Contract-enforced, human-review-gated validation registry. Compact
+ * counters, family filters, proof-ceiling / caveat badges, and an
+ * expandable boundary drawer per package. Renders src/data/validationRegistry.ts.
+ * Website rendering is not proof.
+ */
+
+import { useState } from "react";
+import BoundaryDrawer from "@components/BoundaryDrawer";
+import {
+  validationRows,
+  validationFamilies,
+  registryStats,
+  type ValidationFamily,
+} from "@data/validationRegistry";
+
+type Filter = "All" | ValidationFamily;
+
+const badgeClass: Record<string, string> = {
+  ceiling: "p2-badge p2-badge--ceiling",
+  block: "p2-badge p2-badge--block",
+  drift: "p2-badge p2-badge--drift",
+  warn: "p2-badge p2-badge--warn",
+};
+
+export default function ValidationRegistryDashboard() {
+  const [filter, setFilter] = useState<Filter>("All");
+  const rows = filter === "All" ? validationRows : validationRows.filter((r) => r.family === filter);
+  const filters: Filter[] = ["All", ...validationFamilies];
+
+  return (
+    <div className="reveal reveal--up" aria-label="Validation registry dashboard">
+      <p className="muted mb-5 max-w-3xl text-sm leading-6">
+        The validation registry is contract-enforced and human-review gated. It records
+        controlled-test packages, verifier routes, and blocked runtime / signal / public-safe states.
+      </p>
+
+      <div className="vr-stats" aria-label="Registry totals">
+        <div className="vr-stat">
+          <span className="vr-stat__value mono">{registryStats.totalFixtures}</span>
+          <span className="vr-stat__label">total fixtures</span>
+        </div>
+        <div className="vr-stat">
+          <span className="vr-stat__value mono">{registryStats.passedPackages}</span>
+          <span className="vr-stat__label">passed packages</span>
+        </div>
+        <div className="vr-stat">
+          <span className="vr-stat__value mono">{registryStats.noProofRecordRows}</span>
+          <span className="vr-stat__label">no-proof-record rows</span>
+        </div>
+        <div className="vr-stat">
+          <span className="vr-stat__value mono">{registryStats.contractOnlyRows}</span>
+          <span className="vr-stat__label">contract-only rows</span>
+        </div>
+        <div className="vr-stat">
+          <span className="vr-stat__value vr-stat__value--block mono">{registryStats.publicRuntimeBlockedRows}</span>
+          <span className="vr-stat__label">public-runtime blocked</span>
+        </div>
+      </div>
+
+      <div className="vr-filters" role="group" aria-label="Family filters">
+        {filters.map((f) => (
+          <button
+            key={f}
+            type="button"
+            className="vr-filter"
+            aria-pressed={filter === f}
+            onClick={() => setFilter(f)}
+          >
+            {f}
+          </button>
+        ))}
+      </div>
+
+      <div className="vr-rows">
+        {rows.map((row) => (
+          <article
+            key={row.id}
+            className="vr-row"
+            data-detection-id={row.id}
+            data-no-proof={row.noProofRecord}
+            data-contract-only={row.contractOnly}
+          >
+            <div className="vr-row__head">
+              <div>
+                <span className="vr-row__id">{row.id}</span>
+                <span className="vr-row__fam">{row.family}</span>
+              </div>
+              <div>
+                <span className="vr-row__name">{row.name}</span>
+                <div className="vr-row__counts">
+                  {row.fixtures ? (
+                    <>
+                      <span className="vr-count">total {row.fixtures.total}</span>
+                      <span className="vr-count">pos {row.fixtures.positive}</span>
+                      <span className="vr-count">neg {row.fixtures.negative}</span>
+                      <span className="vr-count vr-count--zero">missed {row.fixtures.missed}</span>
+                      <span className="vr-count vr-count--zero">fp-neg {row.fixtures.falsePositiveNegatives}</span>
+                    </>
+                  ) : (
+                    <span className="vr-count">no fixtures · contract sample</span>
+                  )}
+                </div>
+              </div>
+              <div className="vr-row__badges">
+                {row.badges.map((b) => (
+                  <span key={b.label} className={badgeClass[b.tone]}>{b.label}</span>
+                ))}
+              </div>
+            </div>
+            {row.copyBoundary && (
+              <p className="px-4 pb-1 text-xs leading-5" style={{ color: "var(--ceiling-amber)" }}>
+                {row.copyBoundary}
+              </p>
+            )}
+            <BoundaryDrawer
+              className="vr-row__drawer"
+              summary={`Inspect · ${row.id}`}
+              exists={row.exists}
+              proves={row.proves}
+              doesNotProve={row.doesNotProve}
+            />
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/VerifierCheckCards.tsx
+++ b/components/VerifierCheckCards.tsx
@@ -1,0 +1,30 @@
+/**
+ * VerifierCheckCards
+ *
+ * Grouped verifier-route cards. Verifier scripts check structure, parity,
+ * claim boundaries, and packet contracts. They do not prove runtime activity
+ * or public-safe evidence — stated in the boundary line below.
+ */
+
+import { verifierGroups, verifierBoundary } from "@data/proofPackManifest";
+
+export default function VerifierCheckCards() {
+  return (
+    <div aria-label="Verifier check cards">
+      <div className="vc-grid">
+        {verifierGroups.map((group) => (
+          <article key={group.group} className="vc-card">
+            <p className="vc-card__group">{group.group}</p>
+            <p className="vc-card__blurb">{group.blurb}</p>
+            <ul className="vc-card__list">
+              {group.scripts.map((script) => (
+                <li key={script} className="vc-card__script">{script}</li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+      <p className="muted mt-4 text-xs leading-5 max-w-3xl">{verifierBoundary}</p>
+    </div>
+  );
+}

--- a/scripts/verify-site-contract.mjs
+++ b/scripts/verify-site-contract.mjs
@@ -73,6 +73,10 @@ const blockedTerms = [
   'proofCeiling: "PROVEN_PRIVATE_INTERNAL"',
 ];
 
+const failClosedLiteralTerms = [
+  "PRIVATE_RUNTIME_EVIDENCE_CAPTURED",
+];
+
 const allowedContext = [
   /blocked/i,
   /not claimed/i,
@@ -116,8 +120,8 @@ const renderedArtifactBoundaryTerms = [
   'proofCeiling: "PROVEN_PRIVATE_INTERNAL"',
 ];
 
-const scanRoots = ["README.md", "SCOPE.md", "STATUS.md", "app", "components", "config", "src/data", "public"];
-const scanExtensions = new Set([".astro", ".ts", ".tsx", ".md", ".mjs", ".json", ".xml", ".txt", ".css"]);
+const scanRoots = ["README.md", "SCOPE.md", "STATUS.md", "app", "components", "config", "src/data", "public", "dist", "out"];
+const scanExtensions = new Set([".astro", ".ts", ".tsx", ".md", ".mjs", ".json", ".xml", ".txt", ".css", ".html", ".js"]);
 
 function collectFiles(target) {
   const absolute = join(root, target);
@@ -142,6 +146,12 @@ for (const file of scanRoots.flatMap(collectFiles)) {
   const lines = readFileSync(file, "utf8").split(/\r?\n/);
   lines.forEach((line, index) => {
     const normalizedLine = line.toLowerCase();
+    const failClosedTerm = failClosedLiteralTerms.find((term) => normalizedLine.includes(term.toLowerCase()));
+    if (failClosedTerm) {
+      failures.push(`${relative(root, file)}:${index + 1}: public output must not render private-runtime literal ${failClosedTerm}`);
+      return;
+    }
+
     const matchedTerm = blockedTerms.find((term) => normalizedLine.includes(term.toLowerCase()));
     if (!matchedTerm) return;
     if (matchedTerm === "public-safe" && isNeutralPublicSafeLabel(line)) return;

--- a/src/data/attackCoverage.ts
+++ b/src/data/attackCoverage.ts
@@ -65,7 +65,7 @@ export const attackFamilies: AttackFamily[] = [
         id: "HO-DET-011",
         title: "Windows Service Creation / Binary Change",
         attack: "Persistence: service creation — ATT&CK mapping in source artifact",
-        ceiling: "PRIVATE_RUNTIME_EVIDENCE_CAPTURED · NOT_PUBLIC_SAFE",
+        ceiling: "private runtime evidence captured and excluded from public proof · NOT_PUBLIC_SAFE",
         tone: "private",
         validation: "17 controlled cases: 7 positive, 10 negative, 0 missed, 0 false-positive negatives",
         boundary:

--- a/src/data/blockedClaimFirewall.ts
+++ b/src/data/blockedClaimFirewall.ts
@@ -1,0 +1,32 @@
+/**
+ * Blocked-claim firewall — expandable strip.
+ *
+ * Each entry is a claim that stays blocked from the public surface, paired
+ * with the reason it is blocked. The firewall keeps blocked claims visible
+ * and visually separate from proof-positive content; blocked claims are not
+ * features. Each `term` line sits next to its `detail` so the boundary stays
+ * explicit.
+ */
+
+export type BlockedFirewallEntry = { term: string; detail: string };
+
+export const blockedClaimFirewall: BlockedFirewallEntry[] = [
+  { term: "runtime-active", detail: "No public runtime evidence is linked; blocked." },
+  { term: "signal-observed", detail: "No public signal-observation receipt; blocked." },
+  { term: "production-ready", detail: "Production readiness is not claimed; blocked." },
+  { term: "customer-deployed", detail: "No customer deployment; blocked." },
+  { term: "fleet-wide", detail: "No fleet-wide coverage is claimed; blocked." },
+  { term: "live AWS", detail: "Cloud validation is fixture-only; live AWS blocked." },
+  { term: "live IdP", detail: "Identity validation is fixture-only; live IdP blocked." },
+  { term: "live Splunk", detail: "No live Splunk firing is claimed; blocked." },
+  { term: "Cribl-routed proof", detail: "No Cribl-routed telemetry proof; blocked." },
+  { term: "Security Onion observed proof", detail: "Contract sample only; observed proof blocked." },
+  { term: "public-safe runtime", detail: "Public-safe runtime proof is not claimed; blocked." },
+  { term: "autonomous SOC", detail: "No autonomous SOC operation; blocked." },
+  { term: "AI-approved disposition", detail: "AI is labor; AI-approved disposition is blocked." },
+  { term: "analyst-approved disposition", detail: "No analyst-approved disposition; blocked." },
+  { term: "response automation", detail: "No production response automation; blocked." },
+  { term: "containment execution", detail: "Containment execution is not claimed; blocked." },
+  { term: "closure execution", detail: "Case closure execution is not claimed; blocked." },
+  { term: "suppression execution", detail: "Suppression execution is not claimed; blocked." },
+];

--- a/src/data/platformContracts.ts
+++ b/src/data/platformContracts.ts
@@ -1,0 +1,196 @@
+/**
+ * Platform Contract Blueprints — extracted Phase 2 payload.
+ *
+ * Each blueprint is a three-lane structure: schema, example/packet, and
+ * verifier/gate. Every blueprint carries a blocked-authority footer that
+ * states what it cannot do. These are bounded structure/boundary packets;
+ * website rendering is not proof.
+ *
+ * Scanner note: blocked tokens in `blockedAuthority` are paired on-line
+ * with "blocked" or "not claimed".
+ */
+
+export type ContractLane = {
+  kind: "Schema" | "Example" | "Verifier";
+  label: string;
+  path: string;
+};
+
+export type ContractField = { label: string; value: string };
+
+export type PlatformContract = {
+  id: string;
+  name: string;
+  type: string;
+  supports: string;
+  lanes: ContractLane[];
+  /** optional fixed status fields rendered as a mono key/value strip */
+  fields?: ContractField[];
+  caveat?: string;
+  shortCopy?: string;
+  blockedAuthority: string[];
+};
+
+export const platformContracts: PlatformContract[] = [
+  {
+    id: "soar-case-packet-v0",
+    name: "SOAR Case Packet v0",
+    type: "Deterministic analyst-support case packet",
+    supports:
+      "Analyst-support structure: sanitized refs, checklist, response gates, blocked actions, and an AI support summary.",
+    lanes: [
+      { kind: "Schema", label: "Packet schema", path: "contracts/schemas/soar-case-packet-v0.schema.json" },
+      { kind: "Example", label: "Sample packet", path: "contracts/examples/soar-case-packet-v0.sample.json" },
+      { kind: "Verifier", label: "Packet verifier", path: "scripts/verify-soar-case-packet-v0.py" },
+    ],
+    shortCopy: "SOAR packet models analyst support, not response authority.",
+    blockedAuthority: [
+      "Live Torq / SOAR is not claimed.",
+      "Production SOC and response automation are blocked.",
+      "Containment, closure, and suppression execution are blocked.",
+      "Autonomous SOC and AI / analyst disposition are blocked.",
+    ],
+  },
+  {
+    id: "autosoc-case-ledger-v0",
+    name: "AutoSOC Case Ledger v0",
+    type: "Append-only seed ledger",
+    supports:
+      "An append-only seed ledger that demonstrates constraints — every case is human-review required.",
+    lanes: [
+      { kind: "Example", label: "Seed ledger", path: "evidence/autosoc-case-ledger-v0.sqlite" },
+      { kind: "Schema", label: "Schema logic", path: "scripts/ho_factory.py" },
+    ],
+    fields: [
+      { label: "Total cases", value: "1" },
+      { label: "Human review required", value: "1" },
+      { label: "Public-safe state", value: "0" },
+      { label: "Proof", value: "BLOCKED" },
+      { label: "Deterministic close", value: "BLOCKED" },
+    ],
+    shortCopy: "Append-only seed ledger demonstrates constraints, not live SOC operation.",
+    blockedAuthority: [
+      "Live runtime ledger is not claimed.",
+      "Proof promotion is blocked.",
+      "Case closure is blocked.",
+    ],
+  },
+  {
+    id: "detection-factory-controller-v0",
+    name: "Detection Factory Controller v0",
+    type: "Bounded reviewer status / plan emitter",
+    supports:
+      "Emits bounded reviewer status and plan packets for HO-DET-001, HO-DET-011, HO-DET-012, and ID-DET-001..004.",
+    lanes: [
+      { kind: "Schema", label: "Controller doc", path: "docs/factory/DETECTION_FACTORY_CONTROLLER_V0.md" },
+      { kind: "Schema", label: "Controller schema", path: "contracts/schemas/detection-factory-controller-v0.schema.json" },
+      { kind: "Verifier", label: "Controller script", path: "scripts/ho_factory.py" },
+    ],
+    caveat: "HO-DET-011 reports STATE_DRIFT_REVIEW_REQUIRED.",
+    shortCopy: "The controller emits bounded status and plan packets. It reports state; it does not promote proof or publish evidence.",
+    blockedAuthority: [
+      "Website updates and proof promotion are blocked.",
+      "Evidence publishing and PR creation are blocked.",
+      "Merge and generated-output writing are blocked.",
+    ],
+  },
+  {
+    id: "local-gpu-triage-gate",
+    name: "Local GPU Triage Gate",
+    type: "Bounded manual gate receipt",
+    supports: "A bounded manual gate receipt exists for local GPU triage support.",
+    lanes: [
+      { kind: "Schema", label: "Pipeline doc", path: "docs/factory/LOCAL_GPU_TRIAGE_PIPELINE_V0.md" },
+      { kind: "Example", label: "Support schema / sample", path: "local-gpu-triage-support-v0 schema / sample" },
+      { kind: "Verifier", label: "Triage verifier", path: "scripts/verify_local_gpu_triage.py" },
+    ],
+    fields: [
+      { label: "Gate status", value: "GITHUB_ACTIONS_RUN_PASSED" },
+      { label: "Metadata", value: "PRIVATE_OPERATIONAL" },
+    ],
+    shortCopy: "Local GPU support is private support-only infrastructure. The public website may describe the contract boundary, not public runtime proof.",
+    blockedAuthority: [
+      "Model execution in CI is not claimed.",
+      "Prompt execution in CI and artifact upload are blocked.",
+      "Public proof, production, autonomous, and AI-approved claims are blocked.",
+    ],
+  },
+  {
+    id: "offline-llm-triage-support-contract",
+    name: "Offline LLM Triage Support Contract",
+    type: "Support-only labor contract",
+    supports:
+      "AI may summarize sanitized facts, identify missing context, draft questions, and map fields to the checklist.",
+    lanes: [
+      { kind: "Schema", label: "Support contract", path: "docs/autosoc/OFFLINE_LLM_TRIAGE_SUPPORT_CONTRACT.md" },
+    ],
+    shortCopy: "Offline LLM is support-only labor; human review remains authority.",
+    blockedAuthority: [
+      "Disposition decision and approval are blocked.",
+      "Proof promotion and case closure are blocked.",
+      "Public-safe marking and production claim are blocked.",
+    ],
+  },
+  {
+    id: "local-llm-runtime-receipt",
+    name: "Local LLM Runtime Receipt",
+    type: "Private support-only receipt packet",
+    supports:
+      "A private support-only local LLM runtime receipt exists as a structure / boundary packet.",
+    lanes: [
+      { kind: "Schema", label: "Receipt schema", path: "contracts/schemas/local-llm-runtime-receipt.schema.json" },
+      { kind: "Example", label: "Valid sample", path: "contracts/examples/local-llm-runtime-receipt.valid.sample.json" },
+      { kind: "Verifier", label: "Private evidence index", path: "validation-side private-runtime-evidence-index.json" },
+    ],
+    shortCopy: "A private boundary packet — never a public runtime claim.",
+    blockedAuthority: [
+      "Public-safe state is not claimed.",
+      "Runtime-active public proof and signal-observed status are blocked.",
+      "AI-approved disposition is blocked.",
+    ],
+  },
+  {
+    id: "ho-det-001-runtime-contract",
+    name: "HO-DET-001 Runtime Contract",
+    type: "Non-promotional platform guardrail",
+    supports:
+      "Platform runtime contract enforcement exists as a non-promotional guardrail.",
+    lanes: [
+      { kind: "Schema", label: "Contract schema / sample", path: "ho-det-001-runtime-contract schema / sample" },
+      { kind: "Verifier", label: "Contract verifier", path: "scripts/verify-ho-det-001-runtime-contract.py" },
+    ],
+    fields: [
+      { label: "PROMOTION_STATUS", value: "BLOCKED" },
+      { label: "RUNTIME_ACTIVE", value: "false" },
+      { label: "SIGNAL_OBSERVED", value: "false" },
+      { label: "AI_DECIDED_DISPOSITION", value: "false" },
+    ],
+    shortCopy: "A guardrail that holds promotion blocked — it does not raise the ceiling.",
+    blockedAuthority: [
+      "Promotion beyond CONTROLLED_TEST_VALIDATED is blocked.",
+      "Runtime-active and signal-observed status are not claimed.",
+    ],
+  },
+  {
+    id: "ho-det-011-case-packet",
+    name: "HO-DET-011 Case Packet",
+    type: "Case-packet guardrail",
+    supports: "A case-packet guardrail exists for HO-DET-011.",
+    lanes: [
+      { kind: "Schema", label: "Packet schema / sample", path: "ho-det-011-case-packet schema / sample" },
+      { kind: "Verifier", label: "Packet verifier", path: "scripts/verify-ho-det-011-case-packet.py" },
+    ],
+    fields: [
+      { label: "Packet shape", value: "6-case (pinned)" },
+      { label: "Validation / proof state", value: "17 fixtures" },
+      { label: "Drift", value: "STATE_DRIFT_REVIEW_REQUIRED" },
+    ],
+    caveat:
+      "Pinned to an older 6-case shape while validation / proof state records 17 fixtures. The drift surfaces as STATE_DRIFT_REVIEW_REQUIRED and is not silently normalized.",
+    shortCopy: "The packet shows the drift instead of hiding it.",
+    blockedAuthority: [
+      "Promotion is blocked while drift review is required.",
+      "Public-safe runtime proof is not claimed.",
+    ],
+  },
+];

--- a/src/data/proofPackManifest.ts
+++ b/src/data/proofPackManifest.ts
@@ -1,0 +1,136 @@
+/**
+ * Proof Pack 001 manifest, verifier routes, and proof status index.
+ *
+ * The manifest separates what the reviewer package includes from what is
+ * excluded and what it does not prove. Verifier scripts check structure,
+ * parity, claim boundaries, and packet contracts — they do not prove
+ * runtime activity or public-safe evidence. Website rendering is not proof.
+ */
+
+export const proofPack = {
+  id: "HAWKINSOPERATIONS_PROOF_PACK_001",
+  ceiling: "CONTROLLED_TEST_VALIDATED",
+  reviewerPackage: "PUBLIC_SAFE_REVIEWER_RELEASE_CANDIDATE",
+  rawRuntimeEvidence: "NOT_PUBLIC_SAFE",
+  publicSafeRuntimeProof: "BLOCKED",
+  zipSha256: "44d8a643aa2b113c9e99be0462e699d39af707a67190823cc05bb381907dc452",
+};
+
+export type ManifestItem = { name: string; note: string };
+
+/** Files routed inside the bounded reviewer release. */
+export const manifestIncluded: ManifestItem[] = [
+  { name: "REVIEWER_PACKET.md", note: "Boundary packet for HO-DET-001." },
+  { name: "SHA256SUMS.txt", note: "Source-controlled checksums for packet files." },
+  { name: "HO-DET-001 proof card", note: "Bounded controlled-test proof card." },
+  { name: "HO-DET-001 proof record", note: "Public proof record with stated ceiling." },
+  { name: "Validation record", note: "14 / 14 controlled fixtures." },
+  { name: "Ledger / schema", note: "Evidence ledger and schema." },
+  { name: "Proof verifier", note: "Structure / parity / boundary checks." },
+];
+
+/** Items kept out of the public reviewer release. */
+export const manifestExcluded: ManifestItem[] = [
+  { name: "Raw / private runtime evidence", note: "NOT_PUBLIC_SAFE — excluded from the public proof basis." },
+  { name: "Public-safe runtime proof", note: "BLOCKED until evidence linkage and explicit promotion." },
+];
+
+/** What Proof Pack 001 does not prove. */
+export const proofPackDoesNotProve: string[] = [
+  "Runtime-active status is not claimed.",
+  "Signal-observed status is not claimed.",
+  "Evidence-linked public runtime proof is blocked.",
+  "Production-ready and SOCaaS availability are not claimed.",
+  "Live Splunk, Cribl/Wazuh, and live AWS are blocked.",
+  "Autonomous SOC and AI / analyst disposition are not claimed.",
+];
+
+export const releaseRouteCaveat = {
+  note: "An official direct GitHub Release route exists. Source packet manifest / check-mode language remains source-packet / release-candidate metadata — a route / status distinction, not a stronger proof claim.",
+  badges: ["DIRECT_RELEASE_ROUTE", "SOURCE_PACKET_CHECK_MODE", "NO_SIGNED_ARTIFACT"],
+};
+
+export const reviewerPacket = {
+  name: "REVIEWER_PACKET.md",
+  scope: "Boundary packet for HO-DET-001.",
+  evidenceChain: [
+    "Detections",
+    "Validation",
+    "Platform case-packet sample",
+    "Proof card / record",
+    "Website rendering (not proof)",
+  ],
+  doesNotProve: [
+    "Runtime-active and signal-observed status are not claimed.",
+    "Production / customer deployment is blocked.",
+    "SOCaaS availability and autonomous / AI / analyst approval are blocked.",
+  ],
+};
+
+export const checksumManifest = {
+  name: "SHA256SUMS.txt",
+  scope: "Source-controlled checksums for packet files.",
+  doesNotProve:
+    "Checksum presence does not promote runtime or signal proof, and does not prove an official release unless tied to the release ZIP route / runbook and checksum verification.",
+};
+
+export type VerifierGroup = {
+  group: string;
+  blurb: string;
+  scripts: string[];
+};
+
+export const verifierGroups: VerifierGroup[] = [
+  {
+    group: "Release / pack verifiers",
+    blurb: "Check the release route and ZIP packet contract.",
+    scripts: [
+      "scripts/verify-proof-pack-001-release.py",
+      "scripts/verify-proof-pack-001-zip.py",
+    ],
+  },
+  {
+    group: "Proof integrity verifiers",
+    blurb: "Check proof integrity and HO-DET-001 proof structure.",
+    scripts: [
+      "scripts/verify_proof_integrity.py",
+      "scripts/verify-ho-det-001-proof-integrity.py",
+    ],
+  },
+  {
+    group: "Boundary / parity / contract verifiers",
+    blurb: "Check claim boundaries, parity, and packet contracts.",
+    scripts: [
+      "claim-boundary scanners",
+      "parity verifiers",
+      "contract verifiers",
+    ],
+  },
+];
+
+export const verifierBoundary =
+  "Verifier scripts check structure, parity, claim boundaries, and packet contracts. They do not prove runtime activity or public-safe evidence.";
+
+export type ProofStatusRow = {
+  id: string;
+  status: string;
+  tone: "ceiling" | "block" | "warn" | "drift";
+  note: string;
+};
+
+export const proofStatusIndex = {
+  path: "proof/indexes/DETECTION_PROOF_STATUS_INDEX.yml",
+  websiteStatus: "WEBSITE_UNTOUCHED_NOT_PROOF",
+  humanReview: "HUMAN_REVIEW_REQUIRED",
+  rows: [
+    { id: "HO-DET-001", status: "PROOF_RECORD_PRESENT", tone: "ceiling", note: "Controlled-test proof record and card." },
+    { id: "HO-DET-011", status: "NOT_PUBLIC_SAFE", tone: "block", note: "Private runtime evidence captured and excluded; drift review required." },
+    { id: "HO-DET-012", status: "NO_PROOF_RECORD", tone: "warn", note: "Validation-only; no proof record." },
+    { id: "AWS-DET-001", status: "PROOF_RECORD_PRESENT", tone: "ceiling", note: "Cloud validation card; live AWS blocked." },
+    { id: "ID-DET-001", status: "NO_PROOF_RECORD", tone: "warn", note: "Validation-only; no proof record." },
+    { id: "ID-DET-002", status: "NO_PROOF_RECORD", tone: "warn", note: "Validation-only; no proof record." },
+    { id: "ID-DET-003", status: "NO_PROOF_RECORD", tone: "warn", note: "Validation-only; no proof record." },
+    { id: "ID-DET-004", status: "NO_PROOF_RECORD", tone: "warn", note: "Validation-only; no proof record." },
+    { id: "HO-NDR-001", status: "BOUNDARY_CONTRACT_ONLY", tone: "warn", note: "Cross-source corroboration contract defined, not proof promotion." },
+  ] as ProofStatusRow[],
+};

--- a/src/data/proofRecords.ts
+++ b/src/data/proofRecords.ts
@@ -1,16 +1,30 @@
 import { blockedClaims, proofCeiling } from "./claims";
 import { externalLinks } from "./navigation";
 
+/**
+ * proofRecordState values:
+ *   PROOF_RECORD_PRESENT     a public proof record exists
+ *   PRIVATE_RUNTIME_BOUNDARY private runtime evidence excluded, not public-safe
+ *   NO_PROOF_RECORD          validation-only; no proof record exists yet
+ *   BOUNDARY_CONTRACT_ONLY   contract sample only; no fixtures, no proof record
+ */
+export type ProofRecordState =
+  | "PROOF_RECORD_PRESENT"
+  | "PRIVATE_RUNTIME_BOUNDARY"
+  | "NO_PROOF_RECORD"
+  | "BOUNDARY_CONTRACT_ONLY";
+
 export type ProofRecord = {
   detectionId: string;
   title: string;
   proofLevel: string;
+  proofRecordState: ProofRecordState;
   validationState: string;
   runtimeState: string;
   signalState: string;
   publicSafeState: string;
   sourceRepoLink: string;
-  proofRepoLink: string;
+  proofRepoLink?: string;
   caseFileHref?: string;
   blockedPromotions: string[];
   exists: string[];
@@ -25,6 +39,7 @@ export const proofRecords: ProofRecord[] = [
     detectionId: "HO-DET-001",
     title: "Controlled-test validation proof card",
     proofLevel: proofCeiling,
+    proofRecordState: "PROOF_RECORD_PRESENT",
     validationState: "controlled-test validation status",
     runtimeState: "not claimed from public website",
     signalState: "not claimed from public website",
@@ -74,6 +89,7 @@ export const proofRecords: ProofRecord[] = [
     detectionId: "AWS-DET-001",
     title: "CloudTrail-style IAM denial fixture proof card",
     proofLevel: proofCeiling,
+    proofRecordState: "PROOF_RECORD_PRESENT",
     validationState: "fixture-only controlled validation status",
     runtimeState: "not claimed from public website",
     signalState: "not claimed from public website",
@@ -110,6 +126,217 @@ export const proofRecords: ProofRecord[] = [
       "Cloud deployment evidence linking the rule to an enabled environment.",
       "Public wording reviewed against the blocked-claim list.",
       "Raylee approval after evidence and claim review.",
+    ],
+  },
+  {
+    detectionId: "HO-DET-011",
+    title: "Windows Service Creation / Binary Change · private-runtime boundary",
+    proofLevel: proofCeiling,
+    proofRecordState: "PRIVATE_RUNTIME_BOUNDARY",
+    validationState: "controlled-test validation · 17 fixtures · drift review required",
+    runtimeState: "not claimed from public website",
+    signalState: "not claimed from public website",
+    publicSafeState: "NOT_PUBLIC_SAFE · raw private runtime evidence excluded",
+    sourceRepoLink: externalLinks.validation,
+    blockedPromotions: blockedClaims,
+    exists: [
+      "A controlled-test validation package with 17 fixtures.",
+      "A private runtime evidence index, excluded from the public proof basis.",
+    ],
+    passed: [
+      "17 / 17 fixtures pass deterministically.",
+      "0 missed positives and 0 false-positive negatives.",
+    ],
+    notClaimed: [
+      "Public-safe state is NOT_PUBLIC_SAFE; raw private runtime evidence is excluded.",
+      "Runtime-active and signal-observed status are not claimed.",
+    ],
+    remainingBlocked: [
+      "Platform guardrail drift is unresolved; promotion is blocked until review clears.",
+      "Public-safe runtime proof requires evidence linkage and explicit promotion.",
+    ],
+    promotionRequirements: [
+      "Drift review resolved between case packet and validation state.",
+      "Evidence linkage reviewed independently before any promotion.",
+    ],
+  },
+  {
+    detectionId: "HO-DET-012",
+    title: "Suspicious Scheduled Task Creation · no proof record",
+    proofLevel: proofCeiling,
+    proofRecordState: "NO_PROOF_RECORD",
+    validationState: "controlled-test validation · 8 fixtures",
+    runtimeState: "not claimed from public website",
+    signalState: "not claimed from public website",
+    publicSafeState: "blocked until evidence linkage and explicit promotion",
+    sourceRepoLink: externalLinks.validation,
+    blockedPromotions: blockedClaims,
+    exists: [
+      "A controlled-test validation package with 8 fixtures.",
+      "No proof record exists yet; the row is validation-only.",
+    ],
+    passed: [
+      "8 / 8 fixtures pass deterministically.",
+      "0 missed positives and 0 false-positive negatives.",
+    ],
+    notClaimed: [
+      "No proof record exists, so public proof is not claimed.",
+      "Runtime-active and signal-observed status are not claimed.",
+    ],
+    remainingBlocked: [
+      "A proof record must be created and reviewed before public proof status.",
+    ],
+    promotionRequirements: [
+      "Proof record authored and linked to validation output.",
+    ],
+  },
+  {
+    detectionId: "ID-DET-001",
+    title: "Suspicious identity session context · no proof record",
+    proofLevel: proofCeiling,
+    proofRecordState: "NO_PROOF_RECORD",
+    validationState: "controlled-test validation · 10 fixtures",
+    runtimeState: "not claimed from public website",
+    signalState: "not claimed from public website",
+    publicSafeState: "blocked until evidence linkage and explicit promotion",
+    sourceRepoLink: externalLinks.validation,
+    blockedPromotions: blockedClaims,
+    exists: [
+      "A controlled-test validation package with 10 fixtures.",
+      "No proof record exists yet; the row is validation-only.",
+    ],
+    passed: [
+      "10 / 10 fixtures pass deterministically.",
+      "0 missed positives and 0 false-positive negatives.",
+    ],
+    notClaimed: [
+      "Live IdP / SIEM / NDR coverage is not claimed.",
+      "Production identity coverage and autonomous / AI disposition are not claimed.",
+    ],
+    remainingBlocked: [
+      "A proof record must be created before public proof status.",
+    ],
+    promotionRequirements: [
+      "Proof record authored and linked to validation output.",
+    ],
+  },
+  {
+    detectionId: "ID-DET-002",
+    title: "MFA fatigue / repeated MFA failure · no proof record",
+    proofLevel: proofCeiling,
+    proofRecordState: "NO_PROOF_RECORD",
+    validationState: "controlled-test validation · 10 fixtures",
+    runtimeState: "not claimed from public website",
+    signalState: "not claimed from public website",
+    publicSafeState: "blocked until evidence linkage and explicit promotion",
+    sourceRepoLink: externalLinks.validation,
+    blockedPromotions: blockedClaims,
+    exists: [
+      "A controlled-test validation package with 10 fixtures.",
+      "No proof record exists yet; the row is validation-only.",
+    ],
+    passed: [
+      "10 / 10 fixtures pass deterministically.",
+      "0 missed positives and 0 false-positive negatives.",
+    ],
+    notClaimed: [
+      "Live IdP and live SIEM / NDR are not claimed.",
+      "Proof promotion and public-safe state are not claimed.",
+    ],
+    remainingBlocked: [
+      "A proof record must be created before public proof status.",
+    ],
+    promotionRequirements: [
+      "Proof record authored and linked to validation output.",
+    ],
+  },
+  {
+    detectionId: "ID-DET-003",
+    title: "Privileged role / admin group change · no proof record",
+    proofLevel: proofCeiling,
+    proofRecordState: "NO_PROOF_RECORD",
+    validationState: "controlled-test validation · 10 fixtures",
+    runtimeState: "not claimed from public website",
+    signalState: "not claimed from public website",
+    publicSafeState: "blocked until evidence linkage and explicit promotion",
+    sourceRepoLink: externalLinks.validation,
+    blockedPromotions: blockedClaims,
+    exists: [
+      "A controlled-test validation package with 10 fixtures.",
+      "No proof record exists yet; the row is validation-only.",
+    ],
+    passed: [
+      "10 / 10 fixtures pass deterministically.",
+      "0 missed positives and 0 false-positive negatives.",
+    ],
+    notClaimed: [
+      "Live IdP / SIEM coverage is not claimed.",
+      "Production coverage and AI / analyst disposition are not claimed.",
+    ],
+    remainingBlocked: [
+      "A proof record must be created before public proof status.",
+    ],
+    promotionRequirements: [
+      "Proof record authored and linked to validation output.",
+    ],
+  },
+  {
+    detectionId: "ID-DET-004",
+    title: "Impossible travel / anomalous session · no proof record",
+    proofLevel: proofCeiling,
+    proofRecordState: "NO_PROOF_RECORD",
+    validationState: "controlled-test validation · 10 fixtures",
+    runtimeState: "not claimed from public website",
+    signalState: "not claimed from public website",
+    publicSafeState: "blocked until evidence linkage and explicit promotion",
+    sourceRepoLink: externalLinks.validation,
+    blockedPromotions: blockedClaims,
+    exists: [
+      "A controlled-test validation package with 10 fixtures.",
+      "No proof record exists yet; the row is validation-only.",
+    ],
+    passed: [
+      "10 / 10 fixtures pass deterministically.",
+      "0 missed positives and 0 false-positive negatives.",
+    ],
+    notClaimed: [
+      "Impossible-travel and session-hijacking completeness are not claimed.",
+      "Live IdP and public-safe state are not claimed.",
+    ],
+    remainingBlocked: [
+      "Completeness is blocked; a proof record must be created before public proof status.",
+    ],
+    promotionRequirements: [
+      "Proof record authored and linked to validation output.",
+    ],
+  },
+  {
+    detectionId: "HO-NDR-001",
+    title: "Security Onion visibility contract · boundary scaffold",
+    proofLevel: "BOUNDARY_CONTRACT_ONLY",
+    proofRecordState: "BOUNDARY_CONTRACT_ONLY",
+    validationState: "contract sample only · no fixtures",
+    runtimeState: "not claimed from public website",
+    signalState: "not claimed from public website",
+    publicSafeState: "blocked until evidence linkage and explicit promotion",
+    sourceRepoLink: externalLinks.validation,
+    blockedPromotions: blockedClaims,
+    exists: [
+      "A boundary contract sample for Security Onion visibility.",
+      "No fixtures and no proof record; the row is contract-only.",
+    ],
+    passed: [
+      "A cross-source corroboration contract is defined.",
+    ],
+    notClaimed: [
+      "Security Onion runtime, Splunk search, and Cribl / Wazuh routes are not claimed.",
+      "Zeek / Suricata quality and public-safe proof are not claimed.",
+    ],
+    remainingBlocked: [
+      "Cross-source corroboration contract is defined, not promoted to proof.",
+    ],
+    promotionRequirements: [
+      "Fixtures authored and validated before any proof record.",
     ],
   },
 ];

--- a/src/data/receiptLedger.ts
+++ b/src/data/receiptLedger.ts
@@ -1,0 +1,62 @@
+/**
+ * Receipt / ledger timeline — a hand-maintained reviewer snapshot.
+ *
+ * This is not live telemetry. Each lane is a bounded packet or receipt that
+ * a reviewer can route to. The timeline is append-only in intent and
+ * hand-maintained; it does not imply dynamic runtime telemetry.
+ */
+
+export const ledgerCaveat =
+  "Reviewer snapshot · hand-maintained · rendering only. This timeline is not live runtime telemetry.";
+
+export type LedgerEntry = {
+  marker: string;
+  kind: "receipt" | "bounded packet" | "snapshot";
+  title: string;
+  line: string;
+};
+
+export const ledgerEntries: LedgerEntry[] = [
+  {
+    marker: "001",
+    kind: "bounded packet",
+    title: "Proof Pack 001 reviewer packet",
+    line: "Bounded HO-DET-001 reviewer packet at CONTROLLED_TEST_VALIDATED.",
+  },
+  {
+    marker: "002",
+    kind: "receipt",
+    title: "Checksum manifest",
+    line: "SHA256SUMS.txt locks source packet files for review.",
+  },
+  {
+    marker: "003",
+    kind: "snapshot",
+    title: "Validation registry",
+    line: "Controlled-test packages, fixture counts, and blocked runtime states.",
+  },
+  {
+    marker: "004",
+    kind: "snapshot",
+    title: "Proof status index",
+    line: "Per-detection proof status; human review required.",
+  },
+  {
+    marker: "005",
+    kind: "bounded packet",
+    title: "AutoSOC seed ledger",
+    line: "Append-only seed ledger — 1 case, human-review required.",
+  },
+  {
+    marker: "006",
+    kind: "bounded packet",
+    title: "SOAR case packet",
+    line: "Deterministic analyst-support structure; response authority blocked.",
+  },
+  {
+    marker: "007",
+    kind: "bounded packet",
+    title: "Local GPU / LLM support boundary",
+    line: "Private support-only contract boundary; public runtime proof blocked.",
+  },
+];

--- a/src/data/reviewerRoutes.ts
+++ b/src/data/reviewerRoutes.ts
@@ -17,67 +17,72 @@ export type ReviewerRoute = {
   links: ReviewerRouteLink[];
 };
 
+/**
+ * Four reviewer routes, mapped to the four indexed visuals in
+ * ReviewRouteSelector (timeline, DAG, loop, split). The first link is the
+ * route's first action.
+ */
 export const reviewerRoutes: ReviewerRoute[] = [
   {
-    duration: "3 min",
-    audience: "Hiring manager",
-    title: "Executive scan",
-    purpose: "Confirm the public ceiling, the released reviewer package, and the flagship HO-DET-001 proof route.",
-    cares: "What is the system? What is the current public claim? What is blocked?",
-    doNotInfer: "Do not infer runtime-active, signal-observed, or public-safe runtime proof from the rendered page.",
-    items: ["Read the current proof ceiling.", "Open Proof Pack 001 release.", "Confirm the blocked claim list."],
-    links: [
-      { label: "Proof ledger", href: "/proof/" },
-      { label: "HO-DET-001 card", href: "/proof/ho-det-001/" },
-      { label: "Claim firewall", href: "/controls/" },
-    ],
-  },
-  {
-    duration: "10 min",
-    audience: "Detection engineering lead",
-    title: "Source and validation",
-    purpose: "Trace the HO-DET-001 detection rule, the controlled validation fixtures, and the case packet flow.",
-    cares: "Where is the rule? What does validation prove? What is the case packet?",
+    duration: "5 min",
+    audience: "Validation reviewer",
+    title: "Validation registry",
+    purpose: "Confirm controlled-test packages, fixture counts, and the blocked runtime / signal / public-safe states.",
+    cares: "What is validated? How many fixtures? What is blocked?",
     doNotInfer: "Do not infer runtime deployment or fleet coverage from a passing controlled-test validation.",
-    items: ["Open the detection rule.", "Read the validation result.", "Trace the case packet to the proof record."],
+    items: ["Open the validation registry.", "Filter by family.", "Inspect a package drawer."],
     links: [
-      { label: "Detection rule", href: externalLinks.hoDet001Rule, external: true },
-      { label: "Validation report", href: externalLinks.validationReportHo, external: true },
-      { label: "Proof record", href: externalLinks.proofRecord, external: true },
+      { label: "Validation registry", href: "/proof/#validation-registry" },
+      { label: "Pipeline registry", href: "/pipeline/#validation-registry" },
+      { label: "Validation repo", href: externalLinks.validation, external: true },
     ],
   },
   {
     duration: "10 min",
-    audience: "SOC automation lead",
-    title: "Case packet flow",
-    purpose: "Inspect deterministic checks, CI gates, and the internal/private runtime-contract separation.",
-    cares: "How is the loop gated? What does CI enforce? Where does the runtime contract live?",
-    doNotInfer: "Do not infer model execution in CI or live vendor pipeline proof from the proof-loop workflow.",
+    audience: "Proof / verifier reviewer",
+    title: "Proof / verifier",
+    purpose: "Trace Proof Pack 001, the included / excluded manifest, verifier routes, and the proof status index.",
+    cares: "What is in the pack? What is excluded? What do the verifiers check?",
+    doNotInfer: "Do not infer public-safe runtime proof from a released reviewer package.",
+    items: ["Open Proof Pack 001.", "Read the verifier cards.", "Confirm the proof status index."],
+    links: [
+      { label: "Proof Pack 001", href: "/proof/#proof-pack-001" },
+      { label: "Verifier cards", href: "/proof/#verifiers" },
+      { label: "Proof repo", href: externalLinks.proof, external: true },
+    ],
+  },
+  {
+    duration: "10 min",
+    audience: "Platform / SOAR reviewer",
+    title: "Platform contracts",
+    purpose: "Inspect SOAR packet, AutoSOC ledger, Detection Factory Controller, and the GPU / LLM support boundaries.",
+    cares: "What contracts exist? What authority is blocked on each?",
+    doNotInfer: "Do not infer live Torq / SOAR, response automation, or case closure from a contract blueprint.",
     items: [
-      "Open the proof-loop workflow.",
-      "Open the runtime contract on the platform plane.",
-      "Confirm the verifier preserves the public ceiling.",
+      "Open the platform contract blueprints.",
+      "Read the blocked-authority footer on each.",
+      "Confirm the AutoSOC ledger metrics.",
     ],
     links: [
-      { label: "Proof loop", href: "/proof-loop/" },
+      { label: "Platform contracts", href: "/pipeline/#platform-contracts" },
+      { label: "Receipt lane", href: "/pipeline/#receipt-lane" },
       { label: "Platform plane", href: externalLinks.platform, external: true },
-      { label: "Repository map", href: "/repos/" },
     ],
   },
   {
     duration: "Deep",
     audience: "AI governance reviewer",
-    title: "Authority chain",
+    title: "AI governance boundary",
     purpose: "Trace where AI is allowed as labor and where evidence and human review authorize claims.",
     cares: "What can AI do here? What can AI not do? Where is the authority gate?",
     doNotInfer: "Do not infer AI-approved disposition or analyst-approved disposition from any AI-assisted artifact.",
     items: [
-      "Read the AI support boundary.",
+      "Read the offline LLM support boundary.",
       "Read the claim firewall.",
       "Trace the human-review gate before public wording.",
     ],
     links: [
-      { label: "Truth surfaces", href: "/architecture/truth-surfaces/" },
+      { label: "LLM boundary", href: "/pipeline/#llm-boundary" },
       { label: "Claim firewall", href: "/controls/" },
       { label: "Control matrix", href: externalLinks.controlMatrix, external: true },
     ],

--- a/src/data/truthTelemetryMatrix.ts
+++ b/src/data/truthTelemetryMatrix.ts
@@ -76,8 +76,8 @@ export const matrixDetections: MatrixRow[] = [
     id: "HO-DET-011",
     cells: {
       "source-exists":        "supported",
-      "test-validated":       "gate-defined",
-      "evidence-linked":      "gate-defined",
+      "test-validated":       "supported",
+      "evidence-linked":      "at-ceiling",
       "bounded-public-claim": "gate-defined",
       "runtime-active":       "blocked",
       "signal-observed":      "blocked",
@@ -87,7 +87,51 @@ export const matrixDetections: MatrixRow[] = [
     id: "HO-DET-012",
     cells: {
       "source-exists":        "supported",
-      "test-validated":       "gate-defined",
+      "test-validated":       "supported",
+      "evidence-linked":      "na",
+      "bounded-public-claim": "gate-defined",
+      "runtime-active":       "blocked",
+      "signal-observed":      "blocked",
+    },
+  },
+  {
+    id: "ID-DET-001",
+    cells: {
+      "source-exists":        "supported",
+      "test-validated":       "supported",
+      "evidence-linked":      "na",
+      "bounded-public-claim": "gate-defined",
+      "runtime-active":       "blocked",
+      "signal-observed":      "blocked",
+    },
+  },
+  {
+    id: "ID-DET-002",
+    cells: {
+      "source-exists":        "supported",
+      "test-validated":       "supported",
+      "evidence-linked":      "na",
+      "bounded-public-claim": "gate-defined",
+      "runtime-active":       "blocked",
+      "signal-observed":      "blocked",
+    },
+  },
+  {
+    id: "ID-DET-003",
+    cells: {
+      "source-exists":        "supported",
+      "test-validated":       "supported",
+      "evidence-linked":      "na",
+      "bounded-public-claim": "gate-defined",
+      "runtime-active":       "blocked",
+      "signal-observed":      "blocked",
+    },
+  },
+  {
+    id: "ID-DET-004",
+    cells: {
+      "source-exists":        "supported",
+      "test-validated":       "supported",
       "evidence-linked":      "na",
       "bounded-public-claim": "gate-defined",
       "runtime-active":       "blocked",

--- a/src/data/validationRegistry.ts
+++ b/src/data/validationRegistry.ts
@@ -1,0 +1,310 @@
+/**
+ * Validation Registry — extracted controlled-test validation payload.
+ *
+ * Each row records a contract-enforced, human-review-gated validation
+ * package: fixture counts, the claim ceiling it holds, and the runtime /
+ * signal / public-safe states that stay blocked. Website rendering is not
+ * proof; this file is a reviewer map of validation output only.
+ *
+ * Scanner note: blocked tokens below are paired on-line with "blocked",
+ * "not claimed", or "excluded" so the public claim ceiling stays honest.
+ */
+
+import { externalLinks } from "./navigation";
+
+export type ValidationFamily = "Endpoint" | "Cloud" | "Identity" | "NDR/Telemetry";
+
+export type RegistryBadge = {
+  label: string;
+  tone: "ceiling" | "block" | "drift" | "warn";
+};
+
+export type ValidationRow = {
+  id: string;
+  name: string;
+  family: ValidationFamily;
+  status: "pass" | "contract-sample";
+  /** claim ceiling token shown as the package badge */
+  claimCeiling: string;
+  fixtures: { total: number; positive: number; negative: number; missed: number; falsePositiveNegatives: number } | null;
+  badges: RegistryBadge[];
+  /** true when no proof record exists yet for the row */
+  noProofRecord: boolean;
+  /** true when the row is a boundary contract sample, not a validated package */
+  contractOnly: boolean;
+  /** true when public runtime promotion is blocked for the row */
+  publicRuntimeBlocked: boolean;
+  copyBoundary?: string;
+  exists: string[];
+  proves: string[];
+  doesNotProve: string[];
+  sourceLink: string;
+};
+
+export const validationRows: ValidationRow[] = [
+  {
+    id: "HO-DET-001",
+    name: "Suspicious PowerShell EncodedCommand",
+    family: "Endpoint",
+    status: "pass",
+    claimCeiling: "CONTROLLED_TEST_VALIDATED",
+    fixtures: { total: 14, positive: 7, negative: 7, missed: 0, falsePositiveNegatives: 0 },
+    badges: [{ label: "CONTROLLED_TEST_VALIDATED", tone: "ceiling" }],
+    noProofRecord: false,
+    contractOnly: false,
+    publicRuntimeBlocked: true,
+    exists: [
+      "A controlled-test validation package with 14 fixtures.",
+      "A public proof record and reviewer release route.",
+    ],
+    proves: [
+      "14 / 14 fixtures pass deterministically.",
+      "0 missed positives and 0 false-positive negatives.",
+    ],
+    doesNotProve: [
+      "Runtime-active status is blocked from this surface.",
+      "Signal-observed status is not claimed.",
+      "Live Splunk, Cribl/Wazuh routing, production, fleet, and public-safe runtime proof are blocked.",
+      "AI / analyst disposition is not claimed.",
+    ],
+    sourceLink: externalLinks.validationReportHo,
+  },
+  {
+    id: "HO-DET-011",
+    name: "Windows Service Creation / Binary Change",
+    family: "Endpoint",
+    status: "pass",
+    claimCeiling: "CONTROLLED_TEST_VALIDATED",
+    fixtures: { total: 17, positive: 7, negative: 10, missed: 0, falsePositiveNegatives: 0 },
+    badges: [
+      { label: "CONTROLLED_TEST_VALIDATED", tone: "ceiling" },
+      { label: "DRIFT_REVIEW_REQUIRED", tone: "drift" },
+      { label: "NOT_PUBLIC_SAFE", tone: "block" },
+    ],
+    noProofRecord: false,
+    contractOnly: false,
+    publicRuntimeBlocked: true,
+    copyBoundary: "Platform guardrail drift requires review; private runtime evidence is excluded and not public-safe.",
+    exists: [
+      "A controlled-test validation package with 17 fixtures.",
+      "A private runtime evidence index, excluded from the public proof basis.",
+    ],
+    proves: [
+      "17 / 17 fixtures pass deterministically.",
+      "0 missed positives and 0 false-positive negatives.",
+    ],
+    doesNotProve: [
+      "Public-safe state is NOT_PUBLIC_SAFE; raw private runtime evidence is excluded.",
+      "Runtime-active and signal-observed status are blocked.",
+      "Platform guardrail drift is unresolved and review is required, so promotion is blocked.",
+    ],
+    sourceLink: externalLinks.validation,
+  },
+  {
+    id: "HO-DET-012",
+    name: "Suspicious Scheduled Task Creation",
+    family: "Endpoint",
+    status: "pass",
+    claimCeiling: "CONTROLLED_TEST_VALIDATED",
+    fixtures: { total: 8, positive: 4, negative: 4, missed: 0, falsePositiveNegatives: 0 },
+    badges: [
+      { label: "CONTROLLED_TEST_VALIDATED", tone: "ceiling" },
+      { label: "NO_PROOF_RECORD", tone: "warn" },
+    ],
+    noProofRecord: true,
+    contractOnly: false,
+    publicRuntimeBlocked: true,
+    exists: [
+      "A controlled-test validation package with 8 fixtures.",
+      "No proof record exists yet; the row is validation-only.",
+    ],
+    proves: [
+      "8 / 8 fixtures pass deterministically.",
+      "0 missed positives and 0 false-positive negatives.",
+    ],
+    doesNotProve: [
+      "No proof record exists, so public proof is not claimed.",
+      "Runtime-active and signal-observed status are blocked.",
+    ],
+    sourceLink: externalLinks.validation,
+  },
+  {
+    id: "AWS-DET-001",
+    name: "CloudTrail-style IAM denial",
+    family: "Cloud",
+    status: "pass",
+    claimCeiling: "CONTROLLED_TEST_VALIDATED",
+    fixtures: { total: 6, positive: 3, negative: 3, missed: 0, falsePositiveNegatives: 0 },
+    badges: [
+      { label: "CONTROLLED_TEST_VALIDATED", tone: "ceiling" },
+      { label: "AWS_LIVE_BLOCKED", tone: "block" },
+    ],
+    noProofRecord: false,
+    contractOnly: false,
+    publicRuntimeBlocked: true,
+    copyBoundary: "Fixture-only CloudTrail-style IAM denial validation; live AWS proof is blocked.",
+    exists: [
+      "A fixture-only CloudTrail-style detection candidate.",
+      "A fixture-only validation report with 6 fixtures.",
+    ],
+    proves: [
+      "6 / 6 fixtures pass deterministically.",
+      "0 missed positives and 0 false-positive negatives.",
+    ],
+    doesNotProve: [
+      "Live AWS and CloudTrail live evidence are not claimed.",
+      "Cloud runtime-active and signal-observed status are blocked.",
+    ],
+    sourceLink: externalLinks.validationReportAws,
+  },
+  {
+    id: "ID-DET-001",
+    name: "Suspicious identity session context",
+    family: "Identity",
+    status: "pass",
+    claimCeiling: "CONTROLLED_TEST_VALIDATED",
+    fixtures: { total: 10, positive: 5, negative: 5, missed: 0, falsePositiveNegatives: 0 },
+    badges: [
+      { label: "CONTROLLED_TEST_VALIDATED", tone: "ceiling" },
+      { label: "NO_PROOF_RECORD", tone: "warn" },
+    ],
+    noProofRecord: true,
+    contractOnly: false,
+    publicRuntimeBlocked: true,
+    exists: [
+      "A controlled-test validation package with 10 fixtures.",
+      "No proof record exists yet; the row is validation-only.",
+    ],
+    proves: [
+      "10 / 10 fixtures pass deterministically.",
+      "0 missed positives and 0 false-positive negatives.",
+    ],
+    doesNotProve: [
+      "Live IdP / SIEM / NDR coverage is not claimed.",
+      "Production identity coverage and autonomous / AI disposition are blocked.",
+    ],
+    sourceLink: externalLinks.validation,
+  },
+  {
+    id: "ID-DET-002",
+    name: "MFA fatigue / repeated MFA failure",
+    family: "Identity",
+    status: "pass",
+    claimCeiling: "CONTROLLED_TEST_VALIDATED",
+    fixtures: { total: 10, positive: 5, negative: 5, missed: 0, falsePositiveNegatives: 0 },
+    badges: [
+      { label: "CONTROLLED_TEST_VALIDATED", tone: "ceiling" },
+      { label: "NO_PROOF_RECORD", tone: "warn" },
+    ],
+    noProofRecord: true,
+    contractOnly: false,
+    publicRuntimeBlocked: true,
+    exists: [
+      "A controlled-test validation package with 10 fixtures.",
+      "No proof record exists yet; the row is validation-only.",
+    ],
+    proves: [
+      "10 / 10 fixtures pass deterministically.",
+      "0 missed positives and 0 false-positive negatives.",
+    ],
+    doesNotProve: [
+      "Live IdP and live SIEM / NDR are not claimed.",
+      "Proof promotion and public-safe state are blocked.",
+    ],
+    sourceLink: externalLinks.validation,
+  },
+  {
+    id: "ID-DET-003",
+    name: "Privileged role / admin group change",
+    family: "Identity",
+    status: "pass",
+    claimCeiling: "CONTROLLED_TEST_VALIDATED",
+    fixtures: { total: 10, positive: 5, negative: 5, missed: 0, falsePositiveNegatives: 0 },
+    badges: [
+      { label: "CONTROLLED_TEST_VALIDATED", tone: "ceiling" },
+      { label: "NO_PROOF_RECORD", tone: "warn" },
+    ],
+    noProofRecord: true,
+    contractOnly: false,
+    publicRuntimeBlocked: true,
+    exists: [
+      "A controlled-test validation package with 10 fixtures.",
+      "No proof record exists yet; the row is validation-only.",
+    ],
+    proves: [
+      "10 / 10 fixtures pass deterministically.",
+      "0 missed positives and 0 false-positive negatives.",
+    ],
+    doesNotProve: [
+      "Live IdP / SIEM coverage is not claimed.",
+      "Production coverage and AI / analyst disposition are blocked.",
+    ],
+    sourceLink: externalLinks.validation,
+  },
+  {
+    id: "ID-DET-004",
+    name: "Impossible travel / anomalous session",
+    family: "Identity",
+    status: "pass",
+    claimCeiling: "CONTROLLED_TEST_VALIDATED",
+    fixtures: { total: 10, positive: 5, negative: 5, missed: 0, falsePositiveNegatives: 0 },
+    badges: [
+      { label: "CONTROLLED_TEST_VALIDATED", tone: "ceiling" },
+      { label: "COMPLETENESS_BLOCKED", tone: "block" },
+      { label: "NO_PROOF_RECORD", tone: "warn" },
+    ],
+    noProofRecord: true,
+    contractOnly: false,
+    publicRuntimeBlocked: true,
+    exists: [
+      "A controlled-test validation package with 10 fixtures.",
+      "No proof record exists yet; the row is validation-only.",
+    ],
+    proves: [
+      "10 / 10 fixtures pass deterministically.",
+      "0 missed positives and 0 false-positive negatives.",
+    ],
+    doesNotProve: [
+      "Impossible-travel and session-hijacking completeness are not claimed.",
+      "Live IdP and public-safe state are blocked.",
+    ],
+    sourceLink: externalLinks.validation,
+  },
+  {
+    id: "HO-NDR-001",
+    name: "Security Onion visibility contract",
+    family: "NDR/Telemetry",
+    status: "contract-sample",
+    claimCeiling: "BOUNDARY_CONTRACT_ONLY",
+    fixtures: null,
+    badges: [{ label: "BOUNDARY_CONTRACT_ONLY", tone: "warn" }],
+    noProofRecord: true,
+    contractOnly: true,
+    publicRuntimeBlocked: true,
+    copyBoundary: "Contract sample only; no fixtures. Cross-source corroboration contract defined, not proof promotion.",
+    exists: [
+      "A boundary contract sample for Security Onion visibility.",
+      "No fixtures and no proof record; the row is contract-only.",
+    ],
+    proves: [
+      "A cross-source corroboration contract is defined.",
+    ],
+    doesNotProve: [
+      "Security Onion runtime, Splunk search, and Cribl/Wazuh routes are blocked.",
+      "Zeek / Suricata quality and public-safe proof are not claimed.",
+    ],
+    sourceLink: externalLinks.validation,
+  },
+];
+
+export const validationFamilies: ValidationFamily[] = ["Endpoint", "Cloud", "Identity", "NDR/Telemetry"];
+
+const validatedRows = validationRows.filter((r) => r.status === "pass");
+
+export const registryStats = {
+  totalFixtures: validationRows.reduce((sum, r) => sum + (r.fixtures?.total ?? 0), 0),
+  passedPackages: validatedRows.length,
+  noProofRecordRows: validationRows.filter((r) => r.noProofRecord).length,
+  contractOnlyRows: validationRows.filter((r) => r.contractOnly).length,
+  publicRuntimeBlockedRows: validationRows.filter((r) => r.publicRuntimeBlocked).length,
+};


### PR DESCRIPTION
Summary:
- Adds reviewer-facing Phase 2 proof/pipeline surfaces.
- Adds validation registry, proof manifest, verifier cards, platform contracts, receipt timeline, blocked-claim firewall, and proof status index.
- Preserves public claim ceiling and blocked runtime/signal boundaries.
- Hardens site verifier against private-runtime literal leakage.

Validation:
- npm run check:site
- npm run typecheck
- npm run build
- git diff --check
- rendered-output token scan

Claim boundary:
- Public ceiling: CONTROLLED_TEST_VALIDATED
- Runtime/signal/public proof: blocked
- HO-DET-012 and identity detections: NO_PROOF_RECORD
- HO-NDR-001: BOUNDARY_CONTRACT_ONLY
- HO-DET-011: drift surfaced, not normalized
- PRIVATE_RUNTIME_EVIDENCE_CAPTURED: absent from rendered output

Proof boundary note:
Rendering is not proof. These website surfaces present reviewer navigation and public-safe status only. They do not promote private runtime evidence, signal observation, production readiness, or autonomous SOC claims.