### PR TITLE
fix(website): correct keyboard traversal in reviewer panels

### DIFF
--- a/components/GovernedDetectionLoop.tsx
+++ b/components/GovernedDetectionLoop.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type KeyboardEvent } from "react";
 import { artifactStages } from "@data/artifactMachine";
 
 /**
@@ -14,9 +14,33 @@ import { artifactStages } from "@data/artifactMachine";
  * Claim contract: reuses src/data/artifactMachine.ts only. No new claims.
  */
 export default function GovernedDetectionLoop() {
-  const [active, setActive] = useState(0);
+  const [activeId, setActiveId] = useState(artifactStages[0]?.id ?? "");
+  const active = Math.max(
+    artifactStages.findIndex((s) => s.id === activeId),
+    0,
+  );
   const stage = artifactStages[active];
   const total = artifactStages.length;
+
+  const setActiveByIndex = (index: number) => {
+    setActiveId(artifactStages[index].id);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveByIndex((active + 1) % total);
+    } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveByIndex((active - 1 + total) % total);
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      setActiveByIndex(0);
+    } else if (e.key === "End") {
+      e.preventDefault();
+      setActiveByIndex(total - 1);
+    }
+  };
 
   return (
     <div className="gdl" role="region" aria-label="Governed detection loop">
@@ -34,18 +58,10 @@ export default function GovernedDetectionLoop() {
               aria-controls="gdl-panel"
               tabIndex={isActive ? 0 : -1}
               className={`gdl__node${isActive ? " gdl__node--active" : ""}${isLast ? " gdl__node--boundary" : ""}`}
-              onClick={() => setActive(i)}
-              onFocus={() => setActive(i)}
-              onMouseEnter={() => setActive(i)}
-              onKeyDown={(e) => {
-                if (e.key === "ArrowRight" || e.key === "ArrowDown") {
-                  e.preventDefault();
-                  setActive((i + 1) % total);
-                } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
-                  e.preventDefault();
-                  setActive((i - 1 + total) % total);
-                }
-              }}
+              onClick={() => setActiveId(s.id)}
+              onFocus={() => setActiveId(s.id)}
+              onMouseEnter={() => setActiveId(s.id)}
+              onKeyDown={handleKeyDown}
             >
               <span className="gdl__node-n">{s.n}</span>
               <span className="gdl__node-name">{s.name}</span>

--- a/components/TruthSurfaceBoard.tsx
+++ b/components/TruthSurfaceBoard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type KeyboardEvent } from "react";
 import { truthSurfaces } from "@config/truth-surfaces";
 
 /**
@@ -12,9 +12,33 @@ import { truthSurfaces } from "@config/truth-surfaces";
  * and the related repo. Reuses config/truth-surfaces.ts only.
  */
 export default function TruthSurfaceBoard() {
-  const [active, setActive] = useState(0);
+  const [activeSlug, setActiveSlug] = useState(truthSurfaces[0]?.slug ?? "");
   const total = truthSurfaces.length;
+  const active = Math.max(
+    truthSurfaces.findIndex((surface) => surface.slug === activeSlug),
+    0,
+  );
   const s = truthSurfaces[active];
+
+  const setActiveByIndex = (index: number) => {
+    setActiveSlug(truthSurfaces[index].slug);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === "ArrowDown" || e.key === "ArrowRight") {
+      e.preventDefault();
+      setActiveByIndex((active + 1) % total);
+    } else if (e.key === "ArrowUp" || e.key === "ArrowLeft") {
+      e.preventDefault();
+      setActiveByIndex((active - 1 + total) % total);
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      setActiveByIndex(0);
+    } else if (e.key === "End") {
+      e.preventDefault();
+      setActiveByIndex(total - 1);
+    }
+  };
 
   return (
     <div className="tsb">
@@ -36,18 +60,10 @@ export default function TruthSurfaceBoard() {
               aria-controls="tsb-panel"
               tabIndex={isActive ? 0 : -1}
               className={`tsb__item${isActive ? " tsb__item--active" : ""}`}
-              onClick={() => setActive(i)}
-              onFocus={() => setActive(i)}
-              onMouseEnter={() => setActive(i)}
-              onKeyDown={(e) => {
-                if (e.key === "ArrowDown" || e.key === "ArrowRight") {
-                  e.preventDefault();
-                  setActive((i + 1) % total);
-                } else if (e.key === "ArrowUp" || e.key === "ArrowLeft") {
-                  e.preventDefault();
-                  setActive((i - 1 + total) % total);
-                }
-              }}
+              onClick={() => setActiveSlug(surface.slug)}
+              onFocus={() => setActiveSlug(surface.slug)}
+              onMouseEnter={() => setActiveSlug(surface.slug)}
+              onKeyDown={handleKeyDown}
             >
               <span className="tsb__item-n">{String(i + 1).padStart(2, "0")}</span>
               <span className="tsb__item-name">{surface.name}</span>


### PR DESCRIPTION
Summary:
- Fixes post-merge P2 review feedback from PR #39.
- Corrects keyboard arrow traversal in GovernedDetectionLoop and TruthSurfaceBoard.
- Derives keyboard movement from current active item state instead of mapped render index.
- Preserves click/focus behavior, detail-panel updates, and existing claim boundaries.

Scope:
- components/GovernedDetectionLoop.tsx
- components/TruthSurfaceBoard.tsx

Validation:
- npm run check:site
- npm run typecheck
- npm run build
- git diff --check
- npm run check:site after build

Claim boundary:
- No copy or proof-claim changes.
- CONTROLLED_TEST_VALIDATED ceiling unchanged.
- Website rendering remains not proof.
- No runtime/signal/production/public-safe-runtime claim introduced.

Review notes:
- This PR addresses the two post-merge P2 keyboard-navigation review threads from PR #39.
- No history rewrite.
- No broad redesign.