### PR TITLE
Polish Claim Firewall public website surface

### DIFF
--- a/app/architecture/page.tsx
+++ b/app/architecture/page.tsx
@@ -54,7 +54,7 @@ export default function ArchitecturePage() {
           description="The website can host stable data attributes for scanners, but enforcement still lives in repositories, workflows, and promotion gates."
         />
         <div className="grid gap-4 md:grid-cols-3">
-          <LinkCard href="/controls/" title="Claim firewall" description="Allowed claims, blocked terms, and wording examples." />
+          <LinkCard href="/claim-firewall/" title="Claim Firewall" description="Allowed claims, blocked terms, and wording examples." />
           <LinkCard href="/repos/" title="Repository map" description="Where each proof plane lives." />
           <LinkCard href="/proof/" title="Proof ledger" description="The flagship HO-DET-001 record and current ceiling." />
         </div>

--- a/app/proof/governance-saves/page.tsx
+++ b/app/proof/governance-saves/page.tsx
@@ -78,7 +78,7 @@ export default function GovernanceSavesPage() {
           <div className="grid gap-4 md:grid-cols-4">
             <LinkCard href="/proof/" title="Proof ledger" description="Return to proof authority and current promotion gates." />
             <LinkCard href="/ai-security/" title="AI Security model" description="See how governance saves map to AI Security Operations." />
-            <LinkCard href="/controls/" title="Claim firewall" description="Inspect the control surface for blocked wording." />
+            <LinkCard href="/claim-firewall/" title="Claim Firewall" description="Inspect the control surface for blocked wording." />
             <LinkCard href={externalLinks.governanceSavesCandidates} title="Governance saves source" description="Open the source-controlled candidate ledger." external />
           </div>
         </div>

--- a/app/proof/ho-det-001/page.tsx
+++ b/app/proof/ho-det-001/page.tsx
@@ -56,7 +56,7 @@ const traceSteps: ProofPathStep[] = [
     code: "HUMAN_REVIEW_GATE",
     label: "Human review gate",
     line: "Human review authorizes any stronger claim movement; green checks and rendering do not.",
-    href: "/controls/",
+    href: "/claim-firewall/",
   },
   {
     code: "PROOF_AUTHORITY",

--- a/app/proof/page.tsx
+++ b/app/proof/page.tsx
@@ -210,7 +210,7 @@ export default function ProofIndexPage() {
             </h2>
           </div>
           <div className="grid gap-3 md:grid-cols-4">
-            <a className="artifact-tile" href="/controls/">
+            <a className="artifact-tile" href="/claim-firewall/">
               <span className="artifact-tile__cat">CLAIM FIREWALL</span>
               <span className="artifact-tile__title">Claim Firewall control surface</span>
               <span className="artifact-tile__desc">

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -20,7 +20,6 @@ const staticRoutes = [
   "/platform/contracts/",
   "/start/",
   "/claim-firewall/",
-  "/controls/",
   "/architecture/",
   "/architecture/truth-surfaces/",
   "/architecture/repo-authority-map/",

--- a/components/CodexIndex.tsx
+++ b/components/CodexIndex.tsx
@@ -5,7 +5,7 @@ const routes = [
   { title: "Proof ledger", href: "/proof/", description: "Inspect the HO-DET-001 proof card and current proof ceiling." },
   { title: "Truth surface model", href: "/architecture/truth-surfaces/", description: "Separate source, validation, runtime, signal, evidence, and public proof." },
   { title: "Repository map", href: "/repos/", description: "See which repository owns each trust surface." },
-  { title: "Claim firewall", href: "/controls/", description: "Review allowed claims, blocked claims, and promotion requirements." },
+  { title: "Claim Firewall", href: "/claim-firewall/", description: "Review allowed claims, blocked claims, and promotion requirements." },
   { title: "Field notes", href: "/field-notes/", description: "Read the technical archive behind the proof boundary." },
 ];
 

--- a/components/CurrentProofSpine.tsx
+++ b/components/CurrentProofSpine.tsx
@@ -98,8 +98,8 @@ const proofSpineCards: ProofSpineCard[] = [
       "Maintains blocked-claim controls, reviewer routing, PR review rituals, and proof-boundary enforcement surfaces.",
     doesNotProve:
       "Does not make GitHub Project metadata, website rendering, runtime truth, or signal truth into proof.",
-    routeLabel: "Open controls",
-    routeHref: "/controls/",
+    routeLabel: "Open Claim Firewall",
+    routeHref: "/claim-firewall/",
     tier: "supporting",
   },
   {

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -74,6 +74,11 @@ export default function Footer() {
               </a>
             </li>
             <li>
+              <a href={externalLinks.claimFirewall} target="_blank" rel="noopener noreferrer">
+                Claim Firewall ↗
+              </a>
+            </li>
+            <li>
               <a href={externalLinks.rayleeGithub} target="_blank" rel="noopener noreferrer">
                 Raylee Hawkins ↗
               </a>

--- a/components/PipelineGateCards.tsx
+++ b/components/PipelineGateCards.tsx
@@ -29,7 +29,7 @@ const cards: Card[] = [
     tech: "Blocked terms remain visible as blocked claims but cannot silently become public assertions.",
     plain: "The system can discuss what is blocked without accidentally claiming it.",
     variant: "red",
-    href: "/controls/",
+    href: "/claim-firewall/",
     hrefLabel: "Open the claim firewall →",
   },
   {

--- a/components/WorkDashboard.tsx
+++ b/components/WorkDashboard.tsx
@@ -57,7 +57,7 @@ const counters: Counter[] = [
     value: String(blockedClaims.length),
     label: "blocked claims kept visible",
     meaning: "Runtime, signal, and stronger claims shown as blocked, not hidden.",
-    href: "/controls/",
+    href: "/claim-firewall/",
   },
 ];
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -8,7 +8,6 @@
   <url><loc>https://hawkinsoperations.com/about/</loc></url>
   <url><loc>https://hawkinsoperations.com/start/</loc></url>
   <url><loc>https://hawkinsoperations.com/claim-firewall/</loc></url>
-  <url><loc>https://hawkinsoperations.com/controls/</loc></url>
   <url><loc>https://hawkinsoperations.com/architecture/</loc></url>
   <url><loc>https://hawkinsoperations.com/architecture/truth-surfaces/</loc></url>
   <url><loc>https://hawkinsoperations.com/legacy/</loc></url>

--- a/src/data/artifactMachine.ts
+++ b/src/data/artifactMachine.ts
@@ -57,7 +57,7 @@ export const artifactStages: ArtifactStage[] = [
     supports: "Supports faster labor only — drafting, scaffolding, and reviewer prep.",
     bounded: "AI cannot promote a claim. No AI-approved disposition.",
     nextGate: "Deterministic verifier scans the wording before it can advance.",
-    link: { label: "Claim firewall", href: "/controls/" },
+    link: { label: "Claim Firewall", href: "/claim-firewall/" },
   },
   {
     id: "verifier",

--- a/src/data/artifacts.ts
+++ b/src/data/artifacts.ts
@@ -266,7 +266,7 @@ export const artifacts: Artifact[] = [
     description: "Allowed wording, blocked wording, and the wording examples that route safe claims through promotion gates.",
     proves: "The supported public ceiling and the explicit list of claims kept off the public surface.",
     doesNotProve: "That blocked claims are merely pending; some remain blocked by design.",
-    primary: { label: "Open firewall", href: "/controls/" },
+    primary: { label: "Open Claim Firewall", href: "/claim-firewall/" },
     tags: ["claims", "governance"],
   },
   {
@@ -375,7 +375,7 @@ export const artifacts: Artifact[] = [
     description: "The current public list of claims kept off the rendering layer until separate evidence-backed promotion changes their state.",
     proves: "Reviewers can see what is blocked, not just what is supported.",
     doesNotProve: "Hidden claims; the blocked list is intentionally visible.",
-    primary: { label: "Open firewall", href: "/controls/" },
+    primary: { label: "Open Claim Firewall", href: "/claim-firewall/" },
     secondary: { label: "Why blocked claims help", href: "/field-notes/why-blocked-claims-increase-credibility/" },
     tags: ["claims", "blocked"],
   },

--- a/src/data/fieldNotes.ts
+++ b/src/data/fieldNotes.ts
@@ -61,7 +61,7 @@ export const fieldNotes: FieldNote[] = [
     tags: ["claims", "review", "credibility"],
     summary: "Showing what is blocked makes the supported claim easier to trust.",
     proofBoundary: "Blocked promotions are intentionally visible.",
-    relatedLinks: [{ label: "Claim firewall", href: "/controls/" }],
+    relatedLinks: [{ label: "Claim Firewall", href: "/claim-firewall/" }],
     body: [
       "A proof system is stronger when it names what has not been proven.",
       "The claim firewall prevents a good validation result from being stretched into runtime, signal, or public proof language.",

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -36,6 +36,7 @@ export const externalLinks = {
   validation: "https://github.com/HawkinsOperations/hawkinsoperations-validation",
   platform: "https://github.com/HawkinsOperations/hawkinsoperations-platform",
   proof: "https://github.com/HawkinsOperations/hawkinsoperations-proof",
+  claimFirewall: "https://github.com/HawkinsOperations/claim-firewall",
   governanceSavesCandidates: "https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/docs/governance-saves/GOVERNANCE-SAVES-CANDIDATES.md",
   governanceSavesEvidenceMatrix: "https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/docs/governance-saves/GOVERNANCE-SAVES-EVIDENCE-MATRIX.md",
   platformDetectionFactoryController: "https://github.com/HawkinsOperations/hawkinsoperations-platform/blob/main/docs/factory/DETECTION_FACTORY_CONTROLLER_V0.md",

--- a/src/data/repos.ts
+++ b/src/data/repos.ts
@@ -51,6 +51,14 @@ export const repos: RepoRecord[] = [
     doesNotProve: "Unlinked runtime state or claims outside the record.",
   },
   {
+    name: "claim-firewall",
+    href: externalLinks.claimFirewall,
+    purpose: "Local CLI and GitHub Action for scanning public wording against configured claim policy.",
+    truthSurface: "Claim policy tooling",
+    owns: "Tool behavior, policy examples, and release artifacts for wording scans.",
+    doesNotProve: "Runtime telemetry, signal observation, deployment state, or claim approval.",
+  },
+  {
     name: "hawkinsoperations-website",
     href: externalLinks.website,
     purpose: "Public rendering, reviewer navigation, and claim-boundary presentation.",

--- a/src/data/reviewerRoutes.ts
+++ b/src/data/reviewerRoutes.ts
@@ -83,7 +83,7 @@ export const reviewerRoutes: ReviewerRoute[] = [
     ],
     links: [
       { label: "LLM boundary", href: "/pipeline/#llm-boundary" },
-      { label: "Claim firewall", href: "/controls/" },
+      { label: "Claim Firewall", href: "/claim-firewall/" },
       { label: "Control matrix", href: externalLinks.controlMatrix, external: true },
     ],
   },

--- a/src/data/truthSurfaces.ts
+++ b/src/data/truthSurfaces.ts
@@ -41,7 +41,7 @@ export const truthSurfaces: TruthSurface[] = [
     doesNotProve: "Signal observation, evidence linkage, or public-safe proof.",
     promotesBy: "Current runtime evidence with a bounded trust class.",
     blockedBy: "Private-only evidence, stale host state, or unreviewed telemetry.",
-    exampleArtifact: { label: "Runtime stays blocked — claim firewall", href: "/controls/" },
+    exampleArtifact: { label: "Runtime stays blocked — Claim Firewall", href: "/claim-firewall/" },
   },
   {
     name: "Signal Truth",
@@ -51,7 +51,7 @@ export const truthSurfaces: TruthSurface[] = [
     doesNotProve: "Fleet scope, production readiness, or public-safe status.",
     promotesBy: "Signal artifacts tied to time, source, and validation records.",
     blockedBy: "No event record, unclear source, or non-public evidence limits.",
-    exampleArtifact: { label: "Signal stays blocked — claim firewall", href: "/controls/" },
+    exampleArtifact: { label: "Signal stays blocked — Claim Firewall", href: "/claim-firewall/" },
   },
   {
     name: "Evidence Truth",


### PR DESCRIPTION
## Summary
- Routes Claim Firewall-facing website links to `/claim-firewall/`
- Keeps `/controls/` as compatibility-only and removes it from sitemap discovery
- Adds the Claim Firewall repository to public footer/repository metadata
- Normalizes Claim Firewall labels across reviewer/product surfaces

## Validation
- npm run typecheck: pass
- npm run check:site: pass
- npm run build: pass
- git diff --check: pass, with line-ending normalization warnings only

## Proof Boundary
Website changes are RENDERING_ONLY.
Claim Firewall references are TOOL_FUNCTION_ONLY.

## Non-claims
This PR does not create runtime proof, signal proof, public-safe proof, production deployment evidence, customer rollout evidence, AI approval, analyst approval, or final human authorization.