### PR TITLE
docs(readme): align reviewer value and authority boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,42 @@
 # HawkinsOperations Website
 
-Public proof codex and website rendering layer for HawkinsOperations, the governed successor architecture for detection engineering.
+HawkinsOperations website is the render-only reviewer cockpit for public navigation, claim-boundary summaries, and proof-route handoffs; it is not proof authority.
 
 Owner identity: Raylee Hawkins, Detection Engineer | SOC Automation | Detection-as-Code | Security Automation.
 
-Official links: [Raylee Hawkins on LinkedIn](https://www.linkedin.com/in/raylee-hawkins) · [Raylee Hawkins on GitHub](https://github.com/raylee-hawkins) · [HawkinsOps detection engineering portfolio](https://hawkinsops.com) · [HawkinsOperations GitHub organization](https://github.com/HawkinsOperations) · [RayleeOps public operating journal](https://rayleeops.com)
+Official links: [Raylee Hawkins on LinkedIn](https://www.linkedin.com/in/raylee-hawkins) | [Raylee Hawkins on GitHub](https://github.com/raylee-hawkins) | [HawkinsOps detection engineering portfolio](https://hawkinsops.com) | [HawkinsOperations GitHub organization](https://github.com/HawkinsOperations) | [RayleeOps public operating journal](https://rayleeops.com)
 
-## Purpose
+## What This Repo Is
 
-This repository renders the public explanation for HawkinsOperations: governed detection engineering, truth boundaries, proof promotion, public claim control, and reviewer routing.
+This repository renders the public website for HawkinsOperations reviewer navigation. It presents static routes, typed public data, claim ceilings, blocked-claim boundaries, and links into the repositories that own source, validation, and proof records.
 
-This repo is website rendering only. It is not the source of detection truth, runtime truth, signal truth, evidence truth, or external-use authorization.
+The site can help a reviewer find the right door quickly. It does not create detection truth, runtime truth, signal truth, evidence truth, public proof, or external-use approval.
 
-## Framework and Deploy Model
+## Reviewer Routing
+
+Reviewer routing is separate from build and deployment.
+
+- The homepage cockpit routes reviewers to Proof, Artifacts, Detections, AI Security, About, and source inspection.
+- `src/data/reviewerRoutes.ts` defines bounded reviewer paths for validation review, proof/verifier review, platform/SOAR contract review, and AI governance boundary review.
+- The public pages route reviewers toward owned repositories and proof records; they do not replace those records.
+- The activity ledger is a hand-maintained static snapshot, not a live GitHub feed or runtime dashboard.
+- The receipt and lifetime-ledger displays are reviewer summaries only. The proof repository owns the lifetime-ledger summary and proof bundle; the website renders bounded counts, badges, and route links without promoting runtime, signal, public-safe runtime proof, SOCaaS, production, autonomous SOC, disposition, or case-closure claims.
+
+## Public Claim Data Layer
+
+`src/data/*` is the typed public claim-boundary data layer for this static site.
+
+Current public data modules include reviewer routes, proof records, receipt/activity ledgers, blocked-claim data, navigation links, validation registry content, artifact summaries, truth surfaces, and repository routing metadata. These files control what the website renders; they are not proof authority by themselves.
+
+Data-layer rules:
+
+- Keep every rendered claim at or below its approved ceiling.
+- Treat repo source, validation output, proof records, runtime evidence, and website pages as separate truth surfaces.
+- Use `CONTROLLED_TEST_VALIDATED`, `NOT_PUBLIC_SAFE`, `BLOCKED`, and other bounded labels only where the underlying data already supports them.
+- Do not infer live deployment, signal observation, public-safe runtime proof, production readiness, customer use, autonomous SOC authority, AI-approved disposition, analyst-approved disposition, containment approval, suppression approval, or case closure from a rendered page.
+- Keep lifetime-ledger wording tied to the proof-owned summary/bundle and its explicit render boundary.
+
+## Build and Deploy
 
 - Framework: Next.js (App Router) + Tailwind CSS + TypeScript
 - Output mode: static export (`output: "export"` in `next.config.mjs`)
@@ -24,9 +48,22 @@ This repo is website rendering only. It is not the source of detection truth, ru
 - Image optimization: disabled (`images.unoptimized: true`)
 - Fake dynamic APIs: none
 
-Cloudflare Pages should build from the repository root and publish `dist`. No dashboard
-setting change is required for this migration: the `finalize-dist.mjs` postbuild script
-renames Next.js's `out/` directory to `dist/` to preserve the existing publish path.
+Cloudflare Pages should build from the repository root and publish `dist`. No dashboard setting change is required for this migration: the `finalize-dist.mjs` postbuild script renames Next.js's `out/` directory to `dist/` to preserve the existing publish path.
+
+A successful build or deployment proves only that the static website can be rendered and published. It does not prove a detection fired, a runtime route executed, a signal was observed, evidence is public-safe, or any claim is authorized for external use beyond its approved wording.
+
+## Proof Boundary
+
+Website rendering is not proof.
+
+- Website repo: public rendering and reviewer routing only
+- Detection truth: `hawkinsoperations-detections`
+- Validation truth: `hawkinsoperations-validation`
+- Platform/runtime truth: internal platform routes; not public website authority
+- Proof and claim linkage: `hawkinsoperations-proof`
+- Organization-level successor governance: `https://github.com/HawkinsOperations`
+
+Website pages may summarize approved claim ceilings and route reviewers to public proof records. Page text does not authorize stronger external-use claims, does not promote proof status, and does not make raw/private evidence public-safe.
 
 ## HawkinsOperations Closed SOC Loop 001
 
@@ -46,15 +83,16 @@ renames Next.js's `out/` directory to `dist/` to preserve the existing publish p
 
 ## Blocked Claims
 
-This repository does not claim: runtime-active, signal-observed, evidence-linked public proof, public-safe, live Splunk firing, production triage, analyst-approved disposition, private model host runtime-active, Cribl-routed, Wazuh-routed, AWS-live, autonomous SOC, production-ready SOC, fleet-wide deployment, or AI-approved disposition.
+This repository does not claim: runtime-active, signal-observed, evidence-linked public proof, public-safe runtime proof, live Splunk firing, production triage, analyst-approved disposition, private model host runtime-active, Cribl-routed, Wazuh-routed, AWS-live, autonomous SOC, production-ready SOC, fleet-wide deployment, customer deployment, case closure authority, or AI-approved disposition.
 
 ## Scope
 
-- External-use project narrative after review
+- Render-only website source
 - Reviewer routing between public surfaces
 - Repository map and system overview
-- Links to successor source and proof repositories
-- Static public proof codex routes for reviewer inspection
+- Links to successor source, validation, and proof repositories
+- Static public claim-boundary routes for reviewer inspection
+- Bounded cockpit, activity-ledger, receipt-ledger, and lifetime-ledger presentation
 
 ## Out of Scope
 
@@ -62,7 +100,8 @@ This repository does not claim: runtime-active, signal-observed, evidence-linked
 - Internal cutover/control docs
 - Any non-public secrets or environment details
 - Detection implementation authority
-- Runtime, signal, evidence, or external-use authorization authority
+- Runtime, signal, evidence, publication approval, or external reuse authority
+- Live telemetry, live GitHub status, live SIEM/SOAR state, or deployment-state claims
 
 ## Repository Contract
 
@@ -70,16 +109,7 @@ This repository does not claim: runtime-active, signal-observed, evidence-linked
 - Avoid internal plumbing details that do not help external readers.
 - Link claims to source/proof artifacts rather than undocumented assertions.
 - Do not claim that website text proves runtime behavior, validation, signal observation, evidence linkage, or external-use approval.
-- Treat `src/data/*` as the typed public claim-boundary data layer for this static site.
-
-## Truth Boundary
-
-- Website repo: public rendering and routing only
-- Detection truth: `hawkinsoperations-detections`
-- Validation truth: `hawkinsoperations-validation`
-- Platform/runtime truth: internal platform route; not a public website or proof surface
-- Proof and claim linkage: `hawkinsoperations-proof`
-- Organization-level successor governance: `https://github.com/HawkinsOperations`
+- Treat `src/data/*` as render input for bounded public pages, not as proof authority.
 
 ## Related Repositories
 


### PR DESCRIPTION
## Summary
- Reframes the website as render-only reviewer cockpit and routing surface.
- Separates reviewer routes from build/deploy guidance.
- Adds bounded public claim data layer context for src/data without making website proof authority.

## README stress tests run
- 10-second hook: PASS
- So-What test: PASS
- Jargon translation: PASS
- Proof boundary: PASS
- Reviewer path: PASS
- Executive billboard: PASS
- Visual structure: PASS
- Repo authority: PASS
- Hiring signal: PASS
- Final diff scope: PASS

## Scope
- README.md only.
- No validation repo edits.
- No workflows, source code, schemas, validators, proof records, website source/data, non-README docs, issues, projects, settings, branch protection, or release assets changed.

## Proof boundary
This PR does not promote public-safe status, runtime-active status, signal-observed status, production/SOCaaS availability, proof ceiling, analyst disposition, or AI authority.

## Reviewer value
The README now puts reviewer value before internal mechanics and keeps repo authority boundaries explicit.

## Validation
- README.md only changed.
- npm --prefix C:\Raylee\Repo\HawkinsOperations\hawkinsoperations-website run check:site passed.
- git diff --check -- README.md passed.
- Parent scope scan confirmed only README.md changed.
- Private path scan passed.
- Proof-boundary scan found restricted terms only in blocked/boundary language.

## Exclusion note
hawkinsoperations-validation was intentionally excluded from this sprint because it has existing unrelated non-README work on eature/runtime-proof-runner-trust-split-v1.