### PR TITLE
Re-anchor website around AevumGuard

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -20,5 +20,5 @@ Repository: `hawkinsoperations-website`
 
 - Required governance files must exist.
 - CI gate must pass before merge.
-- Public-safe output only; internal control-plane data stays out.
+- Public rendering output only; internal control-plane data stays out.
 

--- a/app/aevumguard/page.tsx
+++ b/app/aevumguard/page.tsx
@@ -1,0 +1,84 @@
+import type { Metadata } from "next";
+import BoundaryNotice from "@components/BoundaryNotice";
+import LinkCard from "@components/LinkCard";
+import PageHero from "@components/PageHero";
+import SectionHeader from "@components/SectionHeader";
+import { externalLinks } from "@data/navigation";
+
+const productLoop = [
+  "AI-assisted security work",
+  "Artifact Intake",
+  "Evidence Graph",
+  "Telemetry Contract Check",
+  "Controlled Validation",
+  "Runtime Candidate Ledger",
+  "Signal Observation",
+  "Human Review Gate",
+  "ProofCard",
+  "Claim Authority",
+  "Safe Claim / Blocked Claim",
+];
+
+export const metadata: Metadata = {
+  title: "AevumGuard | HawkinsOperations",
+  description:
+    "AevumGuard governs how AI-assisted security work becomes tested, reviewed, blocked, or safe to claim.",
+  alternates: {
+    canonical: "/aevumguard/",
+  },
+};
+
+export default function AevumGuardPage() {
+  return (
+    <>
+      <PageHero
+        title="AevumGuard"
+        subtitle="ProofOps control for the AI security era."
+        description="AevumGuard governs how AI-assisted security work becomes tested, reviewed, blocked, or safe to claim."
+        badges={[{ label: "PRODUCT_FRONT_DOOR" }, { label: "RENDERING_ONLY" }]}
+      />
+
+      <section className="cockpit-section--tight">
+        <div className="container reveal reveal--up">
+          <SectionHeader title="Product Doctrine" eyebrow="AevumGuard" />
+          <p className="muted mt-3 max-w-3xl text-sm leading-6">
+            AI is not the authority. Evidence is. HawkinsOperations is the brand/system;
+            AevumGuard is the product/front-door repo for the governed product experience.
+          </p>
+          <div className="mt-6 grid gap-4 md:grid-cols-2">
+            <LinkCard
+              href={externalLinks.aevumguard}
+              title="AevumGuard repo"
+              description="Product front-door repo for AevumGuard and Claim Authority capabilities."
+              external
+            />
+            <LinkCard
+              href="/claim-firewall/"
+              title="Claim Firewall capability"
+              description="Legacy capability route for the internal AevumGuard Claim Authority wording enforcement edge."
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="cockpit-section--tight">
+        <div className="container reveal reveal--up">
+          <SectionHeader title="Core Loop" eyebrow="Product flow" />
+          <ol className="claim-firewall-demo__outcomes" aria-label="AevumGuard core loop">
+            {productLoop.map((step, index) => (
+              <li key={step}>
+                <span>{String(index + 1).padStart(2, "0")}</span>
+                <strong>{step}</strong>
+                <em>{index === productLoop.length - 1 ? "claim state" : "next"}</em>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </section>
+
+      <section className="container cockpit-section--tight">
+        <BoundaryNotice text="RENDERING_ONLY: this page changes public website wording and routing only. Runtime, signal, public-safe, production, customer, SOCaaS, autonomous SOC, AI-approved, analyst-approved, and case-closed claims remain blocked / not claimed." />
+      </section>
+    </>
+  );
+}

--- a/app/artifacts/[slug]/page.tsx
+++ b/app/artifacts/[slug]/page.tsx
@@ -11,7 +11,7 @@ import { ceiling, publicSafe } from "@config/site";
 /**
  * /artifacts/[slug]/page.tsx
  *
- * Public-safe reviewer detail page for one recent governed work
+ * Public reviewer detail page for one recent governed work
  * artifact. Static-export compatible (generateStaticParams pre-renders
  * one page per slug). No fetch, no GitHub API call.
  *
@@ -147,7 +147,7 @@ export default function ArtifactReviewPage({ params }: { params: { slug: string 
               </div>
             </div>
             <p className="artifact-review__boundary-note">
-              This page is a public-safe reviewer surface. The artifact is a hand-maintained static
+              This page is a public reviewer surface. The artifact is a hand-maintained static
               snapshot taken on {recentGovernedArtifactsSnapshotDate}. It is not auto-updated, does
               not claim runtime-active or signal-observed status, and does not prove public-safe
               runtime proof, GPU CI proven status, model execution in CI, AI-approved disposition,

--- a/app/claim-firewall/page.tsx
+++ b/app/claim-firewall/page.tsx
@@ -4,9 +4,9 @@ import ClaimFirewall from "@components/ClaimFirewall";
 const cliCommand = "python -m claimfirewall scan README.md --policy policy/blocked_claims.yml";
 
 export const metadata: Metadata = {
-  title: "Claim Firewall | HawkinsOperations",
+  title: "Claim Firewall capability | HawkinsOperations",
   description:
-    "Claim Firewall is a HawkinsOperations public utility that scans security docs, PR text, README files, YAML files, and public-facing Markdown for unsupported claims before they ship.",
+    "Claim Firewall is an internal AevumGuard Claim Authority enforcement capability for checking unsupported public wording. It is not the product or a separate repo.",
   alternates: {
     canonical: "/claim-firewall/",
   },
@@ -18,45 +18,37 @@ export default function ClaimFirewallPage() {
       <section className="controls-hero" aria-labelledby="claim-firewall-title">
         <div className="container controls-hero__grid">
           <div className="controls-hero__copy">
-            <p className="cockpit-eyebrow">Public utility satellite</p>
+            <p className="cockpit-eyebrow">AevumGuard Claim Authority capability</p>
             <h1 id="claim-firewall-title" className="controls-hero__title">
               Claim Firewall
             </h1>
             <p className="controls-hero__lede">
-              Block unsupported security claims before they ship.
+              Claim Firewall is a wording enforcement edge inside AevumGuard.
             </p>
             <p className="controls-hero__lede">
-              Claim Firewall is a small CLI and GitHub Action that scans security docs, PR text,
-              README files, YAML files, and public-facing Markdown for wording that outruns evidence.
+              AevumGuard governs how AI-assisted security work becomes tested, reviewed, blocked, or safe to claim.
+              Claim Firewall remains TOOL_FUNCTION_ONLY unless evidence expands.
             </p>
-            <div className="controls-hero__pills" aria-label="Claim Firewall product status">
-              <span>v0.1.0 released</span>
-              <span>CI passed</span>
+            <div className="controls-hero__pills" aria-label="Claim Firewall capability status">
+              <span>Internal AevumGuard capability</span>
+              <span>Claim Authority enforcement</span>
               <span>TOOL_FUNCTION_ONLY</span>
               <span>RENDERING_ONLY website page</span>
               <span>CLI</span>
-              <span>GitHub Action</span>
               <span>Policy as code</span>
             </div>
           </div>
 
           <aside className="controls-hero__rail" aria-label="Claim Firewall release receipts">
-            <span className="controls-hero__rail-label">Release receipts</span>
-            <p>Repo, release, and announcement are public reviewer routes for the v0.1.0 utility.</p>
-            <p>Website rendering is not proof authority. Claim Firewall supports claim hygiene only.</p>
+            <span className="controls-hero__rail-label">Product boundary</span>
+            <p>AevumGuard is the product/front-door repo. Claim Firewall is not the product, platform, front-door repo, or an eighth repo.</p>
+            <p>Website rendering is not proof authority. Claim Firewall supports claim hygiene only as an internal capability.</p>
             <div className="controls-hero__pills" aria-label="Claim Firewall external links">
-              <a href="https://github.com/HawkinsOperations/claim-firewall" target="_blank" rel="noopener noreferrer">
-                <span>View repo</span>
-              </a>
-              <a
-                href="https://github.com/HawkinsOperations/claim-firewall/releases/tag/v0.1.0"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <span>Open release</span>
+              <a href="https://github.com/HawkinsOperations/aevumguard" target="_blank" rel="noopener noreferrer">
+                <span>View AevumGuard</span>
               </a>
               <a href="https://github.com/orgs/HawkinsOperations/discussions/51" target="_blank" rel="noopener noreferrer">
-                <span>Read announcement</span>
+                <span>Historical announcement</span>
               </a>
             </div>
           </aside>
@@ -83,13 +75,13 @@ export default function ClaimFirewallPage() {
               <div className="controls-hero__node controls-hero__node--ceiling">
                 <span>03</span>
                 <strong>CEILING</strong>
-                <p>Unsafe product claims are blocked. Safer wording stays behind evidence.</p>
+                <p>Unsafe public claims are blocked. Safer wording stays behind evidence.</p>
               </div>
             </div>
             <pre className="claim-firewall-demo__terminal" aria-label="Visible CLI command">
               <code>{cliCommand}</code>
             </pre>
-            <div className="controls-hero__meter" aria-label="Product capability summary">
+            <div className="controls-hero__meter" aria-label="AevumGuard capability summary">
               <span>scan files</span>
               <span>scan dirs</span>
               <span>text output</span>

--- a/app/controls/page.tsx
+++ b/app/controls/page.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Claim Firewall moved | HawkinsOperations",
+  title: "Controls compatibility route | HawkinsOperations",
   description:
-    "The Claim Firewall product page now lives at /claim-firewall/. The legacy /controls/ route remains for compatibility.",
+    "The /controls/ route remains as a compatibility page. AevumGuard is the product front door; Claim Firewall is an internal Claim Authority capability.",
   alternates: {
-    canonical: "/claim-firewall/",
+    canonical: "/aevumguard/",
   },
 };
 
@@ -16,17 +16,20 @@ export default function ControlsPage() {
         <div className="controls-hero__copy">
           <p className="cockpit-eyebrow">Legacy route</p>
           <h1 id="legacy-controls-title" className="controls-hero__title">
-            Claim Firewall moved
+            Controls moved under AevumGuard
           </h1>
           <p className="controls-hero__lede">
-            The Claim Firewall product page now lives at /claim-firewall/.
+            AevumGuard is the HawkinsOperations product front door for governed AI-assisted security work.
           </p>
           <p className="controls-hero__lede">
-            This /controls/ route remains as a compatibility page for older reviewer links.
+            Claim Firewall remains an internal AevumGuard Claim Authority enforcement capability. This /controls/ route remains as a compatibility page for older reviewer links.
           </p>
-          <div className="controls-hero__pills" aria-label="Claim Firewall moved route">
+          <div className="controls-hero__pills" aria-label="Controls compatibility route">
+            <a href="/aevumguard/">
+              <span>Open AevumGuard</span>
+            </a>
             <a href="/claim-firewall/">
-              <span>Open Claim Firewall</span>
+              <span>Legacy capability route</span>
             </a>
             <span>RENDERING_ONLY website page</span>
           </div>
@@ -34,7 +37,7 @@ export default function ControlsPage() {
         <aside className="controls-hero__rail" aria-label="Legacy route boundary">
           <span className="controls-hero__rail-label">Compatibility only</span>
           <p>Website rendering is not proof authority. This route does not approve claims.</p>
-          <p>Claim Firewall checks wording policy only on the canonical product page.</p>
+          <p>Claim Firewall checks wording policy only as a TOOL_FUNCTION_ONLY capability inside AevumGuard.</p>
         </aside>
       </div>
     </section>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -5,6 +5,7 @@ import { recentGovernedArtifacts } from "@data/recentGovernedArtifacts";
 
 const staticRoutes = [
   "/",
+  "/aevumguard/",
   "/proof/",
   "/artifacts/",
   "/detections/",
@@ -19,7 +20,6 @@ const staticRoutes = [
   "/validation/",
   "/platform/contracts/",
   "/start/",
-  "/claim-firewall/",
   "/architecture/",
   "/architecture/truth-surfaces/",
   "/architecture/repo-authority-map/",

--- a/app/start/page.tsx
+++ b/app/start/page.tsx
@@ -20,7 +20,7 @@ const intakeRoutes = [
   {
     num: "02",
     title: "Review artifacts",
-    sub: "Open the artifact vault. Each recent governed work item routes to a public-safe reviewer review page.",
+    sub: "Open the artifact vault. Each recent governed work item routes to a bounded public review page.",
     href: "/artifacts/#recent-governed-work",
     variant: "default" as const,
   },
@@ -153,7 +153,7 @@ export default function StartPage() {
         <div className="container reveal reveal--up">
           <RecentGovernedArtifacts
             heading="Recent governed work · snapshot"
-            sub="Hand-maintained static snapshot of recent governed work. Each card opens a public-safe reviewer review page."
+            sub="Hand-maintained static snapshot of recent governed work. Each card opens a bounded public review page."
             limit={6}
           />
         </div>

--- a/components/ClaimFirewall.tsx
+++ b/components/ClaimFirewall.tsx
@@ -59,29 +59,20 @@ const authorityStack = [
   ["platform", "control mechanics"],
   ["proof", "proof and claim authority"],
   ["website", "rendering only"],
-  ["claim-firewall", "utility only"],
+  ["aevumguard", "product front door"],
+  ["Claim Firewall", "internal AevumGuard capability"],
 ] as const;
 
 const receipts = [
   {
-    label: "Repo",
-    value: "HawkinsOperations/claim-firewall",
-    href: "https://github.com/HawkinsOperations/claim-firewall",
-  },
-  {
-    label: "Release v0.1.0",
-    value: "GitHub release",
-    href: "https://github.com/HawkinsOperations/claim-firewall/releases/tag/v0.1.0",
+    label: "Product repo",
+    value: "HawkinsOperations/aevumguard",
+    href: "https://github.com/HawkinsOperations/aevumguard",
   },
   {
     label: "Announcement",
     value: "HawkinsOperations discussion",
     href: "https://github.com/orgs/HawkinsOperations/discussions/51",
-  },
-  {
-    label: "CI",
-    value: "Actions",
-    href: "https://github.com/HawkinsOperations/claim-firewall/actions",
   },
 ];
 
@@ -147,10 +138,10 @@ export default function ClaimFirewall() {
           <span className="claim-firewall-demo__panel-status">ACTION GATE</span>
         </div>
         <p className="claim-firewall-demo__boundary">
-          Drop the action into CI to block configured wording before public text ships.
+          Run the AevumGuard Claim Authority scanner in CI to block configured wording before public text ships.
         </p>
         <pre className="claim-firewall-demo__terminal" aria-label="Claim Firewall GitHub Action example">
-          <code>{`- uses: HawkinsOperations/claim-firewall@v0.1.0
+          <code>{`- run: python -m claimfirewall scan . --policy policy/blocked_claims.yml
   with:
     paths: "."
     format: "text"
@@ -220,7 +211,7 @@ export default function ClaimFirewall() {
           <span className="claim-firewall-demo__panel-status">RENDERING_ONLY / TOOL_FUNCTION_ONLY</span>
         </div>
         <p className="claim-firewall-demo__boundary">
-          Claim Firewall checks wording against configured policy only.
+          Claim Firewall is an internal AevumGuard Claim Authority enforcement capability that checks wording against configured policy only.
         </p>
         <p className="claim-firewall-demo__boundary">
           It does not prove detection behavior, runtime telemetry, signal observation, production deployment,
@@ -233,7 +224,7 @@ export default function ClaimFirewall() {
         </p>
         <ul className="claim-firewall-demo__list claim-firewall-demo__list--allowed">
           <li>RENDERING_ONLY for this website page.</li>
-          <li>TOOL_FUNCTION_ONLY for Claim Firewall v0.1.0.</li>
+          <li>TOOL_FUNCTION_ONLY for the Claim Firewall capability inside AevumGuard.</li>
           <li>No public proof is created by this page.</li>
         </ul>
       </section>
@@ -257,7 +248,7 @@ export default function ClaimFirewall() {
           ))}
         </div>
         <p className="claim-firewall-demo__outcome-copy">
-          Claim Firewall supports claim hygiene. It does not approve claims. Evidence and human review decide truth.
+          Claim Firewall supports claim hygiene as an AevumGuard capability. It does not approve claims. Evidence and human review decide truth.
         </p>
       </section>
 

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -74,8 +74,8 @@ export default function Footer() {
               </a>
             </li>
             <li>
-              <a href={externalLinks.claimFirewall} target="_blank" rel="noopener noreferrer">
-                Claim Firewall ↗
+              <a href={externalLinks.aevumguard} target="_blank" rel="noopener noreferrer">
+                AevumGuard ↗
               </a>
             </li>
             <li>

--- a/public/.well-known/hawkinsoperations-proof.json
+++ b/public/.well-known/hawkinsoperations-proof.json
@@ -22,10 +22,10 @@
       "use": "Review public proof navigation, verifier cards, and claim ceilings."
     },
     {
-      "id": "claim-firewall",
-      "label": "Claim Firewall",
-      "url": "https://hawkinsoperations.com/claim-firewall/",
-      "use": "Review the public wording gate that keeps website rendering below proof authority."
+      "id": "aevumguard",
+      "label": "AevumGuard",
+      "url": "https://hawkinsoperations.com/aevumguard/",
+      "use": "Review the product front door and Claim Authority boundary without inferring runtime or signal truth."
     },
     {
       "id": "validation-registry",

--- a/public/agent.md
+++ b/public/agent.md
@@ -7,7 +7,7 @@ This public website exposes read, review, and navigation metadata for agents and
 - `/.well-known/hawkinsoperations-proof.json`
 - `/.well-known/agent-skills/index.json`
 - `/proof/`
-- `/claim-firewall/`
+- `/aevumguard/`
 - `/validation/`
 - `/architecture/truth-surfaces/`
 - `/architecture/repo-authority-map/`

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,11 +3,11 @@
   <url><loc>https://hawkinsoperations.com/</loc></url>
   <url><loc>https://hawkinsoperations.com/pipeline/</loc></url>
   <url><loc>https://hawkinsoperations.com/proof/</loc></url>
+  <url><loc>https://hawkinsoperations.com/aevumguard/</loc></url>
   <url><loc>https://hawkinsoperations.com/proof/ho-det-001/</loc></url>
   <url><loc>https://hawkinsoperations.com/artifacts/</loc></url>
   <url><loc>https://hawkinsoperations.com/about/</loc></url>
   <url><loc>https://hawkinsoperations.com/start/</loc></url>
-  <url><loc>https://hawkinsoperations.com/claim-firewall/</loc></url>
   <url><loc>https://hawkinsoperations.com/architecture/</loc></url>
   <url><loc>https://hawkinsoperations.com/architecture/truth-surfaces/</loc></url>
   <url><loc>https://hawkinsoperations.com/legacy/</loc></url>

--- a/scripts/verify-site-contract.mjs
+++ b/scripts/verify-site-contract.mjs
@@ -8,6 +8,7 @@ const requiredFiles = [
   "app/page.tsx",
   "app/start/page.tsx",
   "app/proof/page.tsx",
+  "app/aevumguard/page.tsx",
   "app/ai-security/page.tsx",
   "app/detections/page.tsx",
   "app/proof/ho-det-001/page.tsx",
@@ -60,8 +61,8 @@ const navigationData = readFileSync(join(root, "src/data/navigation.ts"), "utf8"
 const primaryNavMatch = navigationData.match(/export const primaryNavigation: NavItem\[] = \[([\s\S]*?)\];/);
 const expectedPrimaryNav = [
   { label: "Home", href: "/" },
+  { label: "AevumGuard", href: "/aevumguard/" },
   { label: "Proof", href: "/proof/" },
-  { label: "Claim Firewall", href: "/claim-firewall/" },
   { label: "Artifacts", href: "/artifacts/" },
   { label: "Detections", href: "/detections/" },
   { label: "AI Security", href: "/ai-security/" },
@@ -141,31 +142,46 @@ const proofPage = readFileSync(join(root, "app/proof/page.tsx"), "utf8");
 const proofHoDet001Page = readFileSync(join(root, "app/proof/ho-det-001/page.tsx"), "utf8");
 const currentProofSpine = readFileSync(join(root, "components/CurrentProofSpine.tsx"), "utf8");
 const claimFirewallPage = readFileSync(join(root, "app/claim-firewall/page.tsx"), "utf8");
+const aevumguardPage = readFileSync(join(root, "app/aevumguard/page.tsx"), "utf8");
 const controlsPage = readFileSync(join(root, "app/controls/page.tsx"), "utf8");
 const claimFirewallComponent = readFileSync(join(root, "components/ClaimFirewall.tsx"), "utf8");
 const proofRecordsData = readFileSync(join(root, "src/data/proofRecords.ts"), "utf8");
 const navigationSource = readFileSync(join(root, "src/data/navigation.ts"), "utf8");
-const claimFirewallFrontDoorRequiredTerms = [
-  ["src/data/navigation.ts", navigationSource, 'label: "Claim Firewall"'],
-  ["src/data/navigation.ts", navigationSource, 'href: "/claim-firewall/"'],
-  ["app/page.tsx", homePage, 'href="/claim-firewall/"'],
-  ["app/page.tsx", homePage, "Claim Firewall"],
-  ["app/page.tsx", homePage, "Unsupported public security claims fail before they ship."],
-  ["app/page.tsx", homePage, "Inspect Claim Firewall"],
+const aevumguardFrontDoorRequiredTerms = [
+  ["src/data/navigation.ts", navigationSource, 'label: "AevumGuard"'],
+  ["src/data/navigation.ts", navigationSource, 'href: "/aevumguard/"'],
+  ["src/data/navigation.ts", navigationSource, "aevumguard"],
+  ["app/aevumguard/page.tsx", aevumguardPage, "AevumGuard governs how AI-assisted security work becomes tested, reviewed, blocked, or safe to claim."],
+  ["app/aevumguard/page.tsx", aevumguardPage, "ProofOps control for the AI security era."],
+  ["app/aevumguard/page.tsx", aevumguardPage, "AI is not the authority. Evidence is."],
+  ["app/aevumguard/page.tsx", aevumguardPage, "AI-assisted security work"],
+  ["app/aevumguard/page.tsx", aevumguardPage, "Artifact Intake"],
+  ["app/aevumguard/page.tsx", aevumguardPage, "Evidence Graph"],
+  ["app/aevumguard/page.tsx", aevumguardPage, "Telemetry Contract Check"],
+  ["app/aevumguard/page.tsx", aevumguardPage, "Controlled Validation"],
+  ["app/aevumguard/page.tsx", aevumguardPage, "Runtime Candidate Ledger"],
+  ["app/aevumguard/page.tsx", aevumguardPage, "Signal Observation"],
+  ["app/aevumguard/page.tsx", aevumguardPage, "Human Review Gate"],
+  ["app/aevumguard/page.tsx", aevumguardPage, "ProofCard"],
+  ["app/aevumguard/page.tsx", aevumguardPage, "Claim Authority"],
+  ["app/aevumguard/page.tsx", aevumguardPage, "Safe Claim / Blocked Claim"],
   ["app/proof/page.tsx", proofPage, "Claim Firewall control surface"],
   ["app/proof/page.tsx", proofPage, "Open Claim Firewall"],
   ["app/proof/page.tsx", proofPage, "website rendering below proof authority"],
+  ["app/claim-firewall/page.tsx", claimFirewallPage, "AevumGuard Claim Authority capability"],
+  ["app/claim-firewall/page.tsx", claimFirewallPage, "Claim Firewall is a wording enforcement edge inside AevumGuard."],
+  ["app/claim-firewall/page.tsx", claimFirewallPage, "Claim Firewall is not the product, platform, front-door repo, or an eighth repo."],
   ["app/claim-firewall/page.tsx", claimFirewallPage, "Website rendering is not proof"],
   ["app/claim-firewall/page.tsx", claimFirewallPage, "Public proof requires evidence linkage and explicit promotion."],
-  ["app/controls/page.tsx", controlsPage, 'href="/claim-firewall/"'],
+  ["app/controls/page.tsx", controlsPage, 'href="/aevumguard/"'],
   ["app/controls/page.tsx", controlsPage, "Compatibility only"],
 ];
-const claimFirewallFrontDoorFailures = claimFirewallFrontDoorRequiredTerms
+const aevumguardFrontDoorFailures = aevumguardFrontDoorRequiredTerms
   .filter(([, source, term]) => !source.includes(term))
   .map(([file, , term]) => `${file} must include ${term}.`);
 
-if (claimFirewallFrontDoorFailures.length > 0) {
-  console.error(`Claim Firewall front-door invariant failed:\n${claimFirewallFrontDoorFailures.map((line) => `- ${line}`).join("\n")}`);
+if (aevumguardFrontDoorFailures.length > 0) {
+  console.error(`AevumGuard front-door invariant failed:\n${aevumguardFrontDoorFailures.map((line) => `- ${line}`).join("\n")}`);
   process.exit(1);
 }
 
@@ -284,7 +300,7 @@ const claimFirewallVisualRequiredTerms = [
   ["app/claim-firewall/page.tsx", claimFirewallPage, "CEILING"],
   ["app/claim-firewall/page.tsx", claimFirewallPage, "PUBLIC WORDING ROUTE"],
   ["app/claim-firewall/page.tsx", claimFirewallPage, "public proof blocked"],
-  ["app/claim-firewall/page.tsx", claimFirewallPage, "Release receipts"],
+  ["app/claim-firewall/page.tsx", claimFirewallPage, "Product boundary"],
   ["app/claim-firewall/page.tsx", claimFirewallPage, "controls-hero__boundary-strip"],
   ["app/claim-firewall/page.tsx", claimFirewallPage, "Public proof requires evidence linkage and explicit promotion."],
   ["components/ClaimFirewall.tsx", claimFirewallComponent, "claim-firewall-demo"],
@@ -334,11 +350,14 @@ if (!Array.isArray(discoveryProof.blocked_claims) || !discoveryProof.blocked_cla
 if (!Array.isArray(discoveryProof.reviewer_routes) || discoveryProof.reviewer_routes.length < 4) {
   discoveryFailures.push("public/.well-known/hawkinsoperations-proof.json must expose reviewer_routes for machine-readable navigation.");
 }
-if (!discoveryProof.reviewer_routes?.some((route) => route.id === "claim-firewall" && route.url === "https://hawkinsoperations.com/claim-firewall/")) {
-  discoveryFailures.push("public/.well-known/hawkinsoperations-proof.json must expose /claim-firewall/ as the claim-firewall reviewer route.");
+if (!discoveryProof.reviewer_routes?.some((route) => route.id === "aevumguard" && route.url === "https://hawkinsoperations.com/aevumguard/")) {
+  discoveryFailures.push("public/.well-known/hawkinsoperations-proof.json must expose /aevumguard/ as the product front-door reviewer route.");
 }
-if (!agentMarkdown.includes("/claim-firewall/")) {
-  discoveryFailures.push("public/agent.md must list /claim-firewall/ as a public entry point.");
+if (!agentMarkdown.includes("/aevumguard/")) {
+  discoveryFailures.push("public/agent.md must list /aevumguard/ as a public entry point.");
+}
+if (agentMarkdown.includes("/claim-firewall/")) {
+  discoveryFailures.push("public/agent.md must not list /claim-firewall/ as a public discovery entry point.");
 }
 if (agentSkills.agent_capability_boundary !== "read_review_navigation_only") {
   discoveryFailures.push("public/.well-known/agent-skills/index.json must cap agent_capability_boundary at read_review_navigation_only.");

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -6,8 +6,8 @@ export type NavItem = {
 
 export const primaryNavigation: NavItem[] = [
   { label: "Home", href: "/", description: "Reviewer cockpit" },
+  { label: "AevumGuard", href: "/aevumguard/", description: "Product front door" },
   { label: "Proof", href: "/proof/", description: "Claim authority" },
-  { label: "Claim Firewall", href: "/claim-firewall/", description: "Public utility satellite" },
   { label: "Artifacts", href: "/artifacts/", description: "Reviewer receipts" },
   { label: "Detections", href: "/detections/", description: "Detection engineering" },
   { label: "AI Security", href: "/ai-security/", description: "AI-assisted SOC model" },
@@ -36,7 +36,7 @@ export const externalLinks = {
   validation: "https://github.com/HawkinsOperations/hawkinsoperations-validation",
   platform: "https://github.com/HawkinsOperations/hawkinsoperations-platform",
   proof: "https://github.com/HawkinsOperations/hawkinsoperations-proof",
-  claimFirewall: "https://github.com/HawkinsOperations/claim-firewall",
+  aevumguard: "https://github.com/HawkinsOperations/aevumguard",
   governanceSavesCandidates: "https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/docs/governance-saves/GOVERNANCE-SAVES-CANDIDATES.md",
   governanceSavesEvidenceMatrix: "https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/docs/governance-saves/GOVERNANCE-SAVES-EVIDENCE-MATRIX.md",
   platformDetectionFactoryController: "https://github.com/HawkinsOperations/hawkinsoperations-platform/blob/main/docs/factory/DETECTION_FACTORY_CONTROLLER_V0.md",

--- a/src/data/repos.ts
+++ b/src/data/repos.ts
@@ -51,12 +51,12 @@ export const repos: RepoRecord[] = [
     doesNotProve: "Unlinked runtime state or claims outside the record.",
   },
   {
-    name: "claim-firewall",
-    href: externalLinks.claimFirewall,
-    purpose: "Local CLI and GitHub Action for scanning public wording against configured claim policy.",
-    truthSurface: "Claim policy tooling",
-    owns: "Tool behavior, policy examples, and release artifacts for wording scans.",
-    doesNotProve: "Runtime telemetry, signal observation, deployment state, or claim approval.",
+    name: "aevumguard",
+    href: externalLinks.aevumguard,
+    purpose: "Product front-door repo for governed AI-assisted security work.",
+    truthSurface: "Product / front door",
+    owns: "AevumGuard product framing and Claim Authority capabilities, starting with Claim Firewall.",
+    doesNotProve: "Runtime telemetry, signal observation, public-safe proof, deployment state, or claim approval.",
   },
   {
     name: "hawkinsoperations-website",


### PR DESCRIPTION
## Summary
- Add `/aevumguard/` as the product/front-door route for HawkinsOperations.
- Reframe Claim Firewall as an internal AevumGuard Claim Authority enforcement capability.
- Replace stale `HawkinsOperations/claim-firewall` repo references with `HawkinsOperations/aevumguard` where the link is product/front-door oriented.
- Remove `/claim-firewall/` from sitemap and agent discovery while keeping it as a legacy capability route.
- Keep public repo metadata at exactly seven repos with `aevumguard` as the seventh repo.

## Proof Ceiling
RENDERING_ONLY. This PR changes public website wording/routing only. It does not create runtime truth, signal truth, public-safe proof, production readiness, customer deployment, SOCaaS, autonomous SOC, AI-approved disposition, analyst-approved disposition, or case closure.

## Validation
- `git status --short`
- `npm --prefix "C:\Raylee\Repo\HawkinsOperations\hawkinsoperations-website" run typecheck`
- `npm --prefix "C:\Raylee\Repo\HawkinsOperations\hawkinsoperations-website" run check:site`
- `npm --prefix "C:\Raylee\Repo\HawkinsOperations\hawkinsoperations-website" run build`
- `git -C "C:\Raylee\Repo\HawkinsOperations\hawkinsoperations-website" diff --check`
- Targeted stale-wording search returned no matches for the required stale terms.

## Browser Check
Built `/aevumguard/` returned HTTP 200 from local static server at `http://127.0.0.1:4173/aevumguard/`. The in-app browser surface was unavailable in this session.