### PR TITLE
data(website): align runtime factory proof status display

### DIFF
--- a/src/data/proofPackManifest.ts
+++ b/src/data/proofPackManifest.ts
@@ -124,7 +124,7 @@ export const proofStatusIndex = {
   humanReview: "HUMAN_REVIEW_REQUIRED",
   rows: [
     { id: "HO-DET-001", status: "PROOF_RECORD_PRESENT", tone: "ceiling", note: "Controlled-test proof record and card." },
-    { id: "HO-DET-011", status: "PROOF_RECORD_PRESENT", tone: "ceiling", note: "Bounded public-safe summary approved; raw evidence private; Splunk NOT_VERIFIED." },
+    { id: "HO-DET-011", status: "PRIVATE_RUNTIME_BOUNDARY", tone: "ceiling", note: "Bounded summary approved; raw evidence private; Splunk NOT_VERIFIED; no public runtime proof." },
     { id: "HO-DET-012", status: "PROOF_RECORD_PRESENT", tone: "ceiling", note: "Bounded public-safe summary approved; raw evidence private; Splunk NOT_VERIFIED." },
     { id: "AWS-DET-001", status: "PROOF_RECORD_PRESENT", tone: "ceiling", note: "Cloud validation card; live AWS blocked." },
     { id: "ID-DET-001", status: "NO_PROOF_RECORD", tone: "warn", note: "Validation-only; no proof record." },


### PR DESCRIPTION
Aligns Runtime Proof Factory v0 website proof status display so HO-DET-011 does not show conflicting status vocabulary across proofRecords and proofPackManifest.

Boundary preserved:
- Public runtime proof is not claimed.
- Public signal proof is not claimed.
- Splunk remains NOT_VERIFIED.
- Raw evidence remains private.
- Production readiness, fleet-wide coverage, autonomous SOC, AI-approved disposition, and analyst-approved disposition are not claimed.