### PR TITLE
Align website product naming to Hoxline

### DIFF
--- a/app/aevumguard/page.tsx
+++ b/app/aevumguard/page.tsx
@@ -20,42 +20,42 @@ const productLoop = [
 ];
 
 export const metadata: Metadata = {
-  title: "AevumGuard | HawkinsOperations",
+  title: "Hoxline | HawkinsOperations",
   description:
-    "AevumGuard governs how AI-assisted security work becomes tested, reviewed, blocked, or safe to claim.",
+    "Hoxline separates AI output from evidence-bound claim authority.",
   alternates: {
     canonical: "/aevumguard/",
   },
 };
 
-export default function AevumGuardPage() {
+export default function HoxlinePage() {
   return (
     <>
       <PageHero
-        title="AevumGuard"
+        title="Hoxline"
         subtitle="ProofOps control for the AI security era."
-        description="AevumGuard governs how AI-assisted security work becomes tested, reviewed, blocked, or safe to claim."
+        description="Hoxline separates AI output from evidence-bound claim authority."
         badges={[{ label: "PRODUCT_FRONT_DOOR" }, { label: "RENDERING_ONLY" }]}
       />
 
       <section className="cockpit-section--tight">
         <div className="container reveal reveal--up">
-          <SectionHeader title="Product Doctrine" eyebrow="AevumGuard" />
+          <SectionHeader title="Product Doctrine" eyebrow="Hoxline" />
           <p className="muted mt-3 max-w-3xl text-sm leading-6">
             AI is not the authority. Evidence is. HawkinsOperations is the brand/system;
-            AevumGuard is the product/front-door repo for the governed product experience.
+            Hoxline is the product/front-door repo for the governed product experience.
           </p>
           <div className="mt-6 grid gap-4 md:grid-cols-2">
             <LinkCard
               href={externalLinks.aevumguard}
-              title="AevumGuard repo"
-              description="Product front-door repo for AevumGuard and Claim Authority capabilities."
+              title="Hoxline repo"
+              description="Compatibility repo path for Hoxline by HawkinsOperations and Claim Authority capabilities."
               external
             />
             <LinkCard
               href="/claim-firewall/"
               title="Claim Firewall capability"
-              description="Legacy capability route for the internal AevumGuard Claim Authority wording enforcement edge."
+              description="Legacy capability route for the internal Hoxline Claim Authority wording enforcement edge."
             />
           </div>
         </div>
@@ -64,7 +64,7 @@ export default function AevumGuardPage() {
       <section className="cockpit-section--tight">
         <div className="container reveal reveal--up">
           <SectionHeader title="Core Loop" eyebrow="Product flow" />
-          <ol className="claim-firewall-demo__outcomes" aria-label="AevumGuard core loop">
+          <ol className="claim-firewall-demo__outcomes" aria-label="Hoxline core loop">
             {productLoop.map((step, index) => (
               <li key={step}>
                 <span>{String(index + 1).padStart(2, "0")}</span>

--- a/app/claim-firewall/page.tsx
+++ b/app/claim-firewall/page.tsx
@@ -6,7 +6,7 @@ const cliCommand = "python -m claimfirewall scan README.md --policy policy/block
 export const metadata: Metadata = {
   title: "Claim Firewall capability | HawkinsOperations",
   description:
-    "Claim Firewall is an internal AevumGuard Claim Authority enforcement capability for checking unsupported public wording. It is not the product or a separate repo.",
+    "Claim Firewall is an internal Hoxline Claim Authority enforcement capability for checking unsupported public wording. It is not the product or a separate repo.",
   alternates: {
     canonical: "/claim-firewall/",
   },
@@ -18,19 +18,19 @@ export default function ClaimFirewallPage() {
       <section className="controls-hero" aria-labelledby="claim-firewall-title">
         <div className="container controls-hero__grid">
           <div className="controls-hero__copy">
-            <p className="cockpit-eyebrow">AevumGuard Claim Authority capability</p>
+            <p className="cockpit-eyebrow">Hoxline Claim Authority capability</p>
             <h1 id="claim-firewall-title" className="controls-hero__title">
               Claim Firewall
             </h1>
             <p className="controls-hero__lede">
-              Claim Firewall is a wording enforcement edge inside AevumGuard.
+              Claim Firewall is a wording enforcement edge inside Hoxline.
             </p>
             <p className="controls-hero__lede">
-              AevumGuard governs how AI-assisted security work becomes tested, reviewed, blocked, or safe to claim.
+              Hoxline separates AI output from evidence-bound claim authority.
               Claim Firewall remains TOOL_FUNCTION_ONLY unless evidence expands.
             </p>
             <div className="controls-hero__pills" aria-label="Claim Firewall capability status">
-              <span>Internal AevumGuard capability</span>
+              <span>Internal Hoxline capability</span>
               <span>Claim Authority enforcement</span>
               <span>TOOL_FUNCTION_ONLY</span>
               <span>RENDERING_ONLY website page</span>
@@ -41,11 +41,11 @@ export default function ClaimFirewallPage() {
 
           <aside className="controls-hero__rail" aria-label="Claim Firewall release receipts">
             <span className="controls-hero__rail-label">Product boundary</span>
-            <p>AevumGuard is the product/front-door repo. Claim Firewall is not the product, platform, front-door repo, or an eighth repo.</p>
+            <p>Hoxline is the product identity for the current product/front-door repo. Claim Firewall is not the product, platform, front-door repo, or an eighth repo.</p>
             <p>Website rendering is not proof authority. Claim Firewall supports claim hygiene only as an internal capability.</p>
             <div className="controls-hero__pills" aria-label="Claim Firewall external links">
               <a href="https://github.com/HawkinsOperations/aevumguard" target="_blank" rel="noopener noreferrer">
-                <span>View AevumGuard</span>
+                <span>View Hoxline repo</span>
               </a>
               <a href="https://github.com/orgs/HawkinsOperations/discussions/51" target="_blank" rel="noopener noreferrer">
                 <span>Historical announcement</span>
@@ -81,7 +81,7 @@ export default function ClaimFirewallPage() {
             <pre className="claim-firewall-demo__terminal" aria-label="Visible CLI command">
               <code>{cliCommand}</code>
             </pre>
-            <div className="controls-hero__meter" aria-label="AevumGuard capability summary">
+            <div className="controls-hero__meter" aria-label="Hoxline capability summary">
               <span>scan files</span>
               <span>scan dirs</span>
               <span>text output</span>

--- a/app/controls/page.tsx
+++ b/app/controls/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Controls compatibility route | HawkinsOperations",
   description:
-    "The /controls/ route remains as a compatibility page. AevumGuard is the product front door; Claim Firewall is an internal Claim Authority capability.",
+    "The /controls/ route remains as a compatibility page. Hoxline is the product front door; Claim Firewall is an internal Claim Authority capability.",
   alternates: {
     canonical: "/aevumguard/",
   },
@@ -16,17 +16,17 @@ export default function ControlsPage() {
         <div className="controls-hero__copy">
           <p className="cockpit-eyebrow">Legacy route</p>
           <h1 id="legacy-controls-title" className="controls-hero__title">
-            Controls moved under AevumGuard
+            Controls moved under Hoxline
           </h1>
           <p className="controls-hero__lede">
-            AevumGuard is the HawkinsOperations product front door for governed AI-assisted security work.
+            Hoxline by HawkinsOperations is the proof-bound claim control system for AI-assisted security work.
           </p>
           <p className="controls-hero__lede">
-            Claim Firewall remains an internal AevumGuard Claim Authority enforcement capability. This /controls/ route remains as a compatibility page for older reviewer links.
+            Claim Firewall remains an internal Hoxline Claim Authority enforcement capability. This /controls/ route remains as a compatibility page for older reviewer links.
           </p>
           <div className="controls-hero__pills" aria-label="Controls compatibility route">
             <a href="/aevumguard/">
-              <span>Open AevumGuard</span>
+              <span>Open Hoxline</span>
             </a>
             <a href="/claim-firewall/">
               <span>Legacy capability route</span>
@@ -37,7 +37,7 @@ export default function ControlsPage() {
         <aside className="controls-hero__rail" aria-label="Legacy route boundary">
           <span className="controls-hero__rail-label">Compatibility only</span>
           <p>Website rendering is not proof authority. This route does not approve claims.</p>
-          <p>Claim Firewall checks wording policy only as a TOOL_FUNCTION_ONLY capability inside AevumGuard.</p>
+          <p>Claim Firewall checks wording policy only as a TOOL_FUNCTION_ONLY capability inside Hoxline.</p>
         </aside>
       </div>
     </section>

--- a/components/ClaimFirewall.tsx
+++ b/components/ClaimFirewall.tsx
@@ -60,7 +60,7 @@ const authorityStack = [
   ["proof", "proof and claim authority"],
   ["website", "rendering only"],
   ["aevumguard", "product front door"],
-  ["Claim Firewall", "internal AevumGuard capability"],
+  ["Claim Firewall", "internal Hoxline capability"],
 ] as const;
 
 const receipts = [
@@ -138,7 +138,7 @@ export default function ClaimFirewall() {
           <span className="claim-firewall-demo__panel-status">ACTION GATE</span>
         </div>
         <p className="claim-firewall-demo__boundary">
-          Run the AevumGuard Claim Authority scanner in CI to block configured wording before public text ships.
+          Run the Hoxline Claim Authority scanner in CI to block configured wording before public text ships.
         </p>
         <pre className="claim-firewall-demo__terminal" aria-label="Claim Firewall GitHub Action example">
           <code>{`- run: python -m claimfirewall scan . --policy policy/blocked_claims.yml
@@ -211,7 +211,7 @@ export default function ClaimFirewall() {
           <span className="claim-firewall-demo__panel-status">RENDERING_ONLY / TOOL_FUNCTION_ONLY</span>
         </div>
         <p className="claim-firewall-demo__boundary">
-          Claim Firewall is an internal AevumGuard Claim Authority enforcement capability that checks wording against configured policy only.
+          Claim Firewall is an internal Hoxline Claim Authority enforcement capability that checks wording against configured policy only.
         </p>
         <p className="claim-firewall-demo__boundary">
           It does not prove detection behavior, runtime telemetry, signal observation, production deployment,
@@ -224,7 +224,7 @@ export default function ClaimFirewall() {
         </p>
         <ul className="claim-firewall-demo__list claim-firewall-demo__list--allowed">
           <li>RENDERING_ONLY for this website page.</li>
-          <li>TOOL_FUNCTION_ONLY for the Claim Firewall capability inside AevumGuard.</li>
+          <li>TOOL_FUNCTION_ONLY for the Claim Firewall capability inside Hoxline.</li>
           <li>No public proof is created by this page.</li>
         </ul>
       </section>
@@ -248,7 +248,7 @@ export default function ClaimFirewall() {
           ))}
         </div>
         <p className="claim-firewall-demo__outcome-copy">
-          Claim Firewall supports claim hygiene as an AevumGuard capability. It does not approve claims. Evidence and human review decide truth.
+          Claim Firewall supports claim hygiene as a Hoxline capability. It does not approve claims. Evidence and human review decide truth.
         </p>
       </section>
 

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -75,7 +75,7 @@ export default function Footer() {
             </li>
             <li>
               <a href={externalLinks.aevumguard} target="_blank" rel="noopener noreferrer">
-                AevumGuard ↗
+                Hoxline ↗
               </a>
             </li>
             <li>

--- a/public/.well-known/hawkinsoperations-proof.json
+++ b/public/.well-known/hawkinsoperations-proof.json
@@ -23,7 +23,7 @@
     },
     {
       "id": "aevumguard",
-      "label": "AevumGuard",
+      "label": "Hoxline",
       "url": "https://hawkinsoperations.com/aevumguard/",
       "use": "Review the product front door and Claim Authority boundary without inferring runtime or signal truth."
     },

--- a/scripts/verify-site-contract.mjs
+++ b/scripts/verify-site-contract.mjs
@@ -61,7 +61,7 @@ const navigationData = readFileSync(join(root, "src/data/navigation.ts"), "utf8"
 const primaryNavMatch = navigationData.match(/export const primaryNavigation: NavItem\[] = \[([\s\S]*?)\];/);
 const expectedPrimaryNav = [
   { label: "Home", href: "/" },
-  { label: "AevumGuard", href: "/aevumguard/" },
+  { label: "Hoxline", href: "/aevumguard/" },
   { label: "Proof", href: "/proof/" },
   { label: "Artifacts", href: "/artifacts/" },
   { label: "Detections", href: "/detections/" },
@@ -147,11 +147,11 @@ const controlsPage = readFileSync(join(root, "app/controls/page.tsx"), "utf8");
 const claimFirewallComponent = readFileSync(join(root, "components/ClaimFirewall.tsx"), "utf8");
 const proofRecordsData = readFileSync(join(root, "src/data/proofRecords.ts"), "utf8");
 const navigationSource = readFileSync(join(root, "src/data/navigation.ts"), "utf8");
-const aevumguardFrontDoorRequiredTerms = [
-  ["src/data/navigation.ts", navigationSource, 'label: "AevumGuard"'],
+const hoxlineFrontDoorRequiredTerms = [
+  ["src/data/navigation.ts", navigationSource, 'label: "Hoxline"'],
   ["src/data/navigation.ts", navigationSource, 'href: "/aevumguard/"'],
   ["src/data/navigation.ts", navigationSource, "aevumguard"],
-  ["app/aevumguard/page.tsx", aevumguardPage, "AevumGuard governs how AI-assisted security work becomes tested, reviewed, blocked, or safe to claim."],
+  ["app/aevumguard/page.tsx", aevumguardPage, "Hoxline separates AI output from evidence-bound claim authority."],
   ["app/aevumguard/page.tsx", aevumguardPage, "ProofOps control for the AI security era."],
   ["app/aevumguard/page.tsx", aevumguardPage, "AI is not the authority. Evidence is."],
   ["app/aevumguard/page.tsx", aevumguardPage, "AI-assisted security work"],
@@ -168,20 +168,20 @@ const aevumguardFrontDoorRequiredTerms = [
   ["app/proof/page.tsx", proofPage, "Claim Firewall control surface"],
   ["app/proof/page.tsx", proofPage, "Open Claim Firewall"],
   ["app/proof/page.tsx", proofPage, "website rendering below proof authority"],
-  ["app/claim-firewall/page.tsx", claimFirewallPage, "AevumGuard Claim Authority capability"],
-  ["app/claim-firewall/page.tsx", claimFirewallPage, "Claim Firewall is a wording enforcement edge inside AevumGuard."],
+  ["app/claim-firewall/page.tsx", claimFirewallPage, "Hoxline Claim Authority capability"],
+  ["app/claim-firewall/page.tsx", claimFirewallPage, "Claim Firewall is a wording enforcement edge inside Hoxline."],
   ["app/claim-firewall/page.tsx", claimFirewallPage, "Claim Firewall is not the product, platform, front-door repo, or an eighth repo."],
   ["app/claim-firewall/page.tsx", claimFirewallPage, "Website rendering is not proof"],
   ["app/claim-firewall/page.tsx", claimFirewallPage, "Public proof requires evidence linkage and explicit promotion."],
   ["app/controls/page.tsx", controlsPage, 'href="/aevumguard/"'],
   ["app/controls/page.tsx", controlsPage, "Compatibility only"],
 ];
-const aevumguardFrontDoorFailures = aevumguardFrontDoorRequiredTerms
+const hoxlineFrontDoorFailures = hoxlineFrontDoorRequiredTerms
   .filter(([, source, term]) => !source.includes(term))
   .map(([file, , term]) => `${file} must include ${term}.`);
 
-if (aevumguardFrontDoorFailures.length > 0) {
-  console.error(`AevumGuard front-door invariant failed:\n${aevumguardFrontDoorFailures.map((line) => `- ${line}`).join("\n")}`);
+if (hoxlineFrontDoorFailures.length > 0) {
+  console.error(`Hoxline front-door invariant failed:\n${hoxlineFrontDoorFailures.map((line) => `- ${line}`).join("\n")}`);
   process.exit(1);
 }
 

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -6,7 +6,7 @@ export type NavItem = {
 
 export const primaryNavigation: NavItem[] = [
   { label: "Home", href: "/", description: "Reviewer cockpit" },
-  { label: "AevumGuard", href: "/aevumguard/", description: "Product front door" },
+  { label: "Hoxline", href: "/aevumguard/", description: "Product front door" },
   { label: "Proof", href: "/proof/", description: "Claim authority" },
   { label: "Artifacts", href: "/artifacts/", description: "Reviewer receipts" },
   { label: "Detections", href: "/detections/", description: "Detection engineering" },

--- a/src/data/repos.ts
+++ b/src/data/repos.ts
@@ -55,7 +55,7 @@ export const repos: RepoRecord[] = [
     href: externalLinks.aevumguard,
     purpose: "Product front-door repo for governed AI-assisted security work.",
     truthSurface: "Product / front door",
-    owns: "AevumGuard product framing and Claim Authority capabilities, starting with Claim Firewall.",
+    owns: "Hoxline product framing and Claim Authority capabilities, starting with Claim Firewall.",
     doesNotProve: "Runtime telemetry, signal observation, public-safe proof, deployment state, or claim approval.",
   },
   {


### PR DESCRIPTION
## Summary
Updates the website public product wording so the /aevumguard/ compatibility route renders Hoxline as the working product name.

## Files changed
- pp/aevumguard/page.tsx
- pp/claim-firewall/page.tsx
- pp/controls/page.tsx
- components/ClaimFirewall.tsx
- components/Footer.tsx
- public/.well-known/hawkinsoperations-proof.json
- scripts/verify-site-contract.mjs
- src/data/navigation.ts
- src/data/repos.ts

## Naming truth
- Product name: Hoxline
- Public form: Hoxline by HawkinsOperations
- Parent authority brand: HawkinsOperations
- Doctrine: AI is not the authority. Evidence is.
- Claim Authority governs what can be claimed.
- Claim Firewall blocks unsupported claims.
- ProofCards export the evidence boundary behind an approved claim.

## Compatibility notes
- Route remains /aevumguard/.
- External repo link remains HawkinsOperations/aevumguard.
- No route rename, repo rename, package rename, or import rename is included.
- scripts/verify-site-contract.mjs was updated only for hard-coded public text expectations.

## Validation results
- git -C C:\Raylee\Repo\HawkinsOperations\hawkinsoperations-website diff --check passed.
- 
pm run check:site passed.
- 
pm run typecheck passed.
- 
pm run build passed.
- 
pm run lint was not run because no lint script exists in package.json.

## Remaining old-name hits and why they remain
- No current Aevum/AevumGuard/abandoned-name content hits remain in website source after excluding .git, 
ode_modules, dist, uild, and coverage.
- /aevumguard/ remains as the compatibility route until a separate route migration is approved.

## Proof ceiling
Hoxline is the working product name in edited repo/public surfaces only. This does not establish trademark clearance, domain ownership, repository rename completion, route rename completion, production readiness, customer validation, or legal brand availability.
