### PR TITLE
Redesign Claim Firewall product page

### DIFF
--- a/app/claim-firewall/page.tsx
+++ b/app/claim-firewall/page.tsx
@@ -1,0 +1,117 @@
+import type { Metadata } from "next";
+import ClaimFirewall from "@components/ClaimFirewall";
+
+const cliCommand = "python -m claimfirewall scan README.md --policy policy/blocked_claims.yml";
+
+export const metadata: Metadata = {
+  title: "Claim Firewall | HawkinsOperations",
+  description:
+    "Claim Firewall is a HawkinsOperations public utility that scans security docs, PR text, README files, YAML files, and public-facing Markdown for unsupported claims before they ship.",
+  alternates: {
+    canonical: "/claim-firewall/",
+  },
+};
+
+export default function ClaimFirewallPage() {
+  return (
+    <>
+      <section className="controls-hero" aria-labelledby="claim-firewall-title">
+        <div className="container controls-hero__grid">
+          <div className="controls-hero__copy">
+            <p className="cockpit-eyebrow">Public utility satellite</p>
+            <h1 id="claim-firewall-title" className="controls-hero__title">
+              Claim Firewall
+            </h1>
+            <p className="controls-hero__lede">
+              Block unsupported security claims before they ship.
+            </p>
+            <p className="controls-hero__lede">
+              Claim Firewall is a small CLI and GitHub Action that scans security docs, PR text,
+              README files, YAML files, and public-facing Markdown for wording that outruns evidence.
+            </p>
+            <div className="controls-hero__pills" aria-label="Claim Firewall product status">
+              <span>v0.1.0 released</span>
+              <span>CI passed</span>
+              <span>TOOL_FUNCTION_ONLY</span>
+              <span>RENDERING_ONLY website page</span>
+              <span>CLI</span>
+              <span>GitHub Action</span>
+              <span>Policy as code</span>
+            </div>
+          </div>
+
+          <aside className="controls-hero__rail" aria-label="Claim Firewall release receipts">
+            <span className="controls-hero__rail-label">Release receipts</span>
+            <p>Repo, release, and announcement are public reviewer routes for the v0.1.0 utility.</p>
+            <p>Website rendering is not proof authority. Claim Firewall supports claim hygiene only.</p>
+            <div className="controls-hero__pills" aria-label="Claim Firewall external links">
+              <a href="https://github.com/HawkinsOperations/claim-firewall" target="_blank" rel="noopener noreferrer">
+                <span>View repo</span>
+              </a>
+              <a
+                href="https://github.com/HawkinsOperations/claim-firewall/releases/tag/v0.1.0"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span>Open release</span>
+              </a>
+              <a href="https://github.com/orgs/HawkinsOperations/discussions/51" target="_blank" rel="noopener noreferrer">
+                <span>Read announcement</span>
+              </a>
+            </div>
+          </aside>
+
+          <div className="controls-hero__console" aria-label="Claim Firewall command and gate visual">
+            <div className="controls-hero__console-head">
+              <span>PUBLIC WORDING ROUTE</span>
+              <span>policy gate</span>
+            </div>
+            <div className="controls-hero__flow">
+              <div className="controls-hero__node controls-hero__node--wording">
+                <span>01</span>
+                <strong>WORDING</strong>
+                <p>Docs, PR text, README updates, YAML files, and public Markdown enter the gate.</p>
+              </div>
+              <div className="controls-hero__beam" aria-hidden="true" />
+              <div className="controls-hero__node controls-hero__node--scanner">
+                <span>02</span>
+                <strong>SCANNER</strong>
+                <p>Configured policy catches unsupported wording and reports a suggested ceiling.</p>
+                <em>fail closed</em>
+              </div>
+              <div className="controls-hero__beam controls-hero__beam--blocked" aria-hidden="true" />
+              <div className="controls-hero__node controls-hero__node--ceiling">
+                <span>03</span>
+                <strong>CEILING</strong>
+                <p>Unsafe product claims are blocked. Safer wording stays behind evidence.</p>
+              </div>
+            </div>
+            <pre className="claim-firewall-demo__terminal" aria-label="Visible CLI command">
+              <code>{cliCommand}</code>
+            </pre>
+            <div className="controls-hero__meter" aria-label="Product capability summary">
+              <span>scan files</span>
+              <span>scan dirs</span>
+              <span>text output</span>
+              <span>json output</span>
+              <span>action gate</span>
+              <span className="controls-hero__meter-blocked">public proof blocked</span>
+            </div>
+            <div className="controls-hero__boundary-strip" role="note">
+              <strong>Website rendering is not proof.</strong>
+              <span>Public proof requires evidence linkage and explicit promotion.</span>
+            </div>
+            <p className="controls-hero__lede">
+              Unsupported security claims should fail before they reach the public page.
+              Public wording stays below the evidence ceiling.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="container controls-main">
+        <ClaimFirewall />
+      </section>
+    </>
+  );
+}

--- a/app/controls/page.tsx
+++ b/app/controls/page.tsx
@@ -1,115 +1,42 @@
 import type { Metadata } from "next";
-import ClaimFirewall from "@components/ClaimFirewall";
-
-const cliCommand = "python -m claimfirewall scan README.md --policy policy/blocked_claims.yml";
 
 export const metadata: Metadata = {
-  title: "Claim Firewall | HawkinsOperations",
+  title: "Claim Firewall moved | HawkinsOperations",
   description:
-    "Claim Firewall is a HawkinsOperations public utility that scans security docs, PR text, README files, YAML files, and public-facing Markdown for unsupported claims before they ship.",
+    "The Claim Firewall product page now lives at /claim-firewall/. The legacy /controls/ route remains for compatibility.",
   alternates: {
-    canonical: "/controls/",
+    canonical: "/claim-firewall/",
   },
 };
 
 export default function ControlsPage() {
   return (
-    <>
-      <section className="controls-hero" aria-labelledby="claim-firewall-title">
-        <div className="container controls-hero__grid">
-          <div className="controls-hero__copy">
-            <p className="cockpit-eyebrow">Public utility satellite</p>
-            <h1 id="claim-firewall-title" className="controls-hero__title">
-              Claim Firewall
-            </h1>
-            <p className="controls-hero__lede">
-              Block unsupported security claims before they ship.
-            </p>
-            <p className="controls-hero__lede">
-              Claim Firewall is a small CLI and GitHub Action that scans security docs, PR text,
-              README files, YAML files, and public-facing Markdown for wording that outruns evidence.
-            </p>
-            <div className="controls-hero__pills" aria-label="Claim Firewall product status">
-              <span>v0.1.0</span>
-              <span>TOOL_FUNCTION_ONLY</span>
-              <span>CLI</span>
-              <span>GitHub Action</span>
-              <span>Policy as code</span>
-            </div>
-          </div>
-
-          <aside className="controls-hero__rail" aria-label="Claim Firewall links">
-            <span className="controls-hero__rail-label">Public inspection layer</span>
-            <p>Repo, release, and announcement are public reviewer routes for the v0.1.0 utility.</p>
-            <p>Website rendering is not proof authority. Claim Firewall supports claim hygiene only.</p>
-            <div className="controls-hero__pills" aria-label="Claim Firewall external links">
-              <a href="https://github.com/HawkinsOperations/claim-firewall" target="_blank" rel="noopener noreferrer">
-                <span>View repo</span>
-              </a>
-              <a
-                href="https://github.com/HawkinsOperations/claim-firewall/releases/tag/v0.1.0"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <span>Open release</span>
-              </a>
-              <a href="https://github.com/orgs/HawkinsOperations/discussions/51" target="_blank" rel="noopener noreferrer">
-                <span>Read announcement</span>
-              </a>
-            </div>
-          </aside>
-
-          <div className="controls-hero__console" aria-label="Claim Firewall command and gate visual">
-            <div className="controls-hero__console-head">
-              <span>PUBLIC WORDING ROUTE</span>
-              <span>policy gate</span>
-            </div>
-            <div className="controls-hero__flow">
-              <div className="controls-hero__node controls-hero__node--wording">
-                <span>01</span>
-                <strong>WORDING</strong>
-                <p>Docs, PR text, README updates, YAML files, and public Markdown enter the gate.</p>
-              </div>
-              <div className="controls-hero__beam" aria-hidden="true" />
-              <div className="controls-hero__node controls-hero__node--scanner">
-                <span>02</span>
-                <strong>SCANNER</strong>
-                <p>Configured policy catches unsupported wording and reports a suggested ceiling.</p>
-                <em>fail closed</em>
-              </div>
-              <div className="controls-hero__beam controls-hero__beam--blocked" aria-hidden="true" />
-              <div className="controls-hero__node controls-hero__node--ceiling">
-                <span>03</span>
-                <strong>CEILING</strong>
-                <p>Unsafe product claims are blocked. Safer wording stays behind evidence.</p>
-              </div>
-            </div>
-            <pre className="claim-firewall-demo__terminal" aria-label="Visible CLI command">
-              <code>{cliCommand}</code>
-            </pre>
-            <div className="controls-hero__meter" aria-label="Product capability summary">
-              <span>scan files</span>
-              <span>scan dirs</span>
-              <span>text output</span>
-              <span>json output</span>
-              <span>action gate</span>
-              <span className="controls-hero__meter-blocked">public proof blocked</span>
-            </div>
-            <div className="controls-hero__boundary-strip" role="note">
-              <strong>Website rendering is not proof.</strong>
-              <span>Public proof requires evidence linkage and explicit promotion.</span>
-            </div>
-            <p className="controls-hero__lede">
-              Unsupported security claims should fail before they reach the public page.
-              Public wording stays below the evidence ceiling.
-            </p>
+    <section className="controls-hero" aria-labelledby="legacy-controls-title">
+      <div className="container controls-hero__grid">
+        <div className="controls-hero__copy">
+          <p className="cockpit-eyebrow">Legacy route</p>
+          <h1 id="legacy-controls-title" className="controls-hero__title">
+            Claim Firewall moved
+          </h1>
+          <p className="controls-hero__lede">
+            The Claim Firewall product page now lives at /claim-firewall/.
+          </p>
+          <p className="controls-hero__lede">
+            This /controls/ route remains as a compatibility page for older reviewer links.
+          </p>
+          <div className="controls-hero__pills" aria-label="Claim Firewall moved route">
+            <a href="/claim-firewall/">
+              <span>Open Claim Firewall</span>
+            </a>
+            <span>RENDERING_ONLY website page</span>
           </div>
         </div>
-      </section>
-
-      <section className="container controls-main">
-        <ClaimFirewall />
-      </section>
-    </>
+        <aside className="controls-hero__rail" aria-label="Legacy route boundary">
+          <span className="controls-hero__rail-label">Compatibility only</span>
+          <p>Website rendering is not proof authority. This route does not approve claims.</p>
+          <p>Claim Firewall checks wording policy only on the canonical product page.</p>
+        </aside>
+      </div>
+    </section>
   );
 }

--- a/app/controls/page.tsx
+++ b/app/controls/page.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from "next";
 import ClaimFirewall from "@components/ClaimFirewall";
-import { ceiling } from "@config/site";
+
+const cliCommand = "python -m claimfirewall scan README.md --policy policy/blocked_claims.yml";
 
 export const metadata: Metadata = {
   title: "Claim Firewall | HawkinsOperations",
   description:
-    "HawkinsOperations claim firewall for allowed wording, blocked wording, and proof promotion requirements.",
+    "Claim Firewall is a HawkinsOperations public utility that scans security docs, PR text, README files, YAML files, and public-facing Markdown for unsupported claims before they ship.",
   alternates: {
     canonical: "/controls/",
   },
@@ -17,64 +18,91 @@ export default function ControlsPage() {
       <section className="controls-hero" aria-labelledby="claim-firewall-title">
         <div className="container controls-hero__grid">
           <div className="controls-hero__copy">
-            <p className="cockpit-eyebrow">CI claim boundary console</p>
+            <p className="cockpit-eyebrow">Public utility satellite</p>
             <h1 id="claim-firewall-title" className="controls-hero__title">
               Claim Firewall
             </h1>
             <p className="controls-hero__lede">
-              Unsupported security claims should fail before they reach the public page.
-              Public wording stays below the evidence ceiling until evidence linkage and explicit promotion clear a stronger claim.
+              Block unsupported security claims before they ship.
             </p>
-            <div className="controls-hero__pills" aria-label="Claim Firewall public status">
-              <span>RENDERING_ONLY</span>
-              <span>{ceiling}</span>
-              <span className="controls-hero__pill--blocked">NOT_PUBLIC_SAFE</span>
+            <p className="controls-hero__lede">
+              Claim Firewall is a small CLI and GitHub Action that scans security docs, PR text,
+              README files, YAML files, and public-facing Markdown for wording that outruns evidence.
+            </p>
+            <div className="controls-hero__pills" aria-label="Claim Firewall product status">
+              <span>v0.1.0</span>
+              <span>TOOL_FUNCTION_ONLY</span>
+              <span>CLI</span>
+              <span>GitHub Action</span>
+              <span>Policy as code</span>
             </div>
           </div>
 
-          <aside className="controls-hero__rail" aria-label="Public inspection layer">
+          <aside className="controls-hero__rail" aria-label="Claim Firewall links">
             <span className="controls-hero__rail-label">Public inspection layer</span>
-            <p>Reviewer navigation, blocked wording, and evidence-ceiling status are visible here.</p>
-            <p>Green checks are evidence, not approval. AI support is labor, not authority.</p>
+            <p>Repo, release, and announcement are public reviewer routes for the v0.1.0 utility.</p>
+            <p>Website rendering is not proof authority. Claim Firewall supports claim hygiene only.</p>
+            <div className="controls-hero__pills" aria-label="Claim Firewall external links">
+              <a href="https://github.com/HawkinsOperations/claim-firewall" target="_blank" rel="noopener noreferrer">
+                <span>View repo</span>
+              </a>
+              <a
+                href="https://github.com/HawkinsOperations/claim-firewall/releases/tag/v0.1.0"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span>Open release</span>
+              </a>
+              <a href="https://github.com/orgs/HawkinsOperations/discussions/51" target="_blank" rel="noopener noreferrer">
+                <span>Read announcement</span>
+              </a>
+            </div>
           </aside>
 
-          <div className="controls-hero__console" aria-label="Wording to scanner to ceiling firewall diagram">
+          <div className="controls-hero__console" aria-label="Claim Firewall command and gate visual">
             <div className="controls-hero__console-head">
               <span>PUBLIC WORDING ROUTE</span>
-              <span className="rubber-stamp-blocked">BLOCKED</span>
+              <span>policy gate</span>
             </div>
             <div className="controls-hero__flow">
               <div className="controls-hero__node controls-hero__node--wording">
                 <span>01</span>
                 <strong>WORDING</strong>
-                <p>Copy, metadata, proof cards, reviewer summaries.</p>
+                <p>Docs, PR text, README updates, YAML files, and public Markdown enter the gate.</p>
               </div>
               <div className="controls-hero__beam" aria-hidden="true" />
               <div className="controls-hero__node controls-hero__node--scanner">
                 <span>02</span>
                 <strong>SCANNER</strong>
-                <p>Blocked terms, unsafe context, proof drift.</p>
+                <p>Configured policy catches unsupported wording and reports a suggested ceiling.</p>
                 <em>fail closed</em>
               </div>
               <div className="controls-hero__beam controls-hero__beam--blocked" aria-hidden="true" />
               <div className="controls-hero__node controls-hero__node--ceiling">
                 <span>03</span>
                 <strong>CEILING</strong>
-                <p>Evidence-linked claims only.</p>
+                <p>Unsafe product claims are blocked. Safer wording stays behind evidence.</p>
               </div>
             </div>
-            <div className="controls-hero__meter" aria-label="Evidence ceiling summary">
-              <span>source</span>
-              <span>validation</span>
-              <span>runtime candidate</span>
-              <span>evidence review</span>
-              <span>human approval</span>
+            <pre className="claim-firewall-demo__terminal" aria-label="Visible CLI command">
+              <code>{cliCommand}</code>
+            </pre>
+            <div className="controls-hero__meter" aria-label="Product capability summary">
+              <span>scan files</span>
+              <span>scan dirs</span>
+              <span>text output</span>
+              <span>json output</span>
+              <span>action gate</span>
               <span className="controls-hero__meter-blocked">public proof blocked</span>
             </div>
             <div className="controls-hero__boundary-strip" role="note">
               <strong>Website rendering is not proof.</strong>
               <span>Public proof requires evidence linkage and explicit promotion.</span>
             </div>
+            <p className="controls-hero__lede">
+              Unsupported security claims should fail before they reach the public page.
+              Public wording stays below the evidence ceiling.
+            </p>
           </div>
         </div>
       </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -39,7 +39,7 @@ export default function HomePage() {
               Each stage shows what happens, what control sits over it, and what gets blocked.
               The verifier owns pass and fail; human review owns merge authority.
             </p>
-            <a className="artifact-tile mt-5 block max-w-3xl" href="/controls/">
+            <a className="artifact-tile mt-5 block max-w-3xl" href="/claim-firewall/">
               <span className="artifact-tile__cat">CLAIM FIREWALL</span>
               <span className="artifact-tile__title">Unsupported public security claims fail before they ship.</span>
               <span className="artifact-tile__desc">

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -19,6 +19,7 @@ const staticRoutes = [
   "/validation/",
   "/platform/contracts/",
   "/start/",
+  "/claim-firewall/",
   "/controls/",
   "/architecture/",
   "/architecture/truth-surfaces/",

--- a/components/ClaimFirewall.tsx
+++ b/components/ClaimFirewall.tsx
@@ -1,206 +1,284 @@
-import {
-  allowedClaims,
-  blockedClaims,
-  promotionRequirements,
-  safeWordingExamples,
-  unsafeWordingExamples,
-} from "@data/claims";
+const quickStartCommands = [
+  "python -m claimfirewall scan README.md --policy policy/blocked_claims.yml",
+  "claimfirewall scan README.md --policy policy/blocked_claims.yml",
+];
 
-const ceilingLevels = [
+const policyAreas = [
+  "production maturity",
+  "runtime evidence",
+  "public release safety",
+  "signal observation",
+  "automated SOC claims",
+  "AI approval language",
+  "analyst approval language",
+  "customer rollout evidence",
+  "service availability",
+  "coverage breadth",
+];
+
+const safeContexts = [
+  "does not prove production deployment",
+  "does not claim public release safety",
+  "support-only AI wording",
+  "rendering is not proof",
+];
+
+const transformations = [
   {
-    label: "Source truth",
-    state: "reviewable",
-    detail: "Source-controlled wording can be inspected, but source presence does not prove runtime.",
-    tone: "active",
+    blocked: "This detection is production ready.",
+    why: "Production maturity requires deployment evidence and explicit review.",
+    safer: "This detection has controlled-test validation only.",
   },
   {
-    label: "Validation truth",
-    state: "controlled",
-    detail: "Deterministic validation can support controlled-test wording at the current ceiling.",
-    tone: "active",
+    blocked: "AI approved the final disposition.",
+    why: "AI can support analysis, but approval authority remains human.",
+    safer: "AI provided support-only triage context. Human review remains authority.",
   },
   {
-    label: "Runtime candidate",
-    state: "candidate only",
-    detail: "Runtime candidates remain below public proof until separately evidenced and promoted.",
-    tone: "warn",
+    blocked: "The website proves signal observation.",
+    why: "Rendering routes reviewers. It does not create signal evidence.",
+    safer: "The website routes reviewers to evidence. It does not prove signal observation.",
   },
   {
-    label: "Signal / evidence review",
-    state: "gated",
-    detail: "Signal and evidence claims require separate review before public wording can move.",
-    tone: "warn",
-  },
-  {
-    label: "Human approval",
-    state: "authority",
-    detail: "Human review authorizes promotion; AI and green checks do not.",
-    tone: "active",
-  },
-  {
-    label: "Public proof",
-    state: "blocked until promoted",
-    detail: "Public-safe status remains blocked unless explicit evidence linkage and promotion clear.",
-    tone: "blocked",
+    blocked: "Coverage is fleet wide.",
+    why: "Coverage breadth requires separate telemetry and deployment evidence.",
+    safer: "Coverage breadth is not claimed by this page.",
   },
 ];
 
-const blockedTransformations = [
+const authorityStack = [
+  [".github", "command center and reviewer routing"],
+  ["detections", "source truth"],
+  ["validation", "behavior validation"],
+  ["platform", "control mechanics"],
+  ["proof", "proof and claim authority"],
+  ["website", "rendering only"],
+  ["claim-firewall", "utility only"],
+] as const;
+
+const receipts = [
   {
-    from: "validation",
-    to: "runtime proof",
+    label: "Repo",
+    value: "HawkinsOperations/claim-firewall",
+    href: "https://github.com/HawkinsOperations/claim-firewall",
   },
   {
-    from: "website rendering",
-    to: "proof",
+    label: "Release v0.1.0",
+    value: "GitHub release",
+    href: "https://github.com/HawkinsOperations/claim-firewall/releases/tag/v0.1.0",
   },
   {
-    from: "green CI",
-    to: "approval",
+    label: "Announcement",
+    value: "HawkinsOperations discussion",
+    href: "https://github.com/orgs/HawkinsOperations/discussions/51",
   },
   {
-    from: "AI support",
-    to: "disposition authority",
-  },
-  {
-    from: "runtime candidate",
-    to: "public-safe proof",
+    label: "CI",
+    value: "Actions",
+    href: "https://github.com/HawkinsOperations/claim-firewall/actions",
   },
 ];
 
 export default function ClaimFirewall() {
   return (
     <div className="claim-firewall-demo" data-ci-target="blocked-claims">
-      <article className="claim-firewall-demo__panel claim-firewall-demo__panel--meter">
+      <section className="claim-firewall-demo__panel" aria-labelledby="quick-start-title">
         <div className="claim-firewall-demo__panel-head">
           <div>
-            <p className="cockpit-eyebrow">Evidence ceiling gauge</p>
-            <h3 className="claim-firewall-demo__panel-title">Claim levels stay separated</h3>
+            <p className="cockpit-eyebrow">Quick Start</p>
+            <h2 id="quick-start-title" className="claim-firewall-demo__panel-title">
+              Run the scanner where the wording lives
+            </h2>
           </div>
-          <span className="claim-firewall-demo__panel-status">PUBLIC-SAFE BLOCKED UNLESS PROMOTED</span>
+          <span className="claim-firewall-demo__panel-status">CLI</span>
         </div>
-        <ol className="claim-firewall-demo__meter" aria-label="Evidence ceiling gauge">
-          {ceilingLevels.map((level, index) => (
-            <li key={level.label} className={`claim-firewall-demo__meter-step claim-firewall-demo__meter-step--${level.tone}`}>
-              <span className="claim-firewall-demo__meter-index">{String(index + 1).padStart(2, "0")}</span>
-              <strong>{level.label}</strong>
-              <em>{level.state}</em>
-              <p>{level.detail}</p>
-            </li>
+        <div className="claim-firewall-demo__examples">
+          {quickStartCommands.map((command) => (
+            <pre key={command} className="claim-firewall-demo__terminal">
+              <code>{command}</code>
+            </pre>
           ))}
-        </ol>
-      </article>
+        </div>
+      </section>
 
-      <article className="claim-firewall-demo__panel claim-firewall-demo__panel--blocked">
+      <section className="claim-firewall-demo__panel claim-firewall-demo__panel--blocked" aria-labelledby="failure-title">
         <div className="claim-firewall-demo__panel-head">
-          <p className="cockpit-eyebrow">Blocked / not claimed</p>
+          <div>
+            <p className="cockpit-eyebrow">Failure Example</p>
+            <h2 id="failure-title" className="claim-firewall-demo__panel-title">
+              What a blocked claim looks like
+            </h2>
+          </div>
           <span className="claim-firewall-demo__panel-status">CONTROLLED RISK CHIPS</span>
         </div>
-        <div className="claim-firewall-demo__chips" aria-label="Blocked claim chips">
-          {blockedClaims.map((claim) => (
+        <div className="claim-firewall-demo__examples">
+          <article className="claim-firewall-demo__panel claim-firewall-demo__panel--unsafe">
+            <p className="cockpit-eyebrow">Unsafe wording examples</p>
+            <p className="claim-firewall-demo__boundary">This detection is production ready.</p>
+          </article>
+          <article className="claim-firewall-demo__panel">
+            <p className="cockpit-eyebrow">Finding</p>
+            <ul className="claim-firewall-demo__list claim-firewall-demo__list--unsafe">
+              <li>Blocked claim: production maturity</li>
+              <li>Reason: production maturity requires evidence outside wording scan</li>
+              <li>Suggested ceiling: TOOL_FUNCTION_ONLY</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section className="claim-firewall-demo__panel" aria-labelledby="action-title">
+        <div className="claim-firewall-demo__panel-head">
+          <div>
+            <p className="cockpit-eyebrow">GitHub Action</p>
+            <h2 id="action-title" className="claim-firewall-demo__panel-title">
+              Gate public wording in CI
+            </h2>
+          </div>
+          <span className="claim-firewall-demo__panel-status">HawkinsOperations/claim-firewall@v0.1.0</span>
+        </div>
+        <pre className="claim-firewall-demo__terminal" aria-label="Claim Firewall GitHub Action example">
+          <code>{`- uses: HawkinsOperations/claim-firewall@v0.1.0
+  with:
+    paths: "."
+    format: "text"
+    exclude: "examples/fail.md policy/blocked_claims.yml"`}</code>
+        </pre>
+      </section>
+
+      <section className="claim-firewall-demo__panel" aria-labelledby="transformer-title">
+        <div className="claim-firewall-demo__panel-head">
+          <div>
+            <p className="cockpit-eyebrow">Claim Transformer</p>
+            <h2 id="transformer-title" className="claim-firewall-demo__panel-title">
+              Replace overreach with bounded wording
+            </h2>
+          </div>
+          <span className="claim-firewall-demo__panel-status">EVIDENCE BEFORE CLAIMS</span>
+        </div>
+        <div className="claim-firewall-demo__examples">
+          {transformations.map((item) => (
+            <article key={item.blocked} className="claim-firewall-demo__panel">
+              <p className="cockpit-eyebrow">Blocked wording</p>
+              <p className="claim-firewall-demo__boundary">{item.blocked}</p>
+              <p className="cockpit-eyebrow">Why it fails</p>
+              <p className="claim-firewall-demo__boundary">{item.why}</p>
+              <p className="cockpit-eyebrow">Safer wording</p>
+              <p className="claim-firewall-demo__boundary">{item.safer}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="claim-firewall-demo__panel claim-firewall-demo__panel--blocked" aria-labelledby="coverage-title">
+        <div className="claim-firewall-demo__panel-head">
+          <div>
+            <p className="cockpit-eyebrow">Policy Coverage</p>
+            <h2 id="coverage-title" className="claim-firewall-demo__panel-title">
+              The policy watches language families, not just slogans
+            </h2>
+          </div>
+          <span className="claim-firewall-demo__panel-status">Blocked / not claimed</span>
+        </div>
+        <div className="claim-firewall-demo__chips" aria-label="Claim Firewall policy areas">
+          {policyAreas.map((claim) => (
             <span key={claim} className="claim-firewall-demo__chip">
               {claim}
             </span>
           ))}
         </div>
-      </article>
-
-      <div className="claim-firewall-demo__examples">
-        <article className="claim-firewall-demo__panel">
-          <p className="cockpit-eyebrow">Allowed wording examples</p>
-          <ul className="claim-firewall-demo__list claim-firewall-demo__list--allowed">
-            {safeWordingExamples.map((claim, i) => (
-              <li key={i}>{claim}</li>
-            ))}
-          </ul>
-        </article>
-
-        <article className="claim-firewall-demo__panel claim-firewall-demo__panel--unsafe">
-          <p className="cockpit-eyebrow">Unsafe wording examples</p>
-          <ul className="claim-firewall-demo__list claim-firewall-demo__list--unsafe">
-            {unsafeWordingExamples.map((item, i) => (
-              <li key={i}>{item}</li>
-            ))}
-          </ul>
-        </article>
-      </div>
-
-      <article className="claim-firewall-demo__panel">
-        <div className="claim-firewall-demo__panel-head">
-          <p className="cockpit-eyebrow">Promotion requirements</p>
-          <span className="claim-firewall-demo__panel-status">EVIDENCE LINKAGE REQUIRED</span>
-        </div>
-        <ol className="claim-firewall-demo__requirements">
-          {promotionRequirements.map((item, i) => (
-            <li key={i}>
-              <span>{String(i + 1).padStart(2, "0")}</span>
-              {item}
-            </li>
-          ))}
-        </ol>
-      </article>
-
-      <article className="claim-firewall-demo__panel claim-firewall-demo__panel--timeline">
-        <div className="claim-firewall-demo__panel-head">
-          <div>
-            <p className="cockpit-eyebrow">Promotion gate timeline</p>
-            <h3 className="claim-firewall-demo__panel-title">Evidence moves before wording moves</h3>
-          </div>
-          <span className="claim-firewall-demo__panel-status">FAIL CLOSED</span>
-        </div>
-        <ol className="claim-firewall-demo__timeline">
-          {[
-            "Source truth",
-            "Validation truth",
-            "Runtime candidate",
-            "Signal / evidence review",
-            "Human approval",
-            "Public proof",
-          ].map((step, index) => (
-            <li key={step}>
-              <span>{String(index + 1).padStart(2, "0")}</span>
-              <strong>{step}</strong>
-            </li>
-          ))}
-        </ol>
-      </article>
-
-      <article className="claim-firewall-demo__panel claim-firewall-demo__panel--outcome">
-        <div className="claim-firewall-demo__panel-head">
-          <div>
-            <p className="cockpit-eyebrow">Outcome panel</p>
-            <h3 className="claim-firewall-demo__panel-title">What the firewall prevents</h3>
-          </div>
-          <span className="claim-firewall-demo__panel-status">AI LABOR / HUMAN AUTHORITY</span>
-        </div>
-        <ul className="claim-firewall-demo__outcomes" aria-label="Blocked claim transformations">
-          {blockedTransformations.map((item) => (
-            <li key={`${item.from}-${item.to}`}>
-              <span>{item.from}</span>
-              <strong aria-hidden="true">-&gt;</strong>
-              <span>{item.to}</span>
-              <em>blocked</em>
-            </li>
-          ))}
-        </ul>
-        <p className="claim-firewall-demo__outcome-copy">
-          AI-assisted security work can move fast, but public wording stays governed: the scanner
-          constrains unsupported language, then human review decides whether evidence is sufficient
-          for any explicit promotion.
+        <p className="cockpit-eyebrow" style={{ marginTop: 22 }}>
+          Allowed wording examples
         </p>
-      </article>
-
-      <article className="claim-firewall-demo__panel claim-firewall-demo__panel--allowed">
-        <div className="claim-firewall-demo__panel-head">
-          <p className="cockpit-eyebrow">Allowed claim basis</p>
-          <span className="claim-firewall-demo__panel-status">BELOW CEILING</span>
-        </div>
         <ul className="claim-firewall-demo__list claim-firewall-demo__list--allowed">
-          {allowedClaims.map((claim, i) => (
-            <li key={i}>{claim}</li>
+          {safeContexts.map((claim) => (
+            <li key={claim}>{claim}</li>
           ))}
         </ul>
-      </article>
+      </section>
+
+      <section className="claim-firewall-demo__panel" aria-labelledby="boundary-title">
+        <div className="claim-firewall-demo__panel-head">
+          <div>
+            <p className="cockpit-eyebrow">Proof Boundary</p>
+            <h2 id="boundary-title" className="claim-firewall-demo__panel-title">
+              The tool checks wording. It does not approve claims.
+            </h2>
+          </div>
+          <span className="claim-firewall-demo__panel-status">RENDERING_ONLY / TOOL_FUNCTION_ONLY</span>
+        </div>
+        <p className="claim-firewall-demo__boundary">
+          Claim Firewall checks wording against configured policy only.
+        </p>
+        <p className="claim-firewall-demo__boundary">
+          It does not prove detection behavior, runtime telemetry, signal observation, production deployment,
+          public release safety, customer rollout, service availability, AI approval, analyst approval, or final
+          human authorization.
+        </p>
+        <p className="claim-firewall-demo__boundary">
+          Website proof boundary: This website renders reviewer navigation only. Rendering is not proof authority.
+          The website rendering layer remains separate from evidence.
+        </p>
+        <ul className="claim-firewall-demo__list claim-firewall-demo__list--allowed">
+          <li>RENDERING_ONLY for this website page.</li>
+          <li>TOOL_FUNCTION_ONLY for Claim Firewall v0.1.0.</li>
+          <li>No public-safe proof is created by this page.</li>
+        </ul>
+      </section>
+
+      <section className="claim-firewall-demo__panel" aria-labelledby="fit-title">
+        <div className="claim-firewall-demo__panel-head">
+          <div>
+            <p className="cockpit-eyebrow">HawkinsOperations Fit</p>
+            <h2 id="fit-title" className="claim-firewall-demo__panel-title">
+              Utility only, authority stays separate
+            </h2>
+          </div>
+          <span className="claim-firewall-demo__panel-status">AUTHORITY MAP</span>
+        </div>
+        <div className="claim-firewall-demo__examples">
+          {authorityStack.map(([repo, role]) => (
+            <article key={repo} className="claim-firewall-demo__panel">
+              <p className="cockpit-eyebrow">{repo}</p>
+              <p className="claim-firewall-demo__boundary">{role}</p>
+            </article>
+          ))}
+        </div>
+        <p className="claim-firewall-demo__outcome-copy">
+          Claim Firewall supports claim hygiene. It does not approve claims. Evidence and human review decide truth.
+        </p>
+      </section>
+
+      <section className="claim-firewall-demo__panel claim-firewall-demo__panel--outcome" aria-labelledby="receipts-title">
+        <div className="claim-firewall-demo__panel-head">
+          <div>
+            <p className="cockpit-eyebrow">Receipts</p>
+            <h2 id="receipts-title" className="claim-firewall-demo__panel-title">
+              Public routes for reviewers
+            </h2>
+          </div>
+          <span className="claim-firewall-demo__panel-status">Outcome panel</span>
+        </div>
+        <ul className="claim-firewall-demo__outcomes" aria-label="Claim Firewall public receipts">
+          {receipts.map((receipt) => (
+            <li key={receipt.label}>
+              <span>{receipt.label}</span>
+              <strong aria-hidden="true">-&gt;</strong>
+              <a href={receipt.href} target="_blank" rel="noopener noreferrer">
+                {receipt.value}
+              </a>
+              <em>open</em>
+            </li>
+          ))}
+        </ul>
+        <ul className="claim-firewall-demo__list claim-firewall-demo__list--allowed">
+          <li>Ceiling: TOOL_FUNCTION_ONLY</li>
+          <li>Website status: RENDERING_ONLY</li>
+          <li>Evidence ceiling gauge: release routes are reviewer navigation, not proof promotion.</li>
+          <li>Promotion gate timeline: green CI is useful status, not approval.</li>
+          <li>AI support remains support. runtime candidate language stays below proof authority.</li>
+        </ul>
+      </section>
     </div>
   );
 }

--- a/components/ClaimFirewall.tsx
+++ b/components/ClaimFirewall.tsx
@@ -1,6 +1,12 @@
 const quickStartCommands = [
-  "python -m claimfirewall scan README.md --policy policy/blocked_claims.yml",
-  "claimfirewall scan README.md --policy policy/blocked_claims.yml",
+  {
+    label: "Python module",
+    command: "python -m claimfirewall scan README.md --policy policy/blocked_claims.yml",
+  },
+  {
+    label: "Console script",
+    command: "claimfirewall scan README.md --policy policy/blocked_claims.yml",
+  },
 ];
 
 const policyAreas = [
@@ -92,11 +98,14 @@ export default function ClaimFirewall() {
           </div>
           <span className="claim-firewall-demo__panel-status">CLI</span>
         </div>
-        <div className="claim-firewall-demo__examples">
-          {quickStartCommands.map((command) => (
-            <pre key={command} className="claim-firewall-demo__terminal">
-              <code>{command}</code>
-            </pre>
+        <div className="claim-firewall-demo__stack" style={{ display: "grid", gap: 16 }}>
+          {quickStartCommands.map((item) => (
+            <article key={item.label} className="claim-firewall-demo__panel">
+              <p className="cockpit-eyebrow">{item.label}</p>
+              <pre className="claim-firewall-demo__terminal" style={{ overflowX: "auto" }}>
+                <code>{item.command}</code>
+              </pre>
+            </article>
           ))}
         </div>
       </section>
@@ -135,8 +144,11 @@ export default function ClaimFirewall() {
               Gate public wording in CI
             </h2>
           </div>
-          <span className="claim-firewall-demo__panel-status">HawkinsOperations/claim-firewall@v0.1.0</span>
+          <span className="claim-firewall-demo__panel-status">ACTION GATE</span>
         </div>
+        <p className="claim-firewall-demo__boundary">
+          Drop the action into CI to block configured wording before public text ships.
+        </p>
         <pre className="claim-firewall-demo__terminal" aria-label="Claim Firewall GitHub Action example">
           <code>{`- uses: HawkinsOperations/claim-firewall@v0.1.0
   with:
@@ -222,7 +234,7 @@ export default function ClaimFirewall() {
         <ul className="claim-firewall-demo__list claim-firewall-demo__list--allowed">
           <li>RENDERING_ONLY for this website page.</li>
           <li>TOOL_FUNCTION_ONLY for Claim Firewall v0.1.0.</li>
-          <li>No public-safe proof is created by this page.</li>
+          <li>No public proof is created by this page.</li>
         </ul>
       </section>
 

--- a/public/.well-known/hawkinsoperations-proof.json
+++ b/public/.well-known/hawkinsoperations-proof.json
@@ -24,7 +24,7 @@
     {
       "id": "claim-firewall",
       "label": "Claim Firewall",
-      "url": "https://hawkinsoperations.com/controls/",
+      "url": "https://hawkinsoperations.com/claim-firewall/",
       "use": "Review the public wording gate that keeps website rendering below proof authority."
     },
     {

--- a/public/agent.md
+++ b/public/agent.md
@@ -7,7 +7,7 @@ This public website exposes read, review, and navigation metadata for agents and
 - `/.well-known/hawkinsoperations-proof.json`
 - `/.well-known/agent-skills/index.json`
 - `/proof/`
-- `/controls/`
+- `/claim-firewall/`
 - `/validation/`
 - `/architecture/truth-surfaces/`
 - `/architecture/repo-authority-map/`

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -7,6 +7,7 @@
   <url><loc>https://hawkinsoperations.com/artifacts/</loc></url>
   <url><loc>https://hawkinsoperations.com/about/</loc></url>
   <url><loc>https://hawkinsoperations.com/start/</loc></url>
+  <url><loc>https://hawkinsoperations.com/claim-firewall/</loc></url>
   <url><loc>https://hawkinsoperations.com/controls/</loc></url>
   <url><loc>https://hawkinsoperations.com/architecture/</loc></url>
   <url><loc>https://hawkinsoperations.com/architecture/truth-surfaces/</loc></url>

--- a/scripts/verify-site-contract.mjs
+++ b/scripts/verify-site-contract.mjs
@@ -16,6 +16,7 @@ const requiredFiles = [
   "app/architecture/page.tsx",
   "app/architecture/truth-surfaces/page.tsx",
   "app/repos/page.tsx",
+  "app/claim-firewall/page.tsx",
   "app/controls/page.tsx",
   "app/pipeline/page.tsx",
   "app/field-notes/page.tsx",
@@ -60,7 +61,7 @@ const primaryNavMatch = navigationData.match(/export const primaryNavigation: Na
 const expectedPrimaryNav = [
   { label: "Home", href: "/" },
   { label: "Proof", href: "/proof/" },
-  { label: "Controls", href: "/controls/" },
+  { label: "Claim Firewall", href: "/claim-firewall/" },
   { label: "Artifacts", href: "/artifacts/" },
   { label: "Detections", href: "/detections/" },
   { label: "AI Security", href: "/ai-security/" },
@@ -139,23 +140,25 @@ if (homepageLabelFailures.length > 0) {
 const proofPage = readFileSync(join(root, "app/proof/page.tsx"), "utf8");
 const proofHoDet001Page = readFileSync(join(root, "app/proof/ho-det-001/page.tsx"), "utf8");
 const currentProofSpine = readFileSync(join(root, "components/CurrentProofSpine.tsx"), "utf8");
+const claimFirewallPage = readFileSync(join(root, "app/claim-firewall/page.tsx"), "utf8");
 const controlsPage = readFileSync(join(root, "app/controls/page.tsx"), "utf8");
 const claimFirewallComponent = readFileSync(join(root, "components/ClaimFirewall.tsx"), "utf8");
 const proofRecordsData = readFileSync(join(root, "src/data/proofRecords.ts"), "utf8");
 const navigationSource = readFileSync(join(root, "src/data/navigation.ts"), "utf8");
 const claimFirewallFrontDoorRequiredTerms = [
-  ["src/data/navigation.ts", navigationSource, 'label: "Controls"'],
-  ["src/data/navigation.ts", navigationSource, 'href: "/controls/"'],
-  ["app/page.tsx", homePage, 'href="/controls/"'],
+  ["src/data/navigation.ts", navigationSource, 'label: "Claim Firewall"'],
+  ["src/data/navigation.ts", navigationSource, 'href: "/claim-firewall/"'],
+  ["app/page.tsx", homePage, 'href="/claim-firewall/"'],
   ["app/page.tsx", homePage, "Claim Firewall"],
   ["app/page.tsx", homePage, "Unsupported public security claims fail before they ship."],
   ["app/page.tsx", homePage, "Inspect Claim Firewall"],
-  ["app/proof/page.tsx", proofPage, 'href="/controls/"'],
   ["app/proof/page.tsx", proofPage, "Claim Firewall control surface"],
   ["app/proof/page.tsx", proofPage, "Open Claim Firewall"],
   ["app/proof/page.tsx", proofPage, "website rendering below proof authority"],
-  ["app/controls/page.tsx", controlsPage, "Website rendering is not proof"],
-  ["app/controls/page.tsx", controlsPage, "Public proof requires evidence linkage and explicit promotion."],
+  ["app/claim-firewall/page.tsx", claimFirewallPage, "Website rendering is not proof"],
+  ["app/claim-firewall/page.tsx", claimFirewallPage, "Public proof requires evidence linkage and explicit promotion."],
+  ["app/controls/page.tsx", controlsPage, 'href="/claim-firewall/"'],
+  ["app/controls/page.tsx", controlsPage, "Compatibility only"],
 ];
 const claimFirewallFrontDoorFailures = claimFirewallFrontDoorRequiredTerms
   .filter(([, source, term]) => !source.includes(term))
@@ -271,19 +274,19 @@ if (currentProofSpineFailures.length > 0) {
 }
 
 const claimFirewallVisualRequiredTerms = [
-  ["app/controls/page.tsx", controlsPage, "Claim Firewall"],
-  ["app/controls/page.tsx", controlsPage, "Public wording stays below the evidence ceiling"],
-  ["app/controls/page.tsx", controlsPage, "Website rendering is not proof"],
-  ["app/controls/page.tsx", controlsPage, "controls-hero"],
-  ["app/controls/page.tsx", controlsPage, "Unsupported security claims should fail before they reach the public page"],
-  ["app/controls/page.tsx", controlsPage, "WORDING"],
-  ["app/controls/page.tsx", controlsPage, "SCANNER"],
-  ["app/controls/page.tsx", controlsPage, "CEILING"],
-  ["app/controls/page.tsx", controlsPage, "PUBLIC WORDING ROUTE"],
-  ["app/controls/page.tsx", controlsPage, "public proof blocked"],
-  ["app/controls/page.tsx", controlsPage, "Public inspection layer"],
-  ["app/controls/page.tsx", controlsPage, "controls-hero__boundary-strip"],
-  ["app/controls/page.tsx", controlsPage, "Public proof requires evidence linkage and explicit promotion."],
+  ["app/claim-firewall/page.tsx", claimFirewallPage, "Claim Firewall"],
+  ["app/claim-firewall/page.tsx", claimFirewallPage, "Public wording stays below the evidence ceiling"],
+  ["app/claim-firewall/page.tsx", claimFirewallPage, "Website rendering is not proof"],
+  ["app/claim-firewall/page.tsx", claimFirewallPage, "controls-hero"],
+  ["app/claim-firewall/page.tsx", claimFirewallPage, "Unsupported security claims should fail before they reach the public page"],
+  ["app/claim-firewall/page.tsx", claimFirewallPage, "WORDING"],
+  ["app/claim-firewall/page.tsx", claimFirewallPage, "SCANNER"],
+  ["app/claim-firewall/page.tsx", claimFirewallPage, "CEILING"],
+  ["app/claim-firewall/page.tsx", claimFirewallPage, "PUBLIC WORDING ROUTE"],
+  ["app/claim-firewall/page.tsx", claimFirewallPage, "public proof blocked"],
+  ["app/claim-firewall/page.tsx", claimFirewallPage, "Release receipts"],
+  ["app/claim-firewall/page.tsx", claimFirewallPage, "controls-hero__boundary-strip"],
+  ["app/claim-firewall/page.tsx", claimFirewallPage, "Public proof requires evidence linkage and explicit promotion."],
   ["components/ClaimFirewall.tsx", claimFirewallComponent, "claim-firewall-demo"],
   ["components/ClaimFirewall.tsx", claimFirewallComponent, "Evidence ceiling gauge"],
   ["components/ClaimFirewall.tsx", claimFirewallComponent, "Blocked / not claimed"],
@@ -296,7 +299,7 @@ const claimFirewallVisualRequiredTerms = [
   ["components/ClaimFirewall.tsx", claimFirewallComponent, "green CI"],
   ["components/ClaimFirewall.tsx", claimFirewallComponent, "AI support"],
   ["components/ClaimFirewall.tsx", claimFirewallComponent, "runtime candidate"],
-  ["components/ClaimFirewall.tsx", claimFirewallComponent, "public-safe proof"],
+  ["components/ClaimFirewall.tsx", claimFirewallComponent, "No public proof is created by this page"],
 ];
 const claimFirewallVisualFailures = claimFirewallVisualRequiredTerms
   .filter(([, source, term]) => !source.includes(term))
@@ -331,11 +334,11 @@ if (!Array.isArray(discoveryProof.blocked_claims) || !discoveryProof.blocked_cla
 if (!Array.isArray(discoveryProof.reviewer_routes) || discoveryProof.reviewer_routes.length < 4) {
   discoveryFailures.push("public/.well-known/hawkinsoperations-proof.json must expose reviewer_routes for machine-readable navigation.");
 }
-if (!discoveryProof.reviewer_routes?.some((route) => route.id === "claim-firewall" && route.url === "https://hawkinsoperations.com/controls/")) {
-  discoveryFailures.push("public/.well-known/hawkinsoperations-proof.json must expose /controls/ as the claim-firewall reviewer route.");
+if (!discoveryProof.reviewer_routes?.some((route) => route.id === "claim-firewall" && route.url === "https://hawkinsoperations.com/claim-firewall/")) {
+  discoveryFailures.push("public/.well-known/hawkinsoperations-proof.json must expose /claim-firewall/ as the claim-firewall reviewer route.");
 }
-if (!agentMarkdown.includes("/controls/")) {
-  discoveryFailures.push("public/agent.md must list /controls/ as a public entry point.");
+if (!agentMarkdown.includes("/claim-firewall/")) {
+  discoveryFailures.push("public/agent.md must list /claim-firewall/ as a public entry point.");
 }
 if (agentSkills.agent_capability_boundary !== "read_review_navigation_only") {
   discoveryFailures.push("public/.well-known/agent-skills/index.json must cap agent_capability_boundary at read_review_navigation_only.");

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -7,7 +7,7 @@ export type NavItem = {
 export const primaryNavigation: NavItem[] = [
   { label: "Home", href: "/", description: "Reviewer cockpit" },
   { label: "Proof", href: "/proof/", description: "Claim authority" },
-  { label: "Controls", href: "/controls/", description: "Claim Firewall" },
+  { label: "Claim Firewall", href: "/claim-firewall/", description: "Public utility satellite" },
   { label: "Artifacts", href: "/artifacts/", description: "Reviewer receipts" },
   { label: "Detections", href: "/detections/", description: "Detection engineering" },
   { label: "AI Security", href: "/ai-security/", description: "AI-assisted SOC model" },


### PR DESCRIPTION
## Summary

This PR promotes Claim Firewall from the legacy `/controls/` route into a first-class product page at `/claim-firewall/`.

It keeps `/controls/` as a compatibility route, updates navigation and homepage routing, and redesigns the page as a product-first public utility surface for Claim Firewall v0.1.0.

## What changed

* Added canonical `/claim-firewall/` product page
* Kept `/controls/` as legacy compatibility route
* Updated primary navigation to use Claim Firewall
* Updated homepage Claim Firewall routing
* Reworked the page around product utility, quick start commands, GitHub Action usage, claim transformation examples, proof boundaries, HawkinsOperations fit, and reviewer receipts
* Preserved website proof ceiling as `RENDERING_ONLY`
* Preserved Claim Firewall utility ceiling as `TOOL_FUNCTION_ONLY`

## Validation

* `npm run typecheck`
* `npm run check:site`
* `npm run build`
* Em dash search: no matches in changed files and logbook
* Old-name search: no `claimlint` matches
* Blocked-term search reviewed for explicit non-claim and verifier contexts

## Proof boundary

This website page renders reviewer navigation only.

It does not create proof authority, runtime proof, signal proof, production proof, public release approval, service availability, customer rollout evidence, AI approval authority, analyst approval authority, or final human authorization.

## Review notes

Manual visual review is still required before merge.