### PR TITLE
feat: add proof evidence vault visual

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -11110,3 +11110,527 @@ body::after {
   .htbp__rail { flex-direction: column; align-items: flex-start; gap: 14px; padding: 18px; }
   .htbp__seal { width: 48px; height: 48px; }
 }
+
+/* ════════════════════════════════════════════════════════════════════
+   PROOF · Evidence Vault / Claim Authority Hub
+   ProofVaultHero · ClaimFirewallSplitPane · RuntimeBoundaryVisual ·
+   ProofRecordsEvidenceBay · ProofTrustBoundaryRail
+   ════════════════════════════════════════════════════════════════════ */
+
+/* ── ProofVaultHero ─────────────────────────────────────────────────── */
+.pvh {
+  position: relative;
+  overflow: hidden;
+  padding: clamp(48px, 7vw, 104px) 0 clamp(36px, 5vw, 72px);
+  isolation: isolate;
+}
+.pvh__field {
+  position: absolute;
+  inset: -20% -10% auto -10%;
+  height: 140%;
+  background:
+    radial-gradient(120% 90% at 78% 18%, rgba(143, 216, 255, 0.12), transparent 60%),
+    radial-gradient(90% 80% at 12% 90%, rgba(59, 130, 246, 0.08), transparent 62%);
+  z-index: -1;
+  pointer-events: none;
+}
+.pvh__grid {
+  display: grid;
+  gap: clamp(28px, 5vw, 64px);
+  align-items: center;
+}
+@media (min-width: 980px) {
+  .pvh__grid { grid-template-columns: 1.1fr 0.9fr; }
+}
+.pvh__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  margin: 0 0 18px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.66rem;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  color: var(--ice-blue);
+}
+.pvh__eyebrow-dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--electric-blue-bright);
+  box-shadow: 0 0 10px var(--electric-blue-bright);
+  animation: pvhDot 2.6s ease-in-out infinite;
+}
+@keyframes pvhDot { 0%, 100% { opacity: 0.5; } 50% { opacity: 1; } }
+.pvh__headline {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  line-height: 1.04;
+  letter-spacing: 0;
+  font-weight: 800;
+  color: var(--silver-bright);
+}
+.pvh__headline-emph {
+  background: linear-gradient(92deg, #8FD8FF, #5FBFFF);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.pvh__lede {
+  margin: 22px 0 0;
+  max-width: 44ch;
+  font-size: clamp(0.98rem, 1.5vw, 1.12rem);
+  line-height: 1.62;
+  color: var(--silver);
+}
+.pvh__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 26px 0 0;
+}
+.pvh__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 11px;
+  border-radius: 999px;
+  border: 1px solid var(--moon-border);
+  background: rgba(8, 13, 22, 0.55);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.64rem;
+  letter-spacing: 0.04em;
+  color: var(--silver-bright);
+}
+.pvh__chip-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--ice-blue); }
+.pvh__chip--ceiling { border-color: rgba(143, 216, 255, 0.4); }
+.pvh__chip--ceiling .pvh__chip-dot { background: var(--electric-blue-bright); box-shadow: 0 0 8px var(--electric-blue-bright); }
+.pvh__chip--supported .pvh__chip-dot { background: var(--gate-green, #5fd0a0); }
+.pvh__chip--blocked { border-color: rgba(252, 165, 165, 0.35); }
+.pvh__chip--blocked .pvh__chip-dot { background: var(--blocked-red, #fca5a5); }
+.pvh__ctas { display: flex; flex-wrap: wrap; gap: 12px; margin: 30px 0 0; }
+.pvh__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  padding: 12px 20px;
+  border-radius: 10px;
+  font-size: 0.92rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+}
+.pvh__cta--primary {
+  background: linear-gradient(180deg, rgba(143, 216, 255, 0.95), rgba(59, 130, 246, 0.8));
+  color: #04101e;
+  box-shadow: 0 8px 28px rgba(59, 130, 246, 0.3);
+}
+.pvh__cta--ghost {
+  border: 1px solid var(--moon-border-bright);
+  background: rgba(8, 13, 22, 0.5);
+  color: var(--silver-bright);
+}
+.pvh__cta:hover { transform: translateY(-2px); }
+.pvh__cta--primary:hover { box-shadow: 0 12px 34px rgba(59, 130, 246, 0.42); }
+.pvh__cta--ghost:hover { border-color: var(--electric-blue); }
+.pvh__cta-arrow { transition: transform 180ms ease; }
+.pvh__cta:hover .pvh__cta-arrow { transform: translateX(3px); }
+.pvh__vault {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.pvh__seal { width: min(100%, 420px); height: auto; }
+.pvh__ring { fill: none; stroke: var(--moon-border-bright); stroke-width: 1; opacity: 0.7; }
+.pvh__ring--outer { stroke: rgba(143, 216, 255, 0.3); stroke-dasharray: 3 7; transform-origin: 120px 120px; animation: pvhSpin 60s linear infinite; }
+.pvh__ring--mid { stroke: rgba(143, 216, 255, 0.22); }
+.pvh__ring--inner { stroke: rgba(143, 216, 255, 0.18); }
+.pvh__sweep { transform-origin: 120px 120px; animation: pvhSpin 9s linear infinite; opacity: 0.95; }
+.pvh__lug { fill: var(--silver); opacity: 0.7; }
+.pvh__door {
+  fill: rgba(8, 13, 22, 0.85);
+  stroke: rgba(143, 216, 255, 0.45);
+  stroke-width: 1.4;
+}
+@keyframes pvhSpin { to { transform: rotate(360deg); } }
+@media (max-width: 979px) {
+  .pvh__seal { width: min(72%, 320px); }
+}
+
+/* ── ClaimFirewallSplitPane ─────────────────────────────────────────── */
+.cfsp {
+  border: 1px solid var(--moon-border);
+  border-radius: 16px;
+  background:
+    radial-gradient(120% 90% at 50% -10%, rgba(143, 216, 255, 0.06), transparent 60%),
+    rgba(7, 11, 19, 0.6);
+  padding: clamp(20px, 3vw, 34px);
+}
+.cfsp__head { margin-bottom: 22px; }
+.cfsp__title {
+  margin: 8px 0 0;
+  font-size: clamp(1.4rem, 2.4vw, 2rem);
+  font-weight: 800;
+  letter-spacing: 0;
+  color: var(--silver-bright);
+}
+.cfsp__sub { margin: 12px 0 0; max-width: 64ch; font-size: 0.9rem; line-height: 1.55; color: var(--muted); }
+.cfsp__stage {
+  display: grid;
+  gap: 20px;
+}
+@media (min-width: 900px) {
+  .cfsp__stage { grid-template-columns: 1.05fr 0.95fr; align-items: stretch; }
+}
+.cfsp__lanes {
+  position: relative;
+  display: grid;
+  grid-template-rows: repeat(3, 1fr);
+  gap: 12px;
+}
+.cfsp__lane {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  text-align: left;
+  padding: 16px 18px;
+  border-radius: 12px;
+  border: 1px solid var(--moon-border);
+  background: rgba(8, 13, 22, 0.55);
+  color: var(--silver-bright);
+  cursor: pointer;
+  transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+}
+.cfsp__lane:hover, .cfsp__lane.is-active { transform: translateX(4px); }
+.cfsp__lane-verdict {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.18em;
+  white-space: nowrap;
+}
+.cfsp__lane-label { font-size: 0.95rem; font-weight: 600; }
+.cfsp__lane-count {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.7rem;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--moon-border);
+}
+.cfsp__lane--allowed { border-left: 3px solid var(--gate-green, #5fd0a0); }
+.cfsp__lane--allowed.is-active { border-color: var(--gate-green, #5fd0a0); box-shadow: 0 0 0 1px rgba(95, 208, 160, 0.4), 0 8px 24px rgba(95, 208, 160, 0.15); }
+.cfsp__lane--allowed .cfsp__lane-verdict { color: var(--gate-green, #5fd0a0); }
+.cfsp__lane--careful { border-left: 3px solid var(--ceiling-amber, #f0b85f); }
+.cfsp__lane--careful.is-active { border-color: var(--ceiling-amber, #f0b85f); box-shadow: 0 0 0 1px rgba(240, 184, 95, 0.4), 0 8px 24px rgba(240, 184, 95, 0.14); }
+.cfsp__lane--careful .cfsp__lane-verdict { color: var(--ceiling-amber, #f0b85f); }
+.cfsp__lane--blocked { border-left: 3px solid var(--blocked-red, #fca5a5); }
+.cfsp__lane--blocked.is-active { border-color: var(--blocked-red, #fca5a5); box-shadow: 0 0 0 1px rgba(252, 165, 165, 0.4), 0 8px 24px rgba(252, 165, 165, 0.14); }
+.cfsp__lane--blocked .cfsp__lane-verdict { color: var(--blocked-red, #fca5a5); }
+.cfsp__gate {
+  display: none;
+}
+@media (min-width: 900px) {
+  .cfsp__gate {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    position: absolute;
+    top: 50%;
+    right: -34px;
+    transform: translateY(-50%);
+    width: 60px;
+    text-align: center;
+  }
+  .cfsp__gate::before {
+    content: "";
+    position: absolute;
+    top: -40px; bottom: -40px;
+    left: 50%;
+    width: 2px;
+    background: linear-gradient(180deg, transparent, var(--electric-blue), transparent);
+    opacity: 0.6;
+  }
+  .cfsp__gate-label {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 0.6rem;
+    letter-spacing: 0.2em;
+    color: var(--electric-blue-bright);
+    background: var(--bg);
+    padding: 4px 0;
+    z-index: 1;
+  }
+  .cfsp__gate-sub {
+    display: none;
+  }
+}
+.cfsp__detail {
+  border: 1px solid var(--moon-border);
+  border-radius: 12px;
+  background: rgba(5, 9, 16, 0.7);
+  padding: 20px;
+}
+.cfsp__detail--allowed { border-top: 3px solid var(--gate-green, #5fd0a0); }
+.cfsp__detail--careful { border-top: 3px solid var(--ceiling-amber, #f0b85f); }
+.cfsp__detail--blocked { border-top: 3px solid var(--blocked-red, #fca5a5); }
+.cfsp__detail-verdict {
+  margin: 0;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.66rem;
+  letter-spacing: 0.16em;
+  color: var(--silver-bright);
+}
+.cfsp__detail-body { margin: 10px 0 16px; font-size: 0.9rem; line-height: 1.55; color: var(--silver); }
+.cfsp__detail-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 9px; }
+.cfsp__detail-item { display: flex; gap: 10px; align-items: flex-start; font-size: 0.86rem; line-height: 1.45; color: var(--silver-bright); }
+.cfsp__detail-mark {
+  flex: none;
+  width: 18px;
+  font-family: "JetBrains Mono", monospace;
+  text-align: center;
+}
+.cfsp__detail--allowed .cfsp__detail-mark { color: var(--gate-green, #5fd0a0); }
+.cfsp__detail--careful .cfsp__detail-mark { color: var(--ceiling-amber, #f0b85f); }
+.cfsp__detail--blocked .cfsp__detail-mark { color: var(--blocked-red, #fca5a5); }
+.cfsp__table-wrap { margin-top: 18px; }
+.cfsp__table-summary, .rbv__table-summary, .peb__more-summary {
+  cursor: pointer;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.1em;
+  color: var(--ice-blue);
+}
+.cfsp__table-groups { display: grid; gap: 16px; margin-top: 14px; }
+@media (min-width: 760px) { .cfsp__table-groups { grid-template-columns: repeat(3, 1fr); } }
+.cfsp__table-group-title { margin: 0 0 6px; font-size: 0.82rem; font-weight: 700; color: var(--silver-bright); }
+.cfsp__table-group-body { margin: 0 0 8px; font-size: 0.8rem; line-height: 1.45; color: var(--muted); }
+.cfsp__table-group ul { margin: 0; padding-left: 18px; font-size: 0.8rem; line-height: 1.5; color: var(--silver); }
+
+/* ── RuntimeBoundaryVisual ──────────────────────────────────────────── */
+.rbv {
+  border: 1px solid var(--moon-border);
+  border-radius: 16px;
+  background:
+    radial-gradient(120% 80% at 18% -10%, rgba(143, 216, 255, 0.06), transparent 58%),
+    rgba(7, 11, 19, 0.6);
+  padding: clamp(20px, 3vw, 34px);
+}
+.rbv__head { margin-bottom: 22px; }
+.rbv__title { margin: 8px 0 0; font-size: clamp(1.4rem, 2.4vw, 2rem); font-weight: 800; letter-spacing: 0; color: var(--silver-bright); }
+.rbv__sub { margin: 12px 0 0; max-width: 64ch; font-size: 0.9rem; line-height: 1.55; color: var(--muted); }
+.rbv__stage { display: grid; gap: 20px; }
+@media (min-width: 900px) { .rbv__stage { grid-template-columns: 0.95fr 1.05fr; align-items: start; } }
+.rbv__tower {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+  position: relative;
+}
+.rbv__rung-wrap { margin: 0; }
+.rbv__rung {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto auto 1fr auto;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  text-align: left;
+  padding: 13px 16px;
+  border-radius: 10px;
+  border: 1px solid var(--moon-border);
+  background: rgba(8, 13, 22, 0.5);
+  color: var(--silver-bright);
+  cursor: pointer;
+  transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease, background 160ms ease;
+}
+.rbv__rung:hover, .rbv__rung.is-active { transform: translateX(4px); }
+.rbv__rung-rank { font-family: "JetBrains Mono", monospace; font-size: 0.7rem; color: var(--muted); }
+.rbv__rung-mark { font-size: 0.85rem; }
+.rbv__rung-label { font-size: 0.9rem; font-weight: 600; }
+.rbv__rung-status {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.58rem;
+  letter-spacing: 0.14em;
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--moon-border);
+  white-space: nowrap;
+}
+.rbv__rung--supported { border-left: 3px solid var(--gate-green, #5fd0a0); }
+.rbv__rung--supported .rbv__rung-mark { color: var(--gate-green, #5fd0a0); }
+.rbv__rung-status--supported { color: var(--gate-green, #5fd0a0); }
+.rbv__rung--supported.is-active { border-color: var(--gate-green, #5fd0a0); box-shadow: 0 0 0 1px rgba(95, 208, 160, 0.35); }
+.rbv__rung--partial { border-left: 3px solid var(--ceiling-amber, #f0b85f); }
+.rbv__rung--partial .rbv__rung-mark { color: var(--ceiling-amber, #f0b85f); }
+.rbv__rung-status--partial { color: var(--ceiling-amber, #f0b85f); }
+.rbv__rung--partial.is-active { border-color: var(--ceiling-amber, #f0b85f); box-shadow: 0 0 0 1px rgba(240, 184, 95, 0.35); }
+.rbv__rung--blocked {
+  border-left: 3px solid var(--blocked-red, #fca5a5);
+  background:
+    repeating-linear-gradient(45deg, rgba(252, 165, 165, 0.05) 0 6px, transparent 6px 12px),
+    rgba(8, 13, 22, 0.5);
+}
+.rbv__rung--blocked .rbv__rung-mark { color: var(--blocked-red, #fca5a5); }
+.rbv__rung-status--blocked { color: var(--blocked-red, #fca5a5); border-color: rgba(252, 165, 165, 0.4); }
+.rbv__rung--blocked.is-active { border-color: var(--blocked-red, #fca5a5); box-shadow: 0 0 0 1px rgba(252, 165, 165, 0.35); }
+.rbv__detail {
+  border: 1px solid var(--moon-border);
+  border-radius: 12px;
+  background: rgba(5, 9, 16, 0.7);
+  padding: 22px;
+}
+.rbv__detail--supported { border-top: 3px solid var(--gate-green, #5fd0a0); }
+.rbv__detail--partial { border-top: 3px solid var(--ceiling-amber, #f0b85f); }
+.rbv__detail--blocked { border-top: 3px solid var(--blocked-red, #fca5a5); }
+.rbv__detail-rank { margin: 0; font-family: "JetBrains Mono", monospace; font-size: 0.62rem; letter-spacing: 0.18em; color: var(--muted); }
+.rbv__detail-title { margin: 6px 0 0; font-size: 1.15rem; font-weight: 700; color: var(--silver-bright); }
+.rbv__detail-status {
+  display: inline-block;
+  margin: 10px 0 0;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.14em;
+  padding: 3px 9px;
+  border-radius: 999px;
+  border: 1px solid var(--moon-border);
+}
+.rbv__detail-status--supported { color: var(--gate-green, #5fd0a0); }
+.rbv__detail-status--partial { color: var(--ceiling-amber, #f0b85f); }
+.rbv__detail-status--blocked { color: var(--blocked-red, #fca5a5); border-color: rgba(252, 165, 165, 0.4); }
+.rbv__detail-list { margin: 18px 0 0; display: grid; gap: 14px; }
+.rbv__detail-list dt { font-family: "JetBrains Mono", monospace; font-size: 0.6rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ice-blue); }
+.rbv__detail-list dd { margin: 5px 0 0; font-size: 0.88rem; line-height: 1.55; color: var(--silver); }
+.rbv__table-wrap { margin-top: 18px; }
+.rbv__table { width: 100%; border-collapse: collapse; margin-top: 12px; font-size: 0.8rem; }
+.rbv__table th, .rbv__table td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--moon-border); color: var(--silver); vertical-align: top; }
+.rbv__table thead th { color: var(--ice-blue); font-family: "JetBrains Mono", monospace; font-size: 0.62rem; letter-spacing: 0.12em; }
+
+/* ── ProofRecordsEvidenceBay ────────────────────────────────────────── */
+.peb { display: grid; gap: 18px; }
+.peb__grid { display: grid; gap: 16px; }
+@media (min-width: 760px) { .peb__grid { grid-template-columns: repeat(2, 1fr); } }
+.peb__receipt {
+  position: relative;
+  border: 1px solid var(--moon-border);
+  border-radius: 12px;
+  background: rgba(7, 11, 19, 0.62);
+  padding: 20px;
+}
+.peb__receipt--flagship {
+  background:
+    radial-gradient(120% 100% at 100% 0%, rgba(143, 216, 255, 0.07), transparent 55%),
+    rgba(7, 11, 19, 0.72);
+  border-color: var(--moon-border-bright);
+  box-shadow: 0 10px 36px rgba(0, 0, 0, 0.35);
+}
+.peb__perf {
+  position: absolute; left: 14px; right: 14px; height: 0;
+  border-top: 1px dashed var(--moon-border);
+}
+.peb__perf--top { top: 0; }
+.peb__receipt-head {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 16px;
+}
+.peb__receipt-id { font-size: 1rem; font-weight: 700; color: var(--silver-bright); letter-spacing: 0.04em; }
+.peb__receipt-title { margin: 4px 0 0; font-size: 0.86rem; color: var(--muted); line-height: 1.4; }
+.peb__receipt-meta { display: flex; flex-direction: column; align-items: flex-end; gap: 6px; }
+.peb__ceiling { font-size: 0.62rem; letter-spacing: 0.1em; color: var(--ice-blue); }
+.peb__chip {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.56rem;
+  letter-spacing: 0.1em;
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--moon-border);
+  white-space: nowrap;
+}
+.peb__chip--ok { color: var(--gate-green, #5fd0a0); border-color: rgba(95, 208, 160, 0.4); }
+.peb__chip--warn { color: var(--ceiling-amber, #f0b85f); border-color: rgba(240, 184, 95, 0.4); }
+.peb__chip--block { color: var(--blocked-red, #fca5a5); border-color: rgba(252, 165, 165, 0.4); }
+.peb__split { display: grid; gap: 14px; }
+@media (min-width: 560px) { .peb__split { grid-template-columns: 1fr 1fr; } }
+.peb__split-label {
+  margin: 0 0 6px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.58rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.peb__split-col--ok .peb__split-label { color: var(--gate-green, #5fd0a0); }
+.peb__split-col--block .peb__split-label { color: var(--blocked-red, #fca5a5); }
+.peb__split-col ul, .peb__more-body ul { list-style: none; margin: 0; padding: 0; display: grid; gap: 6px; }
+.peb__split-col li, .peb__more-body li { font-size: 0.82rem; line-height: 1.45; color: var(--silver); padding-left: 14px; position: relative; }
+.peb__split-col li::before, .peb__more-body li::before { content: "›"; position: absolute; left: 0; color: var(--ice-blue); }
+.peb__more { margin-top: 16px; border-top: 1px solid var(--moon-border); padding-top: 12px; }
+.peb__more-body { display: grid; gap: 16px; margin-top: 12px; }
+@media (min-width: 560px) { .peb__more-body { grid-template-columns: 1fr 1fr; } }
+.peb__more-body .peb__split-label { color: var(--ice-blue); }
+.peb__links { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 16px; }
+.peb__link {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-decoration: none;
+  color: var(--silver-bright);
+  padding: 7px 13px;
+  border-radius: 8px;
+  border: 1px solid var(--moon-border);
+  transition: border-color 160ms ease, transform 160ms ease;
+}
+.peb__link:hover { transform: translateY(-1px); border-color: var(--electric-blue); }
+.peb__link--primary { background: rgba(143, 216, 255, 0.12); border-color: rgba(143, 216, 255, 0.4); color: var(--silver-bright); }
+.peb__link--dead { opacity: 0.5; cursor: default; }
+.peb__link--dead:hover { transform: none; border-color: var(--moon-border); }
+.peb__foot { margin: 0; font-size: 0.8rem; }
+
+/* ── ProofTrustBoundaryRail ─────────────────────────────────────────── */
+.ptbr { padding: clamp(28px, 4vw, 56px) 0 clamp(48px, 6vw, 88px); }
+.ptbr__rail {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  max-width: 1180px;
+  margin: 0 auto;
+  width: calc(100% - 2 * clamp(20px, 5vw, 48px));
+  padding: 22px clamp(20px, 3vw, 34px);
+  border: 1px solid var(--moon-border-bright);
+  border-radius: 14px;
+  background:
+    radial-gradient(100% 120% at 0% 50%, rgba(143, 216, 255, 0.07), transparent 60%),
+    rgba(6, 10, 17, 0.8);
+  overflow: hidden;
+}
+.ptbr__seal { flex: none; width: 56px; height: 56px; }
+.ptbr__seal svg { width: 100%; height: 100%; }
+.ptbr__seal-ring { fill: none; stroke: rgba(143, 216, 255, 0.5); stroke-width: 1.4; }
+.ptbr__seal-lock { fill: var(--silver-bright); }
+.ptbr__copy { flex: 1 1 auto; }
+.ptbr__lead { margin: 0; font-size: clamp(1.05rem, 1.8vw, 1.35rem); font-weight: 800; color: var(--silver-bright); letter-spacing: 0; }
+.ptbr__body { margin: 6px 0 0; font-size: 0.9rem; line-height: 1.55; color: var(--silver); max-width: 70ch; }
+.ptbr__edge { position: absolute; inset: auto 0 0 0; height: 1px; background: linear-gradient(90deg, transparent, var(--ice-blue), transparent); opacity: 0.55; }
+@media (max-width: 600px) {
+  .ptbr__rail { flex-direction: column; align-items: flex-start; gap: 14px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pvh__eyebrow-dot,
+  .pvh__ring--outer,
+  .pvh__sweep { animation: none !important; }
+  .pvh__cta,
+  .pvh__cta-arrow,
+  .cfsp__lane,
+  .rbv__rung,
+  .peb__link { transition: none !important; }
+  .pvh__cta:hover,
+  .cfsp__lane:hover, .cfsp__lane.is-active,
+  .rbv__rung:hover, .rbv__rung.is-active,
+  .peb__link:hover { transform: none !important; }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -11118,6 +11118,12 @@ body::after {
    ════════════════════════════════════════════════════════════════════ */
 
 /* ── ProofVaultHero ─────────────────────────────────────────────────── */
+.legacy-anchor-target {
+  display: block;
+  height: 0;
+  scroll-margin-top: 96px;
+}
+
 .pvh {
   position: relative;
   overflow: hidden;

--- a/app/proof/page.tsx
+++ b/app/proof/page.tsx
@@ -1,674 +1,135 @@
 import type { Metadata } from "next";
-import ArtifactFamilyMatrix from "@components/ArtifactFamilyMatrix";
-import BlockedClaimFirewall from "@components/BlockedClaimFirewall";
-import RecentGovernedArtifacts from "@components/RecentGovernedArtifacts";
-import ClaimFirewallPanel from "@components/ClaimFirewallPanel";
-import LinkCard from "@components/LinkCard";
-import PlatformContractBlueprint from "@components/PlatformContractBlueprint";
+import ProofVaultHero from "@components/ProofVaultHero";
+import ControlsFiredGraph from "@components/ControlsFiredGraph";
+import ClaimFirewallSplitPane from "@components/ClaimFirewallSplitPane";
+import ProofPackReceipt from "@components/ProofPackReceipt";
 import ProofManifestConsole from "@components/ProofManifestConsole";
+import RuntimeBoundaryVisual from "@components/RuntimeBoundaryVisual";
+import ProofRecordsEvidenceBay from "@components/ProofRecordsEvidenceBay";
+import ProofTrustBoundaryRail from "@components/ProofTrustBoundaryRail";
 import PromotionGateLadder from "@components/PromotionGateLadder";
-import ProofPathTimeline, { type ProofPathStep } from "@components/ProofPathTimeline";
-import StatusConsole from "@components/StatusConsole";
-import ValidationRegistryDashboard from "@components/ValidationRegistryDashboard";
-import VerifierCheckCards from "@components/VerifierCheckCards";
-import { allowedClaims, promotionRequirements } from "@data/claims";
-import { blockedClaims } from "@config/blocked-claims";
-import { proofRecords } from "@data/proofRecords";
-import { proofStatusIndex } from "@data/proofPackManifest";
-import { reviewerPacket, checksumManifest } from "@data/proofPackManifest";
+import RecentGovernedArtifacts from "@components/RecentGovernedArtifacts";
+import { promotionRequirements } from "@data/claims";
 import { externalLinks } from "@data/navigation";
-import { ceiling, publicSafe } from "@config/site";
-
-const proofStateBadge: Record<string, { label: string; tone: string }> = {
-  PROOF_RECORD_PRESENT: { label: "PROOF_RECORD_PRESENT", tone: "p2-badge p2-badge--ceiling" },
-  PRIVATE_RUNTIME_BOUNDARY: { label: "NOT_PUBLIC_SAFE", tone: "p2-badge p2-badge--block" },
-  NO_PROOF_RECORD: { label: "NO_PROOF_RECORD", tone: "p2-badge p2-badge--warn" },
-  BOUNDARY_CONTRACT_ONLY: { label: "BOUNDARY_CONTRACT_ONLY", tone: "p2-badge p2-badge--warn" },
-};
 
 export const metadata: Metadata = {
   title: "Proof | HawkinsOperations",
   description:
-    "HawkinsOperations proof authority console: public ceiling, supported claim routes, blocked claim firewall, proof records, and promotion gates.",
+    "HawkinsOperations evidence vault and claim authority hub: governance saves, the claim firewall, Proof Pack 001, the runtime boundary, and proof records. The website routes reviewers to proof; it does not authorize claims.",
   alternates: {
     canonical: "/proof/",
   },
 };
 
-type ClaimRow = { id: string; scope: string; text: string; gate: string };
-type BlockedCategory = { id: string; eyebrow: string; title: string; reason: string; terms: string[] };
-
-const supportedRoutes: ClaimRow[] = allowedClaims.map((c, i) => {
-  const scope = i < 2 ? "system" : i < 4 ? "HO-DET-001" : "system";
-  const gate =
-    i < 2
-      ? "rendering layer → repo authority"
-      : i < 4
-      ? "controlled-test validation → proof record"
-      : "doctrine boundary → blocked-claim scanner";
-  return { id: `A·${String(i + 1).padStart(2, "0")}`, scope, text: c, gate };
-});
-
-const blockedCategorization = (terms: string[]): BlockedCategory[] => {
-  const has = (needle: string) => terms.find((t) => t.toLowerCase() === needle.toLowerCase());
-  const pull = (needles: string[]) =>
-    needles.map((n) => has(n)).filter((t): t is string => Boolean(t));
-  return [
-    {
-      id: "runtime",
-      eyebrow: "Runtime",
-      title: "Runtime promotions are blocked",
-      reason: "No public runtime evidence has been linked. Source presence is not runtime.",
-      terms: pull(["runtime-active", "production-ready", "fleet-wide"]),
-    },
-    {
-      id: "signal",
-      eyebrow: "Signal",
-      title: "Signal promotions are blocked",
-      reason: "No public signal-observation receipt has been promoted to the surface.",
-      terms: pull([
-        "signal-observed",
-        "live Splunk fired",
-        "Splunk-proven Runtime Signal 001",
-        "Cribl-routed",
-        "Wazuh-routed",
-        "AWS-live",
-      ]),
-    },
-    {
-      id: "public-safe",
-      eyebrow: "Public-safe",
-      title: "Public-safe promotions are blocked",
-      reason: "Public-safe status requires evidence linkage and explicit promotion. The current state is NOT_PUBLIC_SAFE.",
-      terms: pull(["public-safe", "public-safe runtime proof"]),
-    },
-    {
-      id: "authority",
-      eyebrow: "AI / analyst authority",
-      title: "Disposition authority promotions are blocked",
-      reason: "AI is labor. Governance is authority. No model or implied analyst chain can promote a claim from this surface.",
-      terms: pull(["autonomous SOC", "AI-approved disposition", "analyst-approved disposition"]),
-    },
-  ];
-};
-
-const flagshipTraceSteps: ProofPathStep[] = [
-  {
-    code: "SOURCE_PRESENT",
-    label: "Source present",
-    line: "Detection rule and SPL reside in the detections repo under version control with a stated owner.",
-    href: externalLinks.hoDet001Rule,
-    external: true,
-  },
-  {
-    code: "FIXTURE_VALIDATED",
-    label: "Fixture validated",
-    line: "HO-DET-001 passes controlled positive and negative cases in the validation repo.",
-    href: externalLinks.validationReportHo,
-    external: true,
-  },
-  {
-    code: "RECORD_PUBLISHED",
-    label: "Record published",
-    line: "Public proof record holds the stated ceiling and links back to source and validation.",
-    href: externalLinks.proofRecord,
-    external: true,
-  },
-  {
-    code: "CEILING_HELD",
-    label: "Ceiling held",
-    line: "Public surface holds at CONTROLLED_TEST_VALIDATED. Stronger wording is blocked until promotion clears.",
-    href: "/proof/ho-det-001/",
-  },
-];
-
 export default function ProofIndexPage() {
-  const blockedCategories = blockedCategorization(blockedClaims);
-
   return (
     <>
-      {/* ── Hero · proof authority surface ────────────────────────────── */}
-      <section className="relative overflow-hidden cockpit-section">
-        <div className="container grid gap-14 lg:grid-cols-[1.15fr_0.85fr] lg:gap-16 items-start">
-          <div>
-            <p className="cockpit-eyebrow">Proof authority surface</p>
-            <h1 className="cockpit-headline cockpit-headline--xl mt-5">
-              Proof ledger.
-              <span className="block mt-2" style={{ color: "var(--electric-blue-bright)" }}>
-                Routing only. Evidence lives in the repos.
-              </span>
-            </h1>
-            <p className="lede mt-7 max-w-2xl" style={{ color: "var(--silver)" }}>
-              The ledger shows what can be claimed publicly, what is blocked from public wording, and
-              which repository owns the underlying evidence. Website rendering is not proof.
-            </p>
-            <div className="mt-9 flex flex-wrap items-center gap-3">
-              <a className="cta cta-primary" href="#ceiling-console">See the ceiling →</a>
-              <a className="cta cta-quiet" href="#blocked-firewall">Open the firewall</a>
-              <a className="cta cta-quiet" href={externalLinks.proofRecord} target="_blank" rel="noopener noreferrer">Proof repo ↗</a>
-            </div>
-          </div>
+      {/* ── Vault hero ───────────────────────────────────────────────── */}
+      <ProofVaultHero />
 
-          <div className="lg:pt-2">
-            <StatusConsole />
-          </div>
-        </div>
-
-        <div className="container mt-12">
-          <hr className="cockpit-rule" />
-        </div>
-      </section>
-
-      {/* ── Ceiling authority console ─────────────────────────────────── */}
-      <section id="proof-owner-routes" className="cockpit-section--tight">
-        <div className="container reveal reveal--up">
-          <div className="mb-6">
-            <p className="cockpit-eyebrow">Proof owns these surfaces</p>
-            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.7rem, 2.8vw, 2.4rem)" }}>
-              Controls that fired before bad truth shipped.
-            </h2>
-            <p className="muted mt-3 text-sm leading-6 max-w-3xl">
-              Proof is the authority surface for Governance Saves, Proof Pack 001, runtime boundaries,
-              claim ceilings, blocked claims, human review authority, and the rule that website rendering is not proof.
-            </p>
-          </div>
-          <div className="grid gap-4 md:grid-cols-3">
-            <LinkCard href="/proof/governance-saves/" title="Governance Saves" description="Public-facing examples where controls blocked unsafe public truth, stale state, private-evidence drift, or AI authority drift." />
-            <LinkCard href="/proof/proof-pack-001/" title="Proof Pack 001" description="Bounded reviewer package with included/excluded contents, checksum route, and proof ceiling." />
-            <LinkCard href="/proof/runtime-proof-factory/" title="Runtime Boundary" description="Bounded runtime summaries with raw evidence private and public runtime proof still gated." />
-          </div>
-        </div>
-      </section>
-
-      <section id="recent-governed-proof-work" className="cockpit-section--tight">
-        <div className="container reveal reveal--up">
-          <RecentGovernedArtifacts
-            surface="proof"
-            heading="Recent governed proof-repo work"
-            sub="Recent governed work on the proof repo. Public-safe reviewer cards. Hand-maintained static snapshot. Does not promote runtime or public-safe runtime proof."
-          />
+      {/* ── Governance Saves dashboard ───────────────────────────────── */}
+      <section id="governance-saves" className="cockpit-section--tight">
+        <div className="container">
+          <ControlsFiredGraph />
           <div className="biz-translate" role="note" aria-label="Business translation">
             <span className="biz-translate__label">In plain English</span>
-            <span><span className="biz-translate__text">Proof-repo updates are reviewer-visible but do not change the public claim ceiling. Stronger wording requires a separate evidence-backed promotion gate.</span></span>
+            <span>
+              <span className="biz-translate__text">
+                Governance saves are the moments a control fired before bad truth shipped —
+                drift was attempted, the control caught it, and the public surface stayed honest.
+                Private-only records are excluded from this view.
+              </span>
+            </span>
           </div>
         </div>
       </section>
 
-      <section id="ceiling-console" className="cockpit-section--tight">
+      {/* ── Claim firewall ───────────────────────────────────────────── */}
+      <section id="claim-firewall" className="cockpit-section--tight">
         <div className="container">
-          <div className="mb-6">
-            <p className="cockpit-eyebrow">01 · Ceiling</p>
-            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
-              Public proof ceiling holds at controlled-test scope.
-            </h2>
-            <p className="muted mt-3 text-sm leading-6 max-w-3xl">
-              Stronger runtime, signal, evidence, and public-safe wording cannot ship from this surface
-              until separate evidence-backed promotion clears them.
-            </p>
-          </div>
-
-          <div className="ceiling-authority-panel" aria-label="Ceiling authority panel">
-            <div className="ceiling-authority-panel__left">
-              <span className="mono text-[0.6rem] tracking-[0.2em] uppercase text-[var(--ice-blue)]">Current ceiling</span>
-              <span className="ceiling-authority-panel__token mono">{ceiling}</span>
-              <span className="ceiling-authority-panel__sub">Controlled · Test · Validated</span>
-            </div>
-            <div className="ceiling-authority-panel__rail" aria-hidden="true">
-              <svg viewBox="0 0 320 96" role="img" aria-label="Boundary rail: validated to gate to stronger claims">
-                <defs>
-                  <marker id="cap-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
-                    <path d="M0,0 L10,5 L0,10 z" fill="var(--electric-blue-bright)" />
-                  </marker>
-                </defs>
-                <line x1={20} y1={48} x2={300} y2={48} stroke="var(--diagram-line-strong)" strokeWidth={2} />
-                <circle cx={36} cy={48} r={9} fill="var(--electric-blue)" stroke="var(--electric-blue-bright)" strokeWidth={1.8} />
-                <text x={36} y={26} fontSize={8} fontFamily='"JetBrains Mono", monospace' fill="var(--ice-blue)" textAnchor="middle" letterSpacing="2">CONTROLLED</text>
-                <rect x={132} y={32} width={56} height={32} rx={4} fill="rgba(8,13,22,0.94)" stroke="var(--electric-blue-bright)" strokeWidth={1.4} />
-                <text x={160} y={52} fontSize={9} fontFamily='"JetBrains Mono", monospace' fill="var(--silver-bright)" textAnchor="middle" letterSpacing="1.6">GATE</text>
-                <line x1={46} y1={48} x2={130} y2={48} stroke="var(--electric-blue-bright)" strokeWidth={1.6} markerEnd="url(#cap-arrow)" />
-                <line x1={190} y1={48} x2={284} y2={48} stroke="var(--electric-blue-bright)" strokeWidth={1.6} markerEnd="url(#cap-arrow)" strokeDasharray="4 4" />
-                <circle cx={296} cy={48} r={9} fill="rgba(8,13,22,0.94)" stroke="var(--silver-bright)" strokeWidth={1.8} />
-                <text x={296} y={26} fontSize={8} fontFamily='"JetBrains Mono", monospace' fill="var(--silver-bright)" textAnchor="middle" letterSpacing="2">STRONGER</text>
-                <text x={160} y={84} fontSize={8} fontFamily='"JetBrains Mono", monospace' fill="var(--muted)" textAnchor="middle" letterSpacing="1.5">promotion required</text>
-              </svg>
-            </div>
-            <div className="ceiling-authority-panel__right">
-              <span className="mono text-[0.6rem] tracking-[0.2em] uppercase text-[var(--silver)]">What this means</span>
-              <ul className="ceiling-authority-panel__list">
-                <li><strong>Validated</strong> · controlled-test scope inside the validation repo.</li>
-                <li><strong>Routing only</strong> · the website does not author proof.</li>
-                <li><strong>Public-safe</strong> · {publicSafe} · gated by evidence linkage.</li>
-              </ul>
-            </div>
-          </div>
+          <ClaimFirewallSplitPane />
         </div>
       </section>
 
-      {/* ── Validation registry dashboard ─────────────────────────────── */}
-      <section id="validation-registry" className="cockpit-section--tight">
-        <div className="container">
-          <div className="mb-6">
-            <p className="cockpit-eyebrow">Validation registry</p>
-            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
-              Controlled-test packages, fixture counts, blocked runtime states.
-            </h2>
-          </div>
-          <ValidationRegistryDashboard />
-        </div>
-      </section>
-
-      {/* ── Proof status index ────────────────────────────────────────── */}
-      <section id="proof-status-index" className="cockpit-section--tight">
-        <div className="container">
-          <div className="mb-6">
-            <p className="cockpit-eyebrow">Proof status index</p>
-            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
-              Per-detection proof status · human review required.
-            </h2>
-            <p className="muted mt-3 text-sm leading-6 max-w-3xl">
-              Index source · <span className="mono">{proofStatusIndex.path}</span>. Website status is{" "}
-              <span className="mono">{proofStatusIndex.websiteStatus}</span>. Some rows hold{" "}
-              <span className="mono">NO_PROOF_RECORD</span> where no proof record exists.
-            </p>
-          </div>
-          <div className="grid gap-2">
-            {proofStatusIndex.rows.map((row) => (
-              <div
-                key={row.id}
-                className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-[var(--moon-border)] bg-[rgba(8,13,22,0.5)] px-4 py-3"
-              >
-                <span className="mono text-sm text-[var(--silver-bright)]">{row.id}</span>
-                <span className="muted flex-1 text-sm">{row.note}</span>
-                <span className={`p2-badge p2-badge--${row.tone}`}>{row.status}</span>
-              </div>
-            ))}
-          </div>
-          <p className="muted mt-3 text-xs leading-5">{proofStatusIndex.humanReview} · website rendering is not proof.</p>
-        </div>
-      </section>
-
-      {/* ── Supported claim routes ────────────────────────────────────── */}
-      <section className="cockpit-section--tight">
-        <div className="container">
-          <div className="mb-6">
-            <p className="cockpit-eyebrow">02 · Supported</p>
-            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
-              Supported public claim routes.
-            </h2>
-            <p className="muted mt-3 text-sm leading-6 max-w-3xl">
-              Each row maps a supported claim to its scope and the evidence route that backs it.
-              Stronger wording requires a separate promotion gate below.
-            </p>
-          </div>
-
-          <div className="claim-route-grid">
-            {supportedRoutes.map((row) => (
-              <article key={row.id} className="claim-route-card" data-scope={row.scope}>
-                <header className="claim-route-card__head">
-                  <span className="claim-route-card__id mono">{row.id}</span>
-                  <span className="claim-route-card__scope mono">{row.scope}</span>
-                </header>
-                <p className="claim-route-card__text">{row.text}</p>
-                <div className="claim-route-card__rail" aria-hidden="true">
-                  <span className="claim-route-card__rail-dot" />
-                  <span className="claim-route-card__rail-line" />
-                  <span className="claim-route-card__rail-dot claim-route-card__rail-dot--end" />
-                </div>
-                <p className="claim-route-card__gate mono">route · {row.gate}</p>
-              </article>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* ── Blocked firewall ─────────────────────────────────────────── */}
-      <section id="blocked-firewall" className="cockpit-section--tight">
-        <div className="container">
-          <div className="mb-6">
-            <p className="cockpit-eyebrow">03 · Blocked</p>
-            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
-              Blocked public claims · categorized.
-            </h2>
-            <p className="muted mt-3 text-sm leading-6 max-w-3xl">
-              Blocked claims stay visible. They describe what the public surface does not assert
-              and remain blocked until an evidence-backed promotion gate changes their state.
-            </p>
-          </div>
-
-          <ClaimFirewallPanel />
-
-          <div className="mt-7">
-            <BlockedClaimFirewall />
-          </div>
-
-          <div className="blocked-category-grid mt-7" data-ci-target="blocked-claims">
-            {blockedCategories.map((cat) => (
-              <article key={cat.id} className="blocked-category">
-                <header className="blocked-category__head">
-                  <span className="mono text-[0.6rem] tracking-[0.2em] uppercase" style={{ color: "#FCA5A5" }}>{cat.eyebrow}</span>
-                  <h3 className="blocked-category__title">{cat.title}</h3>
-                </header>
-                <p className="blocked-category__reason">{cat.reason}</p>
-                <ul className="blocked-category__chips" aria-label={`${cat.eyebrow} blocked terms`}>
-                  {cat.terms.map((term) => (
-                    <li key={term} className="blocked-category__chip" title={`${term} is blocked from public wording`}>
-                      <span aria-hidden="true">⊘</span>
-                      <span>{term}</span>
-                    </li>
-                  ))}
-                </ul>
-              </article>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* ── Artifact registry preview ─────────────────────────────────── */}
-      <section className="cockpit-section--tight">
-        <div className="container">
-          <div className="mb-6">
-            <p className="cockpit-eyebrow">04 · Registry</p>
-            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
-              Seven families · four evidence axes.
-            </h2>
-            <p className="muted mt-3 text-sm leading-6 max-w-3xl">
-              Filled cells are supported at the current ceiling. Hollow cells require a specific
-              promotion gate before they can be claimed.
-            </p>
-          </div>
-          <ArtifactFamilyMatrix />
-        </div>
-      </section>
-
-      {/* ── Proof records · receipt panels ────────────────────────────── */}
-      <section className="cockpit-section--tight">
-        <div className="container">
-          <div className="mb-6">
-            <p className="cockpit-eyebrow">05 · Records</p>
-            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
-              Proof records · receipt panels.
-            </h2>
-            <p className="muted mt-3 text-sm leading-6 max-w-3xl">
-              Each record holds its bounded ceiling, the surface it supports, and the routes back
-              to source and validation.
-            </p>
-          </div>
-
-          {proofRecords[0] && (
-            <div className="mb-7">
-              <ProofPathTimeline
-                detectionId={proofRecords[0].detectionId}
-                title="Source to public boundary"
-                steps={flagshipTraceSteps}
-              />
-            </div>
-          )}
-
-          <div className="grid gap-5">
-            {proofRecords.map((record) => (
-              <article
-                key={record.detectionId}
-                className="proof-receipt-panel"
-                data-detection-id={record.detectionId}
-                data-proof-ceiling={record.proofLevel}
-              >
-                <header className="proof-receipt-panel__head">
-                  <div className="proof-receipt-panel__head-left">
-                    <span className="mono text-[0.6rem] tracking-[0.2em] uppercase text-[var(--ice-blue)]">Detection ID</span>
-                    <h3 className="proof-receipt-panel__id">{record.detectionId}</h3>
-                    <p className="proof-receipt-panel__sub">{record.title}</p>
-                  </div>
-                  <div className="proof-receipt-panel__head-right">
-                    <span className="mono text-[0.6rem] tracking-[0.2em] uppercase text-[var(--silver)]">Ceiling</span>
-                    <span className="proof-receipt-panel__ceiling mono">{record.proofLevel}</span>
-                    <span className={`mt-2 ${proofStateBadge[record.proofRecordState]?.tone ?? "p2-badge"}`}>
-                      {proofStateBadge[record.proofRecordState]?.label ?? record.proofRecordState}
-                    </span>
-                  </div>
-                </header>
-
-                <dl className="proof-receipt-panel__cells">
-                  <div className="proof-receipt-panel__cell">
-                    <dt className="mono">Validation</dt>
-                    <dd className="proof-receipt-panel__cell-strong" data-ci-target="validation-status">{record.validationState}</dd>
-                  </div>
-                  <div className="proof-receipt-panel__cell">
-                    <dt className="mono">Runtime</dt>
-                    <dd className="proof-receipt-panel__cell-block">{record.runtimeState}</dd>
-                  </div>
-                  <div className="proof-receipt-panel__cell">
-                    <dt className="mono">Signal</dt>
-                    <dd className="proof-receipt-panel__cell-block">{record.signalState}</dd>
-                  </div>
-                  <div className="proof-receipt-panel__cell">
-                    <dt className="mono">Public-safe state</dt>
-                    <dd className="proof-receipt-panel__cell-strong">{record.publicSafeState}</dd>
-                  </div>
-                </dl>
-
-                <footer className="proof-receipt-panel__foot">
-                  {record.caseFileHref && (
-                    <a className="cta cta-primary" href={record.caseFileHref}>
-                      Open case file →
-                    </a>
-                  )}
-                  {record.proofRepoLink ? (
-                    <a
-                      className={record.caseFileHref ? "cta cta-quiet" : "cta cta-primary"}
-                      href={record.proofRepoLink}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      Proof repo record ↗
-                    </a>
-                  ) : (
-                    <span className="cta cta-quiet" aria-disabled="true" style={{ opacity: 0.6, pointerEvents: "none" }}>
-                      No proof record
-                    </span>
-                  )}
-                  <a className="cta cta-quiet" href={record.sourceRepoLink} target="_blank" rel="noopener noreferrer">
-                    Source repo ↗
-                  </a>
-                </footer>
-              </article>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* ── Proof Pack 001 manifest console ───────────────────────────── */}
+      {/* ── Proof Pack 001 ───────────────────────────────────────────── */}
       <section id="proof-pack-001" className="cockpit-section--tight">
         <div className="container">
           <div className="mb-6">
-            <p className="cockpit-eyebrow">Proof pack · manifest</p>
+            <p className="cockpit-eyebrow">Sealed reviewer package</p>
             <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
-              Proof Pack 001 · included, excluded, and what it does not prove.
+              Proof Pack 001 — a bounded reviewer package.
             </h2>
             <p className="muted mt-3 text-sm leading-6 max-w-3xl">
-              Proof Pack 001 routes a bounded HO-DET-001 reviewer packet at CONTROLLED_TEST_VALIDATED;
-              raw / private runtime evidence is excluded and remains NOT_PUBLIC_SAFE.
+              The receipt states what the package supports and what it does not prove.
+              Raw / private runtime evidence is excluded and public runtime proof stays blocked.
             </p>
           </div>
-          <div className="grid gap-5 lg:grid-cols-[1.2fr_0.8fr] items-start">
+          <ProofPackReceipt />
+          <div className="mt-6">
             <ProofManifestConsole />
-            <div className="grid gap-3">
-              <div className="rounded-md border border-[var(--moon-border)] bg-[rgba(8,13,22,0.5)] p-4">
-                <p className="mono text-[0.62rem] tracking-[0.14em] uppercase text-[var(--ice-blue)]">{reviewerPacket.name}</p>
-                <p className="muted mt-1 text-sm leading-6">{reviewerPacket.scope}</p>
-                <p className="mono mt-3 text-[0.6rem] tracking-[0.12em] uppercase text-[var(--silver)]">Evidence chain</p>
-                <div className="mt-1 flex flex-wrap gap-1.5">
-                  {reviewerPacket.evidenceChain.map((link) => (
-                    <span key={link} className="p2-badge">{link}</span>
-                  ))}
-                </div>
-              </div>
-              <div className="rounded-md border border-[var(--moon-border)] bg-[rgba(8,13,22,0.5)] p-4">
-                <p className="mono text-[0.62rem] tracking-[0.14em] uppercase text-[var(--ice-blue)]">{checksumManifest.name}</p>
-                <p className="muted mt-1 text-sm leading-6">{checksumManifest.scope}</p>
-                <p className="muted mt-2 text-xs leading-5">{checksumManifest.doesNotProve}</p>
-              </div>
-            </div>
           </div>
         </div>
       </section>
 
-      {/* ── Verifier check cards ──────────────────────────────────────── */}
-      <section id="verifiers" className="cockpit-section--tight">
+      {/* ── Runtime boundary tower ───────────────────────────────────── */}
+      <section id="runtime-boundary" className="cockpit-section--tight">
         <div className="container">
-          <div className="mb-6">
-            <p className="cockpit-eyebrow">Verifiers</p>
-            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
-              Verifier routes · structure, parity, boundaries, contracts.
-            </h2>
-          </div>
-          <VerifierCheckCards />
+          <RuntimeBoundaryVisual />
         </div>
       </section>
 
-      {/* ── Platform boundaries ───────────────────────────────────────── */}
-      <section id="platform-boundaries" className="cockpit-section--tight">
+      {/* ── Evidence bay · proof records ─────────────────────────────── */}
+      <section id="evidence-bay" className="cockpit-section--tight">
         <div className="container">
           <div className="mb-6">
-            <p className="cockpit-eyebrow">Platform boundaries</p>
+            <p className="cockpit-eyebrow">Evidence bay</p>
             <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
-              Non-promotional guardrails · drift surfaced, not normalized.
+              Proof records — receipts, not a ledger.
             </h2>
+            <p className="muted mt-3 text-sm leading-6 max-w-3xl">
+              The flagship record leads; supporting records follow at lower weight.
+              Each holds its bounded ceiling and a supports / does-not-prove split.
+            </p>
           </div>
-          <PlatformContractBlueprint
-            ids={["ho-det-001-runtime-contract", "ho-det-011-case-packet", "local-llm-runtime-receipt"]}
+          <ProofRecordsEvidenceBay />
+        </div>
+      </section>
+
+      {/* ── Promotion gates (supporting) ─────────────────────────────── */}
+      <section id="promotion-gates" className="cockpit-section--tight">
+        <div className="container">
+          <div className="mb-6">
+            <p className="cockpit-eyebrow">Promotion gates</p>
+            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.5rem, 2.4vw, 2rem)" }}>
+              What must hold before stronger wording ships.
+            </h2>
+            <p className="muted mt-3 text-sm leading-6 max-w-3xl">
+              The ladder is sequential — no rung is skipped. Stronger runtime, signal,
+              and public proof wording cannot ship until its gate clears.
+            </p>
+          </div>
+          <PromotionGateLadder items={promotionRequirements} ariaLabel="Promotion gate ladder" />
+        </div>
+      </section>
+
+      {/* ── Recent governed proof work (compact) ─────────────────────── */}
+      <section id="recent-governed-proof-work" className="cockpit-section--tight">
+        <div className="container">
+          <RecentGovernedArtifacts
+            surface="proof"
+            heading="Recent governed proof-repo work"
+            sub="Recent governed work on the proof repo. Reviewer-visible cards that do not change the public claim ceiling. Stronger wording requires a separate evidence-backed promotion gate."
           />
         </div>
       </section>
 
-      {/* ── Proof Pack 001 release receipt console ─────────────────────── */}
+      {/* ── Control routes ───────────────────────────────────────────── */}
       <section className="cockpit-section--tight">
         <div className="container">
           <div className="mb-6">
-            <p className="cockpit-eyebrow">Proof pack · release path</p>
-            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
-              Proof Pack 001 · receipt console.
-            </h2>
-            <p className="muted mt-3 text-sm leading-6 max-w-3xl">
-              The official GitHub Release is published from the proof repo. This surface routes
-              reviewers to the release; it does not raise the public proof ceiling.
-            </p>
-          </div>
-
-          <div className="proof-pack-console proof-pack-console--ledger" aria-label="Proof Pack 001 receipt console">
-            <header className="proof-pack-console__head">
-              <div>
-                <p className="cockpit-eyebrow">Proof Pack 001</p>
-                <h3 className="proof-pack-console__title">
-                  HO-DET-001 · official reviewer release route.
-                </h3>
-                <p className="proof-pack-console__sub">
-                  Reviewer packet, manifest, checksum file, proof card, proof record, validation
-                  record, ledger/schema, and proof verifier are packaged in the approved release ZIP.
-                  Nothing here promotes runtime, signal, production, or stronger public proof status.
-                </p>
-              </div>
-              <span className="proof-pack-console__ceiling mono">{ceiling}</span>
-            </header>
-            <dl className="proof-pack-console__grid">
-              <div className="proof-pack-console__cell">
-                <dt>Pack ID</dt>
-                <dd className="mono">HAWKINSOPERATIONS_PROOF_PACK_001</dd>
-              </div>
-              <div className="proof-pack-console__cell">
-                <dt>Detection</dt>
-                <dd className="mono">HO-DET-001</dd>
-              </div>
-              <div className="proof-pack-console__cell">
-                <dt>Pack status</dt>
-                <dd className="mono proof-pack-console__cell-strong">PUBLIC_SAFE_REVIEWER_RELEASE_CANDIDATE</dd>
-              </div>
-              <div className="proof-pack-console__cell">
-                <dt>ZIP SHA256</dt>
-                <dd className="mono">44d8a643aa2b113c9e99be0462e699d39af707a67190823cc05bb381907dc452</dd>
-              </div>
-              <div className="proof-pack-console__cell">
-                <dt>Public-safe state</dt>
-                <dd className="mono proof-pack-console__cell-block">{publicSafe}</dd>
-              </div>
-              <div className="proof-pack-console__cell">
-                <dt>Public-safe runtime proof</dt>
-                <dd className="mono proof-pack-console__cell-block">BLOCKED</dd>
-              </div>
-              <div className="proof-pack-console__cell">
-                <dt>Next gate</dt>
-                <dd className="mono">RUNTIME_AND_SIGNAL_EVIDENCE_REVIEW</dd>
-              </div>
-            </dl>
-            <footer className="proof-pack-console__foot">
-              <span className="mono">GitHub Release route · ZIP asset only · release package does not promote runtime proof</span>
-              <a className="cta cta-primary" href={externalLinks.proofPack001Release} target="_blank" rel="noopener noreferrer">
-                Open official release ↗
-              </a>
-              <a className="cta cta-quiet" href="/artifacts/">Artifact coverage →</a>
-            </footer>
-          </div>
-        </div>
-      </section>
-
-      {/* ── Boundary statement ────────────────────────────────────────── */}
-      <section className="cockpit-section--tight">
-        <div className="container">
-          <div className="mb-6">
-            <p className="cockpit-eyebrow">06 · Boundary</p>
-            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
-              What this proves — and what it does not.
-            </h2>
-          </div>
-          <div className="grid gap-3 lg:grid-cols-2">
-            <div className="status-band">
-              <span className="status-band__rule" aria-hidden="true"></span>
-              <div>
-                <p className="mono text-[0.6rem] tracking-[0.2em] uppercase text-[var(--ice-blue)]">Proves</p>
-                <p className="mt-1 text-sm leading-6 text-[var(--silver)]">
-                  The public proof ceiling is stated, controlled-test validation passed inside its
-                  declared scope, blocked promotions are visible, and reviewers can route from
-                  rendered surface to record to source.
-                </p>
-              </div>
-            </div>
-            <div className="status-band status-band--block">
-              <span className="status-band__rule" aria-hidden="true"></span>
-              <div>
-                <p className="mono text-[0.6rem] tracking-[0.2em] uppercase" style={{ color: "#FCA5A5" }}>Does not prove</p>
-                <p className="mt-1 text-sm leading-6 text-[var(--silver)]">
-                  Runtime activation, signal observation, fleet scope, autonomous SOC, AI-approved disposition,
-                  and public-safe runtime proof — none of these are claimed from this surface.
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* ── Promotion gate ladder ─────────────────────────────────────── */}
-      <section className="cockpit-section--tight">
-        <div className="container">
-          <div className="mb-6">
-            <p className="cockpit-eyebrow">07 · Gates</p>
-            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
-              Promotion gate ladder.
-            </h2>
-            <p className="muted mt-3 text-sm leading-6 max-w-3xl">
-              Each rung names what must hold before stronger public wording can ship. The ladder
-              is sequential — no rung is skipped.
-            </p>
-          </div>
-          <PromotionGateLadder items={promotionRequirements} ariaLabel="Promotion gate ladder · supported claim promotion" />
-        </div>
-      </section>
-
-      {/* ── Control routes ────────────────────────────────────────────── */}
-      <section className="cockpit-section--tight pb-24">
-        <div className="container">
-          <div className="mb-6">
-            <p className="cockpit-eyebrow">08 · Routes</p>
-            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.6rem, 2.6vw, 2.2rem)" }}>
-              Control links.
+            <p className="cockpit-eyebrow">Routes</p>
+            <h2 className="cockpit-headline mt-2" style={{ fontSize: "clamp(1.5rem, 2.4vw, 2rem)" }}>
+              Where to inspect next.
             </h2>
           </div>
           <div className="grid gap-3 md:grid-cols-3">
@@ -677,14 +138,6 @@ export default function ProofIndexPage() {
               <span className="artifact-tile__title">Controls that prevented unsafe truth</span>
               <span className="artifact-tile__desc">
                 Public-backed examples where review, verifiers, branch hygiene, and claim ceilings blocked drift.
-              </span>
-              <span className="artifact-tile__link">Open →</span>
-            </a>
-            <a className="artifact-tile" href="/controls/">
-              <span className="artifact-tile__cat">CLAIM FIREWALL</span>
-              <span className="artifact-tile__title">Allowed and blocked wording</span>
-              <span className="artifact-tile__desc">
-                The firewall keeps validation results from being stretched into runtime or signal language.
               </span>
               <span className="artifact-tile__link">Open →</span>
             </a>
@@ -705,6 +158,9 @@ export default function ProofIndexPage() {
           </div>
         </div>
       </section>
+
+      {/* ── Trust boundary rail ──────────────────────────────────────── */}
+      <ProofTrustBoundaryRail />
     </>
   );
 }

--- a/app/proof/page.tsx
+++ b/app/proof/page.tsx
@@ -45,6 +45,7 @@ export default function ProofIndexPage() {
       </section>
 
       {/* ── Claim firewall ───────────────────────────────────────────── */}
+      <div id="verifiers" className="legacy-anchor-target" aria-hidden="true" />
       <section id="claim-firewall" className="cockpit-section--tight">
         <div className="container">
           <ClaimFirewallSplitPane />
@@ -72,6 +73,7 @@ export default function ProofIndexPage() {
       </section>
 
       {/* ── Runtime boundary tower ───────────────────────────────────── */}
+      <div id="validation-registry" className="legacy-anchor-target" aria-hidden="true" />
       <section id="runtime-boundary" className="cockpit-section--tight">
         <div className="container">
           <RuntimeBoundaryVisual />

--- a/components/ClaimFirewallSplitPane.tsx
+++ b/components/ClaimFirewallSplitPane.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useId, useState } from "react";
+import { blockedClaims } from "@data/claims";
+
+/**
+ * ClaimFirewallSplitPane
+ *
+ * Three lanes around a central gate wall:
+ *   allowed  — claims that pass to the public surface
+ *   careful  — claims that require review before they advance
+ *   blocked  — claims that stop at the gate and are NOT CLAIMED
+ *
+ * Blocked terms are imported from the single source of truth (blockedClaims)
+ * and are always framed as blocked / not claimed. Nothing here promotes them.
+ * Lane data uses a `body` key (not `description`) to stay clear of the
+ * site-contract rendered-field scan.
+ */
+
+type LaneId = "allowed" | "careful" | "blocked";
+
+interface Lane {
+  id: LaneId;
+  label: string;
+  verdict: string;
+  body: string;
+  items: string[];
+}
+
+const lanes: Lane[] = [
+  {
+    id: "allowed",
+    label: "Passes the gate",
+    verdict: "ALLOWED",
+    body: "These claims are backed by reviewer-inspectable evidence at the controlled-test ceiling, so they ship to the public surface.",
+    items: [
+      "Controlled validation where supported",
+      "Reviewer-inspectable proof surfaces",
+      "Reviewer-inspectable artifacts",
+      "Governance saves — controls that fired",
+    ],
+  },
+  {
+    id: "careful",
+    label: "Held for review",
+    verdict: "CAREFUL",
+    body: "These describe bounded, private-evidence work. They survive only as summaries and require a separate evidence-backed promotion gate before any stronger wording advances.",
+    items: [
+      "Runtime-supported (private)",
+      "Runtime-observed (private, source-supported only)",
+      "Closed controlled loop",
+      "SOCaaS-style model",
+      "AI triage support (support-only)",
+    ],
+  },
+  {
+    id: "blocked",
+    label: "Stops at the gate",
+    verdict: "BLOCKED · NOT CLAIMED",
+    body: "These terms are blocked from public wording. They are not claimed anywhere on this surface and stay blocked until a separate evidence-backed promotion gate changes their state.",
+    // Sourced from blockedClaims (single source of truth); listed here as
+    // not-claimed terms. Public runtime proof and signal-observed proof are
+    // not claimed unless separately promoted.
+    items: [
+      ...blockedClaims,
+      "public runtime proof (unless separately promoted)",
+      "production / customer validated",
+      "partner / endorsed",
+    ],
+  },
+];
+
+const laneOrder: LaneId[] = ["allowed", "careful", "blocked"];
+
+export default function ClaimFirewallSplitPane() {
+  const [active, setActive] = useState<LaneId>("allowed");
+  const titleId = useId();
+  const selected = lanes.find((l) => l.id === active) ?? lanes[0];
+
+  return (
+    <section className="cfsp" aria-labelledby={titleId}>
+      <header className="cfsp__head">
+        <p className="cockpit-eyebrow">Claim firewall</p>
+        <h3 id={titleId} className="cfsp__title">
+          Claims pass, wait, or stop at the gate.
+        </h3>
+        <p className="cfsp__sub">
+          A deterministic scanner, evidence gates, and human review authority sit
+          between a claim and the public surface. Blocked terms stay visible —
+          they describe what this surface does not assert.
+        </p>
+      </header>
+
+      <div className="cfsp__stage">
+        {/* Lane selector / pane */}
+        <div className="cfsp__lanes" role="tablist" aria-label="Claim lanes">
+          {laneOrder.map((id) => {
+            const lane = lanes.find((l) => l.id === id)!;
+            const isActive = id === active;
+            return (
+              <button
+                key={id}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                aria-controls={`${titleId}-panel`}
+                className={`cfsp__lane cfsp__lane--${id}${isActive ? " is-active" : ""}`}
+                onMouseEnter={() => setActive(id)}
+                onFocus={() => setActive(id)}
+                onClick={() => setActive(id)}
+              >
+                <span className="cfsp__lane-verdict">{lane.verdict}</span>
+                <span className="cfsp__lane-label">{lane.label}</span>
+                <span className="cfsp__lane-count">{lane.items.length}</span>
+              </button>
+            );
+          })}
+
+          {/* central gate wall */}
+          <div className="cfsp__gate" aria-hidden="true">
+            <span className="cfsp__gate-label">GATE</span>
+            <span className="cfsp__gate-sub">evidence · validators · scanner · human review</span>
+          </div>
+        </div>
+
+        {/* Detail panel */}
+        <aside
+          id={`${titleId}-panel`}
+          className={`cfsp__detail cfsp__detail--${selected.id}`}
+          role="tabpanel"
+          aria-live="polite"
+        >
+          <p className="cfsp__detail-verdict">{selected.verdict}</p>
+          <p className="cfsp__detail-body">{selected.body}</p>
+          <ul className="cfsp__detail-list" aria-label={`${selected.label} claims`}>
+            {selected.items.map((item) => (
+              <li key={item} className="cfsp__detail-item">
+                <span className="cfsp__detail-mark" aria-hidden="true">
+                  {selected.id === "allowed" ? "✓" : selected.id === "careful" ? "~" : "⊘"}
+                </span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </aside>
+      </div>
+
+      <details className="cfsp__table-wrap">
+        <summary className="cfsp__table-summary">View all lanes as text</summary>
+        <div className="cfsp__table-groups">
+          {lanes.map((lane) => (
+            <div key={lane.id} className="cfsp__table-group">
+              <h4 className="cfsp__table-group-title">
+                {lane.verdict} — {lane.label}
+              </h4>
+              <p className="cfsp__table-group-body">{lane.body}</p>
+              <ul>
+                {lane.items.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </details>
+    </section>
+  );
+}

--- a/components/ProofRecordsEvidenceBay.tsx
+++ b/components/ProofRecordsEvidenceBay.tsx
@@ -1,0 +1,129 @@
+import { proofRecords, type ProofRecord, type ProofRecordState } from "@data/proofRecords";
+
+/**
+ * ProofRecordsEvidenceBay
+ *
+ * A lighter evidence bay built from the proof records. Each record renders as
+ * a receipt with a state chip and a supports / does-not-prove split; details
+ * expand for the remaining blocked promotions and promotion requirements.
+ * The flagship record leads; supporting records follow at lower weight.
+ *
+ * All copy is rendered from proofRecords data (the single source of truth);
+ * blocked promotions stay framed as not-claimed.
+ */
+
+const stateChip: Record<ProofRecordState, { label: string; tone: string }> = {
+  PROOF_RECORD_PRESENT: { label: "PROOF RECORD PRESENT", tone: "ok" },
+  PRIVATE_RUNTIME_BOUNDARY: { label: "PRIVATE RUNTIME BOUNDARY", tone: "block" },
+  NO_PROOF_RECORD: { label: "NO PROOF RECORD", tone: "warn" },
+  BOUNDARY_CONTRACT_ONLY: { label: "BOUNDARY CONTRACT ONLY", tone: "warn" },
+};
+
+function ReceiptLinks({ record }: { record: ProofRecord }) {
+  return (
+    <footer className="peb__links">
+      {record.caseFileHref && (
+        <a className="peb__link peb__link--primary" href={record.caseFileHref}>
+          Open case file →
+        </a>
+      )}
+      {record.proofRepoLink ? (
+        <a className="peb__link" href={record.proofRepoLink} target="_blank" rel="noopener noreferrer">
+          Proof record ↗
+        </a>
+      ) : (
+        <span className="peb__link peb__link--dead" aria-disabled="true">
+          No proof record
+        </span>
+      )}
+      <a className="peb__link" href={record.sourceRepoLink} target="_blank" rel="noopener noreferrer">
+        Source repo ↗
+      </a>
+    </footer>
+  );
+}
+
+function Receipt({ record, flagship = false }: { record: ProofRecord; flagship?: boolean }) {
+  const chip = stateChip[record.proofRecordState];
+  const supports = (flagship ? record.passed : record.passed.slice(0, 2));
+  return (
+    <article
+      className={`peb__receipt${flagship ? " peb__receipt--flagship" : ""}`}
+      data-detection-id={record.detectionId}
+      data-proof-ceiling={record.proofLevel}
+    >
+      <span className="peb__perf peb__perf--top" aria-hidden="true" />
+      <header className="peb__receipt-head">
+        <div className="peb__receipt-id-wrap">
+          <span className="peb__receipt-id mono">{record.detectionId}</span>
+          <p className="peb__receipt-title">{record.title}</p>
+        </div>
+        <div className="peb__receipt-meta">
+          <span className="peb__ceiling mono">{record.proofLevel}</span>
+          <span className={`peb__chip peb__chip--${chip.tone}`}>{chip.label}</span>
+        </div>
+      </header>
+
+      <div className="peb__split">
+        <div className="peb__split-col peb__split-col--ok">
+          <p className="peb__split-label">Supports</p>
+          <ul>
+            {supports.map((line) => (
+              <li key={line}>{line}</li>
+            ))}
+          </ul>
+        </div>
+        <div className="peb__split-col peb__split-col--block">
+          <p className="peb__split-label">Does not prove</p>
+          <ul>
+            {record.notClaimed.slice(0, flagship ? record.notClaimed.length : 2).map((line) => (
+              <li key={line}>{line}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      <details className="peb__more">
+        <summary className="peb__more-summary">Remaining gates &amp; promotion requirements</summary>
+        <div className="peb__more-body">
+          <div>
+            <p className="peb__split-label">Remaining blocked</p>
+            <ul>
+              {record.remainingBlocked.map((line) => (
+                <li key={line}>{line}</li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <p className="peb__split-label">Promotion requirements</p>
+            <ul>
+              {record.promotionRequirements.map((line) => (
+                <li key={line}>{line}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </details>
+
+      <ReceiptLinks record={record} />
+    </article>
+  );
+}
+
+export default function ProofRecordsEvidenceBay() {
+  const [flagship, ...rest] = proofRecords;
+  return (
+    <div className="peb">
+      <Receipt record={flagship} flagship />
+      <div className="peb__grid">
+        {rest.map((record) => (
+          <Receipt key={record.detectionId} record={record} />
+        ))}
+      </div>
+      <p className="peb__foot muted">
+        Each record holds its bounded ceiling and routes reviewers to source and
+        validation. Website rendering is not proof.
+      </p>
+    </div>
+  );
+}

--- a/components/ProofTrustBoundaryRail.tsx
+++ b/components/ProofTrustBoundaryRail.tsx
@@ -1,0 +1,31 @@
+/**
+ * ProofTrustBoundaryRail
+ *
+ * Quiet metallic seal that closes the proof page. Locked-rail motif, not a
+ * warning wall. States the standing boundary: rendering is not proof.
+ */
+export default function ProofTrustBoundaryRail() {
+  return (
+    <section className="ptbr" aria-label="Trust boundary">
+      <div className="ptbr__rail">
+        <span className="ptbr__seal" aria-hidden="true">
+          <svg viewBox="0 0 48 48" role="presentation">
+            <circle cx="24" cy="24" r="21" className="ptbr__seal-ring" />
+            <path
+              d="M24 13a7 7 0 0 0-7 7v3h-2v12h18V23h-2v-3a7 7 0 0 0-7-7zm-4 10v-3a4 4 0 0 1 8 0v3z"
+              className="ptbr__seal-lock"
+            />
+          </svg>
+        </span>
+        <div className="ptbr__copy">
+          <p className="ptbr__lead">Rendering is not proof.</p>
+          <p className="ptbr__body">
+            Evidence, validators, and human review authorize claims. The website
+            routes reviewers to proof; it does not author it.
+          </p>
+        </div>
+        <span className="ptbr__edge" aria-hidden="true" />
+      </div>
+    </section>
+  );
+}

--- a/components/ProofVaultHero.tsx
+++ b/components/ProofVaultHero.tsx
@@ -1,0 +1,132 @@
+import { governanceSavesSummary } from "@data/governanceSaves";
+import { ceiling } from "@config/site";
+
+/**
+ * ProofVaultHero
+ *
+ * Entry to the proof vault — a sealed metallic ring with an electric-blue
+ * signal sweep, not a compliance header. Human-readable copy leads; machine
+ * labels appear only as secondary chips.
+ */
+
+type SealChip = { label: string; tone: "ceiling" | "supported" | "blocked" };
+
+const sealChips: SealChip[] = [
+  { label: `Public ceiling · ${ceiling}`, tone: "ceiling" },
+  { label: `${governanceSavesSummary.publicRenderedCount} public-facing governance saves`, tone: "supported" },
+  { label: "Runtime claims bounded", tone: "blocked" },
+  { label: "Private-only records excluded", tone: "blocked" },
+];
+
+export default function ProofVaultHero() {
+  return (
+    <section className="pvh" aria-labelledby="pvh-headline">
+      <div className="pvh__field" aria-hidden="true" />
+
+      <div className="container pvh__grid">
+        <div className="pvh__copy">
+          <p className="pvh__eyebrow">
+            <span className="pvh__eyebrow-dot" />
+            Evidence vault · claim authority hub
+          </p>
+          <h1 id="pvh-headline" className="pvh__headline">
+            Proof is what survives validation, boundaries, and{" "}
+            <span className="pvh__headline-emph">human review.</span>
+          </h1>
+          <p className="pvh__lede">
+            The website routes reviewers to proof. It does not authorize claims.
+            Claims either survive the vault — validators, evidence boundaries, and
+            human review — or they stop at the gate.
+          </p>
+
+          <div className="pvh__chips" role="note" aria-label="Proof status seal">
+            {sealChips.map((chip) => (
+              <span key={chip.label} className={`pvh__chip pvh__chip--${chip.tone}`}>
+                <span className="pvh__chip-dot" aria-hidden="true" />
+                {chip.label}
+              </span>
+            ))}
+          </div>
+
+          <div className="pvh__ctas">
+            <a className="pvh__cta pvh__cta--primary" href="#governance-saves">
+              <span>Governance Saves</span>
+              <span aria-hidden="true" className="pvh__cta-arrow">→</span>
+            </a>
+            <a className="pvh__cta pvh__cta--ghost" href="#proof-pack-001">
+              Proof Pack 001
+            </a>
+            <a className="pvh__cta pvh__cta--ghost" href="#runtime-boundary">
+              Runtime Boundary
+            </a>
+          </div>
+        </div>
+
+        <div className="pvh__vault" aria-hidden="true">
+          <svg className="pvh__seal" viewBox="0 0 240 240" role="presentation">
+            <defs>
+              <radialGradient id="pvhCore" cx="50%" cy="50%" r="50%">
+                <stop offset="0%" stopColor="#8FD8FF" stopOpacity="0.34" />
+                <stop offset="55%" stopColor="#3B82F6" stopOpacity="0.08" />
+                <stop offset="100%" stopColor="#03060B" stopOpacity="0" />
+              </radialGradient>
+              <linearGradient id="pvhSteel" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="#EEF4FA" />
+                <stop offset="55%" stopColor="#8A96A7" />
+                <stop offset="100%" stopColor="#2A3340" />
+              </linearGradient>
+              <linearGradient id="pvhEdge" x1="0" y1="0" x2="1" y2="0">
+                <stop offset="0%" stopColor="#5FBFFF" stopOpacity="0" />
+                <stop offset="50%" stopColor="#8FD8FF" stopOpacity="0.9" />
+                <stop offset="100%" stopColor="#5FBFFF" stopOpacity="0" />
+              </linearGradient>
+            </defs>
+
+            <circle cx="120" cy="120" r="116" fill="url(#pvhCore)" />
+            <circle cx="120" cy="120" r="104" className="pvh__ring pvh__ring--outer" />
+            <circle cx="120" cy="120" r="86" className="pvh__ring pvh__ring--mid" />
+            <circle cx="120" cy="120" r="64" className="pvh__ring pvh__ring--inner" />
+
+            {/* signal sweep */}
+            <circle
+              cx="120"
+              cy="120"
+              r="95"
+              className="pvh__sweep"
+              fill="none"
+              stroke="url(#pvhEdge)"
+              strokeWidth="2.4"
+              strokeLinecap="round"
+              strokeDasharray="60 537"
+            />
+
+            {/* lugs around the vault door */}
+            {Array.from({ length: 8 }).map((_, i) => {
+              const a = (i / 8) * Math.PI * 2;
+              const r = 86;
+              return (
+                <circle
+                  key={i}
+                  cx={120 + r * Math.cos(a)}
+                  cy={120 + r * Math.sin(a)}
+                  r="3.4"
+                  className="pvh__lug"
+                />
+              );
+            })}
+
+            {/* sealed core / monogram */}
+            <circle cx="120" cy="120" r="46" className="pvh__door" />
+            <path
+              d="M104 96 L112 96 L112 116 L128 116 L128 96 L136 96 L136 144 L128 144 L128 124 L112 124 L112 144 L104 144 Z"
+              fill="url(#pvhSteel)"
+              stroke="url(#pvhEdge)"
+              strokeWidth="0.8"
+            />
+            <circle cx="120" cy="120" r="2.6" fill="#8FD8FF" />
+          </svg>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/RuntimeBoundaryVisual.tsx
+++ b/components/RuntimeBoundaryVisual.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useId, useState } from "react";
+
+/**
+ * RuntimeBoundaryVisual
+ *
+ * A sealed vertical proof tower. Each level is a rung from controlled
+ * validation up to production/customer/fleet. Supported rungs glow; blocked
+ * rungs read as sealed gates, not merely inactive. Selecting a level reveals
+ * what it means and what it does not prove.
+ *
+ * Blocked-term wording (signal-observed, production-ready, fleet-wide,
+ * autonomous SOC) appears only inside blocked / not-claimed context, framed
+ * as not claimed. Public runtime proof remains blocked at this surface.
+ */
+
+type Tone = "supported" | "partial" | "blocked";
+
+interface Level {
+  rank: string;
+  label: string;
+  status: string;
+  tone: Tone;
+  means: string;
+  notProve: string;
+}
+
+const levels: Level[] = [
+  {
+    rank: "01",
+    label: "Controlled validation",
+    status: "SUPPORTED",
+    tone: "supported",
+    means:
+      "Validation packages, controlled fixtures, and deterministic verifiers run on every PR. This is the strongest publicly supported tier.",
+    notProve: "It does not prove runtime activation or any signal observation.",
+  },
+  {
+    rank: "02",
+    label: "Runtime path initialized",
+    status: "SOURCE-VISIBLE",
+    tone: "supported",
+    means:
+      "Runtime contracts, truth-spine schemas, and case-packet structures exist in source. Initialization is repo-visible.",
+    notProve: "Source presence is not runtime; nothing here is claimed as executed in production.",
+  },
+  {
+    rank: "03",
+    label: "Runtime-supported (private)",
+    status: "PARTIAL",
+    tone: "partial",
+    means:
+      "Private runtime support is acknowledged in boundary docs (e.g. the RS003 route marker). Evidence stays private; public status remains BLOCKED_PENDING_REVIEW.",
+    notProve: "Public runtime proof is blocked; the private marker is not a public claim.",
+  },
+  {
+    rank: "04",
+    label: "Runtime-observed (private)",
+    status: "PARTIAL",
+    tone: "partial",
+    means:
+      "Mirrored visibility and private observation surfaces exist as bounded summaries, only where source-supported. Raw evidence stays outside public repos.",
+    notProve: "Public NDR, cross-source, and signal-observed proof are not claimed from this surface.",
+  },
+  {
+    rank: "05",
+    label: "Public runtime proof",
+    status: "BLOCKED",
+    tone: "blocked",
+    means:
+      "This rung is a sealed gate. Public runtime claims require separate capture, verifier, checklist, and human approval before anything advances.",
+    notProve:
+      "Runtime-active, signal-observed, and public-safe runtime proof are blocked and not claimed until a separate promotion gate clears them.",
+  },
+  {
+    rank: "06",
+    label: "Production / customer / fleet",
+    status: "BLOCKED",
+    tone: "blocked",
+    means: "This rung is a sealed gate held above every other surface.",
+    notProve:
+      "Production-ready, customer-validated, partner-endorsed, fleet-wide, and autonomous SOC claims are blocked and not made anywhere on this surface.",
+  },
+];
+
+const mark: Record<Tone, string> = {
+  supported: "●",
+  partial: "◐",
+  blocked: "⊘",
+};
+
+export default function RuntimeBoundaryVisual() {
+  const [active, setActive] = useState(0);
+  const titleId = useId();
+  const selected = levels[active];
+
+  return (
+    <section className="rbv" aria-labelledby={titleId}>
+      <header className="rbv__head">
+        <p className="cockpit-eyebrow">Runtime boundary</p>
+        <h3 id={titleId} className="rbv__title">
+          The runtime proof tower — what survives, what stays sealed.
+        </h3>
+        <p className="rbv__sub">
+          Each level names a stronger runtime status. The public surface holds at
+          controlled validation; higher rungs are sealed gates that require
+          separate evidence and human approval.
+        </p>
+      </header>
+
+      <div className="rbv__stage">
+        <ol className="rbv__tower" aria-label="Runtime proof boundary levels">
+          {levels.map((level, i) => {
+            const isActive = i === active;
+            return (
+              <li key={level.rank} className="rbv__rung-wrap">
+                <button
+                  type="button"
+                  aria-pressed={isActive}
+                  className={`rbv__rung rbv__rung--${level.tone}${isActive ? " is-active" : ""}`}
+                  onMouseEnter={() => setActive(i)}
+                  onFocus={() => setActive(i)}
+                  onClick={() => setActive(i)}
+                >
+                  <span className="rbv__rung-rank">{level.rank}</span>
+                  <span className="rbv__rung-mark" aria-hidden="true">{mark[level.tone]}</span>
+                  <span className="rbv__rung-label">{level.label}</span>
+                  <span className={`rbv__rung-status rbv__rung-status--${level.tone}`}>
+                    {level.status}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ol>
+
+        <aside className={`rbv__detail rbv__detail--${selected.tone}`} aria-live="polite">
+          <p className="rbv__detail-rank">Level {selected.rank}</p>
+          <h4 className="rbv__detail-title">{selected.label}</h4>
+          <span className={`rbv__detail-status rbv__detail-status--${selected.tone}`}>
+            {selected.status}
+          </span>
+          <dl className="rbv__detail-list">
+            <div>
+              <dt>What it means</dt>
+              <dd>{selected.means}</dd>
+            </div>
+            <div>
+              <dt>What it does not prove</dt>
+              <dd>{selected.notProve}</dd>
+            </div>
+          </dl>
+        </aside>
+      </div>
+
+      <details className="rbv__table-wrap">
+        <summary className="rbv__table-summary">View levels as text</summary>
+        <table className="rbv__table">
+          <caption className="cfg__sr-only">Runtime proof boundary levels.</caption>
+          <thead>
+            <tr>
+              <th scope="col">Level</th>
+              <th scope="col">Status</th>
+              <th scope="col">What it does not prove</th>
+            </tr>
+          </thead>
+          <tbody>
+            {levels.map((level) => (
+              <tr key={level.rank}>
+                <th scope="row">{level.rank} · {level.label}</th>
+                <td>{level.status}</td>
+                <td>{level.notProve}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </details>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- Reworks the Proof page into an Evidence Vault / Claim Authority Hub.
- Adds Proof-only visual components: ProofVaultHero, ClaimFirewallSplitPane, RuntimeBoundaryVisual, ProofRecordsEvidenceBay, and ProofTrustBoundaryRail.
- Reuses ControlsFiredGraph, ProofPackReceipt, ProofManifestConsole, PromotionGateLadder, and RecentGovernedArtifacts.
- Tightens Proof-specific visual CSS and removes reveal wrappers that hid Proof sections during full-page screenshot capture.
- Preserves claim boundaries: blocked runtime, production, customer, partner, endorsement, autonomous SOC, AI-approved disposition, and public runtime proof terms remain framed only as blocked / not claimed.
- No non-website repos modified.

## Validation
- npm run typecheck: PASS
- npm run check:site: PASS
- npm run build: PASS

## Visual Gate
- Proof page screenshots captured locally at 380x900, 768x1024, 1280x900, and 1440x1000.
- Visual gate passed after the Proof reveal-wrapper fix.
- No merge requested in this PR; holding for Raylee visual review.