### PR TITLE
Upgrade Hoxline website visual system and ProofOps diagram

### DIFF
--- a/app/ai-security/page.tsx
+++ b/app/ai-security/page.tsx
@@ -1,52 +1,98 @@
 import type { Metadata } from "next";
-import BoundaryNotice from "@components/BoundaryNotice";
-import ClosedLoopFlow from "@components/ClosedLoopFlow";
 import LinkCard from "@components/LinkCard";
-import PageHero from "@components/PageHero";
-import RuntimeBoundaryLadder from "@components/RuntimeBoundaryLadder";
 import SectionHeader from "@components/SectionHeader";
-import SocaasWorkflowFlow from "@components/SocaasWorkflowFlow";
+import {
+  BlockedClaimGrid,
+  ClaimBoundaryPanel,
+  EvidenceCeilingCard,
+  ProofOpsLoopDiagram,
+  ProofOpsPageHero,
+  ReviewerLensTabs,
+  SignalBlockedBadge,
+  type ReviewerLens,
+} from "@components/proofops";
 import { externalLinks } from "@data/navigation";
 import { proofPack } from "@data/proofPackManifest";
 import { registryStats } from "@data/validationRegistry";
 
-const whatTransfers = [
+export const metadata: Metadata = {
+  title: "AI Security | HawkinsOperations",
+  description:
+    "A governed AI Security Operations implementation model for AI-assisted detection engineering, deterministic verification, and human authority.",
+  alternates: {
+    canonical: "/ai-security/",
+  },
+};
+
+const workflowLenses: ReviewerLens[] = [
   {
-    title: "Source-controlled detections",
-    detail: "Rule logic, ATT&CK mapping, status metadata, and review history are version-controlled and auditable.",
+    label: "AI support",
+    title: "AI is labor",
+    body: "AI can help draft detections, summarize reviewer context, and organize case packets, but it does not authorize disposition.",
+    checkpoints: [
+      "AI output enters the same artifact intake path.",
+      "Claim wording is checked against evidence ceilings.",
+      "AI approval is not claimed.",
+    ],
   },
   {
-    title: "Deterministic verifiers",
-    detail: "Validation packages, schema checks, and claim-boundary scanners fail closed before merge.",
+    label: "Verifier",
+    title: "Deterministic checks gate behavior",
+    body: "Schemas, controlled fixture results, and claim-boundary scanners provide deterministic friction before public rendering.",
+    checkpoints: [
+      "Validation remains separate from proof authority.",
+      "Controlled validation does not become runtime or signal proof.",
+      "Failed checks stop promotion.",
+    ],
   },
   {
-    title: "Case-packet structure",
-    detail: "SOAR-shaped case packets with support-only AI fields, blocked actions, and dry-run defaults.",
+    label: "Human authority",
+    title: "Humans gate promotion",
+    body: "Human review sits above implementation momentum, green checks, and AI summaries.",
+    checkpoints: [
+      "human_review_required remains true where applicable.",
+      "Final authorization is not claimed by the site.",
+      "Analyst approval is not implied by AI support.",
+    ],
   },
   {
-    title: "Human review authority",
-    detail: "Visible human review sits above CI, above AI output, above implementation momentum.",
+    label: "Ceiling",
+    title: "The proof ceiling travels with the artifact",
+    body: "Each reviewer route should show what the artifact supports and what it does not prove.",
+    checkpoints: [
+      "Website rendering is not proof.",
+      "public_safe remains false unless separately approved.",
+      "Proof authority remains outside the website repo.",
+    ],
   },
-  {
-    title: "Claim ceiling discipline",
-    detail: "Scanners, record boundaries, and record-is-not-rendering rules keep public copy below evidence ceilings.",
-  },
-  {
-    title: "Governance saves discipline",
-    detail: "The public-facing Governance Saves subset models what controls fired looks like across merge, claim, runtime, evidence, and validator surfaces.",
-  },
+];
+
+const blockedClaims = [
+  "runtime-active status",
+  "runtime proven status",
+  "signal observed status",
+  "public-safe proof",
+  "production-ready status",
+  "SOCaaS-ready status",
+  "SOCaaS deployed status",
+  "customer deployed status",
+  "autonomous SOC operation",
+  "AI approved disposition",
+  "analyst approved disposition",
+  "final human authorization",
+  "case closed status",
 ];
 
 const reviewerSurfaces = [
   {
+    href: "/hoxline/",
+    title: "Hoxline",
+    description: "Open the ProofOps control plane route and interactive claim loop.",
+  },
+  {
     href: "/proof/proof-pack-001/",
     title: "Proof Pack 001",
     description: `${proofPack.id} routes a bounded HO-DET-001 reviewer package at ${proofPack.ceiling}.`,
-  },
-  {
-    href: "/proof/governance-saves/",
-    title: "Governance Saves",
-    description: "Public-facing subset: what was blocked, what control fired, why it matters.",
   },
   {
     href: "/detections/",
@@ -60,101 +106,113 @@ const reviewerSurfaces = [
   },
 ];
 
-const blockedClaims = [
-  "HawkinsOperations is not presented as a production SOCaaS platform.",
-  "Customer validation, partner endorsement, and live enterprise deployment are not claimed.",
-  "Runtime-active public proof and public signal-observed proof remain blocked unless separately proven and approved.",
-  "AI-approved disposition, autonomous SOC, and analyst-approved-by-AI wording remain blocked.",
-];
-
-export const metadata: Metadata = {
-  title: "AI Security | HawkinsOperations",
-  description:
-    "A governed AI Security Operations implementation model for AI-assisted detection engineering, SOC workflow support, deterministic verification, and human authority.",
-  alternates: {
-    canonical: "/ai-security/",
-  },
-};
-
 export default function AiSecurityPage() {
   return (
-    <>
-      <PageHero
+    <div className="proofops-page">
+      <ProofOpsPageHero
+        eyebrow="AI support under ProofOps control"
         title="AI Security"
-        subtitle="A governed implementation model for AI-assisted detection engineering and security operations."
-        description="HawkinsOperations demonstrates a governed SOC workflow support model for AI-assisted detection engineering and security operations: detection work, telemetry confidence, validation, case packets, support-only AI triage, human review, and proof-controlled reporting."
-        badges={[
-          { label: "AI_SUPPORT_ONLY" },
-          { label: "HUMAN_AUTHORITY_REQUIRED" },
-          { label: "PRODUCTION_CLAIM_BLOCKED", tone: "block" },
+        accent="without AI authority"
+        subtitle="A governed implementation model where AI helps security work move faster, while evidence and human review decide what can be claimed."
+        description="This route separates AI support, deterministic verification, human authority, proof ceilings, and blocked claims so the model reads like an operator workflow instead of a long report."
+        metrics={[
+          { label: "AI role", value: "support only", tone: "cyan" },
+          { label: "Verifier", value: "deterministic", tone: "green" },
+          { label: "Authority", value: "human review", tone: "amber" },
+          { label: "Promotion", value: "bounded", tone: "blocked" },
         ]}
-      />
-
-      <section className="container section-tight">
-        <BoundaryNotice
-          title="AI Security boundary"
-          text="This is an implementation model and reviewer route. It does not claim production SOCaaS availability, customer validation, partner endorsement, runtime-active public proof, public signal-observed proof, or autonomous SOC authority."
-        />
-      </section>
-
-      <section className="cockpit-section--tight">
-        <div className="container">
-          <SectionHeader
-            title="Workflow: detection → proof-controlled reporting"
-            eyebrow="SOC workflow"
-            description="Each stage owns a distinct truth. AI supports labor; verifiers gate evidence; humans authorize claims."
+      >
+        <p className="proofops-kicker">Support-only split</p>
+        <div className="proofops-grid-2">
+          <EvidenceCeilingCard
+            label="AI support"
+            ceiling="Labor"
+            detail="Draft, organize, summarize, and route."
+            tone="cyan"
           />
-          <SocaasWorkflowFlow />
+          <EvidenceCeilingCard
+            label="Authority"
+            ceiling="Evidence + human review"
+            detail="Claims move only when evidence and review permit it."
+            tone="amber"
+          />
+        </div>
+      </ProofOpsPageHero>
+
+      <section className="proofops-section">
+        <div className="container">
+          <ClaimBoundaryPanel
+            title="AI support does not become claim authority."
+            description="The route keeps AI, deterministic verifiers, human review, and proof ceilings visually separated."
+            boundaries={[
+              { label: "AI support", value: "labor and drafting", tone: "cyan" },
+              { label: "Verifier", value: "schema and controlled checks", tone: "green" },
+              { label: "Human authority", value: "promotion gate", tone: "amber" },
+              { label: "Website", value: "rendering only", tone: "neutral" },
+              { label: "Not claimed", value: "AI approved disposition", tone: "blocked" },
+              { label: "Not claimed", value: "analyst approved disposition", tone: "blocked" },
+            ]}
+          />
         </div>
       </section>
 
-      <section className="cockpit-section--tight">
+      <section className="proofops-section">
         <div className="container">
           <SectionHeader
-            title="Closed controlled loop"
-            eyebrow="Detection to proof"
-            description="A repo-visible loop reviewers can trace end-to-end. Runtime, signal, and production promotion sit outside this loop on purpose."
+            title="Workflow visualization"
+            eyebrow="Support -> verify -> review -> bound"
+            description="The same Hoxline loop applies to AI-assisted security work: AI helps; evidence gates; humans promote."
           />
-          <ClosedLoopFlow />
+          <ProofOpsLoopDiagram />
         </div>
       </section>
 
-      <section className="cockpit-section--tight">
+      <section className="proofops-section">
         <div className="container">
           <SectionHeader
-            title="Runtime boundary ladder"
-            eyebrow="Claim ladder"
-            description="Controlled validation is real. Public runtime proof is not promoted until a separate evidence and approval gate fires."
+            title="Reviewer lenses"
+            eyebrow="Read the model by authority"
+            description="The page is organized by what each layer can do and what it cannot claim."
           />
-          <RuntimeBoundaryLadder />
+          <ReviewerLensTabs lenses={workflowLenses} />
         </div>
       </section>
 
-      <section className="cockpit-section--tight">
+      <section className="proofops-section">
         <div className="container">
-          <SectionHeader
-            title="What transfers to a SOC"
-            eyebrow="Transferable model"
-            description="Each item is repo-visible discipline that maps to real security operations work without requiring HawkinsOperations infrastructure."
-          />
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {whatTransfers.map((item) => (
-              <article key={item.title} className="card p-5">
-                <p className="mono text-xs uppercase text-blue-100">Transfers</p>
-                <h3 className="mt-3 text-lg font-semibold text-slate-50">{item.title}</h3>
-                <p className="mt-3 text-sm leading-6 text-slate-300">{item.detail}</p>
-              </article>
-            ))}
+          <SectionHeader title="Evidence ceiling and blocked claims" eyebrow="Claim discipline" />
+          <div className="proofops-grid-3">
+            <EvidenceCeilingCard
+              label="Controlled validation"
+              ceiling="Supported where records exist"
+              detail="Controlled validation remains distinct from runtime and signal proof."
+              tone="green"
+            />
+            <EvidenceCeilingCard
+              label="public_safe"
+              ceiling="false unless approved"
+              detail="Public release safety requires separate evidence and approval."
+              tone="blocked"
+            />
+            <EvidenceCeilingCard
+              label="Human gate"
+              ceiling="required"
+              detail="Human review sits above AI output and green checks."
+              tone="amber"
+            />
+          </div>
+          <div className="mt-6">
+            <BlockedClaimGrid claims={blockedClaims} />
           </div>
         </div>
       </section>
 
-      <section className="cockpit-section--tight">
+      <section className="proofops-section">
         <div className="container">
           <SectionHeader
             title="Reviewer inspection path"
             eyebrow="Evidence routes"
-            description="Start with the strongest bounded reviewer package, then inspect detections, validation, and Governance Saves."
+            description="Start with Hoxline, then inspect proof, detections, and validation routes. Each surface keeps its own authority boundary."
           />
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
             {reviewerSurfaces.map((surface) => (
@@ -164,20 +222,29 @@ export default function AiSecurityPage() {
         </div>
       </section>
 
-      <section className="cockpit-section--tight">
+      <section className="proofops-section">
         <div className="container">
-          <SectionHeader title="What remains blocked" eyebrow="Claim ceiling" />
-          <div className="grid gap-3 md:grid-cols-2">
-            {blockedClaims.map((claim) => (
-              <article key={claim} className="card p-4">
-                <p className="text-sm leading-6 text-slate-300">{claim}</p>
+          <SectionHeader title="What transfers" eyebrow="Operator-grade pattern" />
+          <div className="proofops-grid-3">
+            {[
+              ["Source control", "Rule logic, mapping, status metadata, and review history remain auditable."],
+              ["Deterministic gates", "Validation packages, schema checks, and claim-boundary scans fail closed."],
+              ["Case structure", "Case packets can carry support-only AI fields and blocked action defaults."],
+              ["Human review", "Review authority stays visible above CI, AI output, and implementation momentum."],
+              ["Claim ceilings", "Public copy remains below the evidence ceiling attached to each artifact."],
+              ["Reviewer routes", "Routes help reviewers inspect evidence without turning rendering into proof."],
+            ].map(([title, detail]) => (
+              <article key={title} className="proofops-card">
+                <p className="proofops-kicker">Transfer</p>
+                <h3>{title}</h3>
+                <p>{detail}</p>
               </article>
             ))}
           </div>
         </div>
       </section>
 
-      <section className="cockpit-section--tight pb-24">
+      <section className="proofops-section pb-24">
         <div className="container">
           <SectionHeader title="Source-controlled context" eyebrow="Repos" />
           <div className="grid gap-4 md:grid-cols-3">
@@ -185,8 +252,13 @@ export default function AiSecurityPage() {
             <LinkCard href={externalLinks.orgRequiredChecksMatrix} title="Required checks matrix" description="Observed checks, report-only controls, and website rendering boundaries." external />
             <LinkCard href={externalLinks.platformDetectionFactoryController} title="Detection Factory Controller v0" description="Bounded reviewer status and plan emitter; platform visibility, not proof promotion." external />
           </div>
+          <div className="mt-6 flex flex-wrap gap-2">
+            <SignalBlockedBadge label="AI approval not claimed" />
+            <SignalBlockedBadge label="analyst approval not claimed" />
+            <SignalBlockedBadge label="case closure not claimed" />
+          </div>
         </div>
       </section>
-    </>
+    </div>
   );
 }

--- a/app/detections/page.tsx
+++ b/app/detections/page.tsx
@@ -1,16 +1,21 @@
 import type { Metadata } from "next";
-import BoundaryNotice from "@components/BoundaryNotice";
 import LinkCard from "@components/LinkCard";
-import PageHero from "@components/PageHero";
 import SectionHeader from "@components/SectionHeader";
+import {
+  BlockedClaimGrid,
+  ClaimBoundaryPanel,
+  EvidenceCeilingCard,
+  ProofOpsPageHero,
+  SignalBlockedBadge,
+} from "@components/proofops";
 import { attackFamilies, attackMapSafeCopy, cyberKillChainStages } from "@data/attackCoverage";
-import { validationRows } from "@data/validationRegistry";
 import { externalLinks } from "@data/navigation";
+import { validationRows } from "@data/validationRegistry";
 
 export const metadata: Metadata = {
   title: "Detections | HawkinsOperations",
   description:
-    "Detection source, validation, proof ceilings, ATT&CK mapping, and runtime/public signal boundaries for HawkinsOperations.",
+    "Detection source, validation, proof ceilings, ATT&CK mapping, and bounded claim surfaces for HawkinsOperations.",
   alternates: {
     canonical: "/detections/",
   },
@@ -34,62 +39,162 @@ const detectionRows = attackFamilies.flatMap((family) =>
   }),
 );
 
+const flagship = detectionRows.find((row) => row.id === "HO-DET-001");
 const lifecycleSummary = cyberKillChainStages.slice(0, 4);
+
+const lifecycle = [
+  {
+    label: "Source",
+    title: "Detection source",
+    detail: "Rule and status metadata stay on the detection source surface.",
+  },
+  {
+    label: "Validation",
+    title: "Controlled fixtures",
+    detail: "Fixture results define the current behavior truth.",
+  },
+  {
+    label: "Proof ceiling",
+    title: "Evidence cap",
+    detail: "The page displays the ceiling; it does not raise it.",
+  },
+  {
+    label: "Claim boundary",
+    title: "Blocked wording",
+    detail: "Runtime, signal, public release, production, and customer claims stay blocked.",
+  },
+];
+
+const blockedClaims = [
+  "runtime-active status",
+  "runtime proven status",
+  "signal observed status",
+  "public-safe proof",
+  "production-ready status",
+  "SOCaaS-ready status",
+  "customer deployed status",
+  "public runtime proof",
+  "public signal proof",
+];
 
 export default function DetectionsPage() {
   return (
-    <>
-      <PageHero
+    <div className="proofops-page">
+      <ProofOpsPageHero
+        eyebrow="Detection source to claim boundary"
         title="Detections"
-        subtitle="Detection source, validation, and proof ceilings."
-        description="This page shows the public detection-engineering lifecycle: detection IDs, validation status, ATT&CK mapping where represented, proof ceilings, and runtime/public signal boundaries."
-        badges={[
-          { label: "DETECTION_ENGINEERING" },
-          { label: "CONTROLLED_VALIDATION" },
-          { label: "RUNTIME_PUBLIC_CLAIMS_BOUNDED", tone: "block" },
+        accent="with ceilings"
+        subtitle="Detection work is useful only when its source, validation, ceiling, and blocked claims travel together."
+        description="This route makes the detection lifecycle easier to scan while preserving the same proof boundaries: source truth, behavior truth, proof authority, and website rendering remain separate."
+        metrics={[
+          { label: "Portfolio", value: `${detectionRows.length} cards`, tone: "cyan" },
+          { label: "Flagship", value: "HO-DET-001", tone: "amber" },
+          { label: "Ceiling shown", value: "per artifact", tone: "green" },
+          { label: "Runtime / signal", value: "not promoted", tone: "blocked" },
         ]}
-      />
+      >
+        <p className="proofops-kicker">Lifecycle strip</p>
+        <ol className="proofops-lifecycle" aria-label="Detection lifecycle">
+          {lifecycle.map((step) => (
+            <li key={step.label}>
+              <span>{step.label}</span>
+              <strong>{step.title}</strong>
+              <p>{step.detail}</p>
+            </li>
+          ))}
+        </ol>
+      </ProofOpsPageHero>
 
-      <section className="container section-tight">
-        <BoundaryNotice
-          title="Detection boundary"
-          text="Detection cards show source, validation, mapping, and proof-boundary status. They do not prove production deployment, customer coverage, runtime-active public proof, public signal-observed proof, or autonomous SOC decisions."
-        />
+      <section className="proofops-section">
+        <div className="container">
+          <ClaimBoundaryPanel
+            title="Detection rendering keeps the claim boundary visible."
+            description="Detection cards show source, validation, mapping, and proof-boundary status. They do not create deployment, signal, or public proof."
+            boundaries={[
+              { label: "Source truth", value: "hawkinsoperations-detections", tone: "cyan" },
+              { label: "Behavior truth", value: "hawkinsoperations-validation", tone: "cyan" },
+              { label: "Proof authority", value: "hawkinsoperations-proof", tone: "amber" },
+              { label: "Website", value: "rendering only", tone: "neutral" },
+            ]}
+          />
+        </div>
       </section>
 
-      <section className="cockpit-section--tight">
+      {flagship && (
+        <section className="proofops-section">
+          <div className="container">
+            <article className="proofops-flagship">
+              <div className="proofops-flagship__grid">
+                <div>
+                  <p className="proofops-kicker">Flagship controlled-validation example</p>
+                  <h2 className="mt-3 text-3xl font-semibold leading-tight text-slate-50 md:text-4xl">
+                    {flagship.id}: {flagship.title}
+                  </h2>
+                  <p className="mt-4 text-sm leading-6 text-slate-300">{flagship.attack}</p>
+                  <div className="mt-5 flex flex-wrap gap-2">
+                    <SignalBlockedBadge label="runtime not promoted" />
+                    <SignalBlockedBadge label="signal not promoted" />
+                    <SignalBlockedBadge label="public_safe false" />
+                  </div>
+                </div>
+                <div className="proofops-grid-2">
+                  <EvidenceCeilingCard
+                    label="Validation"
+                    ceiling={flagship.validationState}
+                    detail="Controlled fixture status remains distinct from runtime or signal proof."
+                    tone="green"
+                  />
+                  <EvidenceCeilingCard
+                    label="Proof ceiling"
+                    ceiling={flagship.proofCeiling}
+                    detail={flagship.boundary}
+                    tone="amber"
+                  />
+                </div>
+              </div>
+              <div className="mt-6 grid gap-4 md:grid-cols-3">
+                <LinkCard href="/hoxline/" title="Hoxline ProofOps route" description="Inspect the Hoxline loop that governs the claim boundary." />
+                <LinkCard href="/proof/ho-det-001/" title="HO-DET-001 route" description="Open the existing bounded reviewer case-file route." />
+                <LinkCard href="/validation/" title="Validation registry" description="Inspect controlled fixtures and validation status." />
+              </div>
+            </article>
+          </div>
+        </section>
+      )}
+
+      <section className="proofops-section">
         <div className="container">
           <SectionHeader
             title="Detection systems"
-            eyebrow="Source → validation → proof ceiling"
+            eyebrow="Source -> validation -> proof ceiling"
             description="Each card keeps source, validation, proof ceiling, and runtime/signal boundary visible so detection work cannot be over-promoted."
           />
           <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
             {detectionRows.map((row) => (
-              <article key={`${row.family}-${row.id}`} className="card p-5">
-                <p className="mono text-xs uppercase text-blue-100">{row.family}</p>
+              <article key={`${row.family}-${row.id}`} className="proofops-card">
+                <p className="proofops-kicker">{row.family}</p>
                 <div className="mt-3 flex flex-wrap items-center gap-2">
                   <span className="chip chip-ice">{row.id}</span>
                   <span className="chip chip-quiet">{row.tone.toUpperCase()}</span>
                 </div>
-                <h3 className="mt-4 text-lg font-semibold text-slate-50">{row.title}</h3>
-                <p className="mt-3 text-sm leading-6 text-slate-300">{row.attack}</p>
+                <h3>{row.title}</h3>
+                <p>{row.attack}</p>
                 <dl className="mt-4 grid gap-3 text-sm">
                   <div>
-                    <dt className="mono text-[0.62rem] uppercase tracking-[0.16em] text-slate-400">Validation</dt>
+                    <dt className="mono text-[0.62rem] uppercase text-slate-400">Validation</dt>
                     <dd className="mt-1 text-slate-200">{row.validationState}</dd>
                   </div>
                   <div>
-                    <dt className="mono text-[0.62rem] uppercase tracking-[0.16em] text-slate-400">Proof ceiling</dt>
+                    <dt className="mono text-[0.62rem] uppercase text-slate-400">Proof ceiling</dt>
                     <dd className="mt-1 text-slate-200">{row.proofCeiling}</dd>
                   </div>
                   <div>
-                    <dt className="mono text-[0.62rem] uppercase tracking-[0.16em] text-slate-400">Runtime / signal boundary</dt>
+                    <dt className="mono text-[0.62rem] uppercase text-slate-400">Runtime / signal boundary</dt>
                     <dd className="mt-1 text-slate-300">{row.boundary}</dd>
                   </div>
                 </dl>
                 <a className="mt-5 inline-flex text-sm text-slate-300 hover:text-blue-100" href={row.inspectHref}>
-                  Inspect route →
+                  Inspect route -&gt;
                 </a>
               </article>
             ))}
@@ -97,7 +202,14 @@ export default function DetectionsPage() {
         </div>
       </section>
 
-      <section className="cockpit-section--tight">
+      <section className="proofops-section">
+        <div className="container">
+          <SectionHeader title="What remains blocked" eyebrow="Claim boundary" />
+          <BlockedClaimGrid claims={blockedClaims} />
+        </div>
+      </section>
+
+      <section className="proofops-section">
         <div className="container">
           <SectionHeader
             title="ATT&CK and lifecycle map"
@@ -106,20 +218,18 @@ export default function DetectionsPage() {
           />
           <div className="grid gap-4 md:grid-cols-2">
             {lifecycleSummary.map((stage) => (
-              <article key={stage.stage} className="card p-5">
-                <p className="mono text-xs uppercase text-blue-100">{stage.stage}</p>
-                <h3 className="mt-3 text-lg font-semibold text-slate-50">{stage.currentState}</h3>
-                <p className="mt-3 text-sm leading-6 text-slate-300">{stage.reviewerInterpretation}</p>
-                <p className="mt-4 text-sm leading-6 text-slate-400">
-                  Strongest reviewer artifact: {stage.strongestArtifact}
-                </p>
+              <article key={stage.stage} className="proofops-card">
+                <p className="proofops-kicker">{stage.stage}</p>
+                <h3>{stage.currentState}</h3>
+                <p>{stage.reviewerInterpretation}</p>
+                <p>Strongest reviewer artifact: {stage.strongestArtifact}</p>
               </article>
             ))}
           </div>
         </div>
       </section>
 
-      <section className="cockpit-section--tight pb-24">
+      <section className="proofops-section pb-24">
         <div className="container">
           <SectionHeader title="Inspect source" eyebrow="Routes" />
           <div className="grid gap-4 md:grid-cols-3">
@@ -129,6 +239,6 @@ export default function DetectionsPage() {
           </div>
         </div>
       </section>
-    </>
+    </div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -2050,7 +2050,15 @@ body::after {
 .brand-mark--lg { width: min(178px, 48vw); height: min(178px, 48vw); border-radius: 16px; }
 
 .site-header {
+  z-index: 80;
+  background: #03060b;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
   box-shadow: 0 18px 48px rgba(0, 0, 0, 0.38);
+}
+
+.site-header nav {
+  background: #03060b;
 }
 
 .headline {
@@ -13644,6 +13652,14 @@ a.card.group:hover { border-color: rgba(143, 216, 255, 0.45); }
     linear-gradient(180deg, rgba(7, 12, 22, 0.2), transparent 70%);
 }
 
+@media (max-width: 720px) {
+  .proofops-hero::before {
+    background:
+      linear-gradient(120deg, rgba(96, 165, 250, 0.1), transparent 44%),
+      linear-gradient(180deg, rgba(7, 12, 22, 0.3), transparent 72%);
+  }
+}
+
 .proofops-hero__grid {
   position: relative;
   display: grid;
@@ -13865,6 +13881,14 @@ a.card.group:hover { border-color: rgba(143, 216, 255, 0.45); }
   text-transform: uppercase;
 }
 
+.proofops-loop__hint {
+  margin: 12px 0 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  text-transform: none;
+}
+
 .proofops-loop__stage {
   display: grid;
   gap: 18px;
@@ -13880,7 +13904,7 @@ a.card.group:hover { border-color: rgba(143, 216, 255, 0.45); }
 .proofops-loop__rail {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
+  gap: 12px;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -13892,21 +13916,72 @@ a.card.group:hover { border-color: rgba(143, 216, 255, 0.45); }
   }
 }
 
+@media (min-width: 1120px) {
+  .proofops-loop__rail {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+.proofops-loop__rail li {
+  position: relative;
+}
+
+@media (min-width: 700px) {
+  .proofops-loop__rail li:not(:nth-child(3n))::after {
+    content: "";
+    position: absolute;
+    left: calc(100% + 2px);
+    top: 50%;
+    width: 8px;
+    border-top: 1px solid rgba(143, 216, 255, 0.26);
+    transform: translateY(-50%);
+  }
+}
+
+@media (min-width: 1120px) {
+  .proofops-loop__rail li:not(:nth-child(3n))::after {
+    content: none;
+  }
+
+  .proofops-loop__rail li:not(:nth-child(4n))::after {
+    content: "";
+    position: absolute;
+    left: calc(100% + 2px);
+    top: 50%;
+    width: 8px;
+    border-top: 1px solid rgba(143, 216, 255, 0.26);
+    transform: translateY(-50%);
+  }
+}
+
 .proofops-loop__step {
+  position: relative;
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
   gap: 8px;
   align-items: center;
   width: 100%;
   min-height: 64px;
-  border: 1px solid rgba(201, 211, 223, 0.14);
+  border: 1px solid rgba(201, 211, 223, 0.16);
   border-radius: 8px;
-  background: rgba(8, 13, 22, 0.58);
+  background:
+    linear-gradient(180deg, rgba(12, 19, 32, 0.74), rgba(6, 10, 18, 0.82));
   color: var(--silver);
-  padding: 10px;
+  padding: 11px 10px 11px 14px;
   text-align: left;
   cursor: pointer;
   transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
+}
+
+.proofops-loop__step::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 10px;
+  bottom: 10px;
+  width: 3px;
+  border-radius: 0 999px 999px 0;
+  background: rgba(143, 216, 255, 0.42);
 }
 
 .proofops-loop__step:hover,
@@ -13918,8 +13993,17 @@ a.card.group:hover { border-color: rgba(143, 216, 255, 0.45); }
 
 .proofops-loop__step.is-active {
   border-color: var(--proofops-cyan);
-  background: rgba(143, 216, 255, 0.08);
-  box-shadow: 0 0 0 1px rgba(143, 216, 255, 0.22) inset;
+  background:
+    radial-gradient(120% 140% at 0% 0%, rgba(143, 216, 255, 0.16), transparent 52%),
+    rgba(13, 21, 36, 0.9);
+  box-shadow:
+    0 0 0 1px rgba(143, 216, 255, 0.28) inset,
+    0 12px 28px rgba(0, 0, 0, 0.26);
+}
+
+.proofops-loop__step.is-active::before {
+  background: var(--proofops-cyan);
+  box-shadow: 0 0 16px rgba(143, 216, 255, 0.48);
 }
 
 .proofops-loop__index {
@@ -13940,6 +14024,10 @@ a.card.group:hover { border-color: rgba(143, 216, 255, 0.45); }
 .proofops-loop__step--ceiling .proofops-loop__index { color: var(--proofops-amber); }
 .proofops-loop__step--blocked .proofops-loop__index { color: var(--proofops-blocked); }
 .proofops-loop__step--safe .proofops-loop__index { color: var(--proofops-green); }
+.proofops-loop__step--ceiling::before { background: rgba(240, 184, 95, 0.52); }
+.proofops-loop__step--blocked::before { background: rgba(252, 165, 165, 0.5); }
+.proofops-loop__step--safe::before { background: rgba(95, 208, 160, 0.52); }
+.proofops-loop__step--human::before { background: rgba(96, 165, 250, 0.52); }
 
 .proofops-loop__detail {
   position: sticky;

--- a/app/globals.css
+++ b/app/globals.css
@@ -13599,3 +13599,709 @@ a.card.group:hover { border-color: rgba(143, 216, 255, 0.45); }
     transform: none !important;
   }
 }
+
+/* ════════════════════════════════════════════════════════════════════
+   Hoxline / ProofOps visual system v0
+   Shared cockpit treatment for Hoxline, Detections, and AI Security.
+   ════════════════════════════════════════════════════════════════════ */
+
+.proofops-page {
+  --proofops-cyan: #8fd8ff;
+  --proofops-blue: #60a5fa;
+  --proofops-amber: #f0b85f;
+  --proofops-green: #5fd0a0;
+  --proofops-blocked: #fca5a5;
+  --proofops-panel: rgba(7, 12, 22, 0.76);
+  --proofops-panel-strong: rgba(10, 17, 30, 0.92);
+  --proofops-border: rgba(143, 216, 255, 0.18);
+}
+
+.proofops-kicker {
+  margin: 0;
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  line-height: 1.3;
+  color: var(--proofops-cyan);
+  text-transform: uppercase;
+}
+
+.proofops-hero {
+  position: relative;
+  padding: clamp(64px, 9vw, 112px) 0 clamp(40px, 6vw, 72px);
+  overflow: hidden;
+}
+
+.proofops-hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(120deg, rgba(96, 165, 250, 0.12), transparent 34%),
+    radial-gradient(80% 80% at 78% 14%, rgba(240, 184, 95, 0.08), transparent 46%),
+    linear-gradient(180deg, rgba(7, 12, 22, 0.2), transparent 70%);
+}
+
+.proofops-hero__grid {
+  position: relative;
+  display: grid;
+  gap: clamp(28px, 5vw, 56px);
+  align-items: stretch;
+}
+
+@media (min-width: 980px) {
+  .proofops-hero__grid {
+    grid-template-columns: minmax(0, 1.05fr) minmax(320px, 0.75fr);
+  }
+}
+
+.proofops-hero__copy {
+  min-width: 0;
+}
+
+.proofops-hero__title {
+  margin: 16px 0 0;
+  max-width: 10ch;
+  color: var(--silver-bright);
+  font-size: clamp(3rem, 8vw, 7rem);
+  font-weight: 820;
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+.proofops-hero__title span {
+  display: block;
+  color: var(--proofops-cyan);
+}
+
+.proofops-hero__subtitle {
+  margin: 24px 0 0;
+  max-width: 66ch;
+  color: var(--silver-bright);
+  font-size: clamp(1.08rem, 2.2vw, 1.44rem);
+  line-height: 1.55;
+}
+
+.proofops-hero__description {
+  margin: 16px 0 0;
+  max-width: 72ch;
+  color: var(--muted);
+  font-size: 0.98rem;
+  line-height: 1.7;
+}
+
+.proofops-hero__metrics {
+  display: grid;
+  gap: 10px;
+  margin-top: 28px;
+}
+
+@media (min-width: 620px) {
+  .proofops-hero__metrics {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+.proofops-metric {
+  min-width: 0;
+  border: 1px solid var(--proofops-border);
+  border-radius: 8px;
+  background: rgba(8, 13, 22, 0.6);
+  padding: 12px 13px;
+}
+
+.proofops-metric span,
+.proofops-ceiling p,
+.proofops-blocked-grid__item span {
+  display: block;
+  color: var(--muted);
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.11em;
+  line-height: 1.35;
+  text-transform: uppercase;
+}
+
+.proofops-metric strong {
+  display: block;
+  margin-top: 7px;
+  color: var(--silver-bright);
+  font-size: 0.82rem;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.proofops-metric--cyan { border-color: rgba(143, 216, 255, 0.35); }
+.proofops-metric--amber { border-color: rgba(240, 184, 95, 0.42); }
+.proofops-metric--green { border-color: rgba(95, 208, 160, 0.4); }
+.proofops-metric--blocked { border-color: rgba(252, 165, 165, 0.42); }
+
+.proofops-hero__panel {
+  position: relative;
+  display: grid;
+  align-content: start;
+  gap: 14px;
+  border: 1px solid var(--moon-border-bright);
+  border-radius: 10px;
+  background:
+    linear-gradient(180deg, rgba(12, 19, 32, 0.9), rgba(5, 9, 16, 0.96));
+  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.48);
+  padding: clamp(20px, 3vw, 30px);
+}
+
+.proofops-hero__panel::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  border-top: 2px solid rgba(143, 216, 255, 0.52);
+}
+
+.proofops-compact-list {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+}
+
+.proofops-compact-list div {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  border-bottom: 1px solid rgba(201, 211, 223, 0.1);
+  padding-bottom: 12px;
+}
+
+.proofops-compact-list dt {
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.proofops-compact-list dd {
+  margin: 0;
+  color: var(--silver-bright);
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.72rem;
+  text-align: right;
+  overflow-wrap: anywhere;
+}
+
+.proofops-section {
+  padding: clamp(36px, 6vw, 72px) 0;
+}
+
+.proofops-grid-2,
+.proofops-grid-3,
+.proofops-grid-4 {
+  display: grid;
+  gap: 16px;
+}
+
+@media (min-width: 760px) {
+  .proofops-grid-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .proofops-grid-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .proofops-grid-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+}
+
+.proofops-card {
+  min-width: 0;
+  border: 1px solid var(--proofops-border);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, rgba(12, 19, 32, 0.68), rgba(6, 10, 18, 0.82));
+  padding: 18px;
+}
+
+.proofops-card h3 {
+  margin: 10px 0 0;
+  color: var(--silver-bright);
+  font-size: 1.08rem;
+  line-height: 1.25;
+}
+
+.proofops-card p {
+  margin: 10px 0 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.proofops-loop {
+  border: 1px solid var(--moon-border-bright);
+  border-radius: 12px;
+  background:
+    radial-gradient(80% 60% at 0% 0%, rgba(143, 216, 255, 0.08), transparent 62%),
+    rgba(5, 9, 16, 0.78);
+  padding: clamp(18px, 3vw, 28px);
+}
+
+.proofops-loop__head {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: end;
+  margin-bottom: 20px;
+}
+
+.proofops-loop__head h2,
+.proofops-boundary h2,
+.proofops-tabs__panel h3,
+.proofops-safe-claim h3 {
+  margin: 8px 0 0;
+  color: var(--silver-bright);
+  font-size: clamp(1.35rem, 2.6vw, 2.05rem);
+  line-height: 1.12;
+}
+
+.proofops-loop__head > p {
+  margin: 0;
+  color: var(--muted);
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.7rem;
+  text-align: right;
+  text-transform: uppercase;
+}
+
+.proofops-loop__stage {
+  display: grid;
+  gap: 18px;
+}
+
+@media (min-width: 980px) {
+  .proofops-loop__stage {
+    grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
+    align-items: start;
+  }
+}
+
+.proofops-loop__rail {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+@media (min-width: 700px) {
+  .proofops-loop__rail {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.proofops-loop__step {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 8px;
+  align-items: center;
+  width: 100%;
+  min-height: 64px;
+  border: 1px solid rgba(201, 211, 223, 0.14);
+  border-radius: 8px;
+  background: rgba(8, 13, 22, 0.58);
+  color: var(--silver);
+  padding: 10px;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
+}
+
+.proofops-loop__step:hover,
+.proofops-loop__step:focus-visible {
+  border-color: rgba(143, 216, 255, 0.44);
+  background: rgba(13, 21, 36, 0.82);
+  transform: translateY(-1px);
+}
+
+.proofops-loop__step.is-active {
+  border-color: var(--proofops-cyan);
+  background: rgba(143, 216, 255, 0.08);
+  box-shadow: 0 0 0 1px rgba(143, 216, 255, 0.22) inset;
+}
+
+.proofops-loop__index {
+  color: var(--proofops-cyan);
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.66rem;
+}
+
+.proofops-loop__label {
+  min-width: 0;
+  color: var(--silver-bright);
+  font-size: 0.78rem;
+  font-weight: 700;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+.proofops-loop__step--ceiling .proofops-loop__index { color: var(--proofops-amber); }
+.proofops-loop__step--blocked .proofops-loop__index { color: var(--proofops-blocked); }
+.proofops-loop__step--safe .proofops-loop__index { color: var(--proofops-green); }
+
+.proofops-loop__detail {
+  position: sticky;
+  top: 88px;
+  border: 1px solid var(--proofops-border);
+  border-radius: 10px;
+  background: var(--proofops-panel-strong);
+  padding: 20px;
+}
+
+.proofops-loop__detail--ceiling { border-top: 3px solid var(--proofops-amber); }
+.proofops-loop__detail--blocked { border-top: 3px solid var(--proofops-blocked); }
+.proofops-loop__detail--safe { border-top: 3px solid var(--proofops-green); }
+.proofops-loop__detail--human { border-top: 3px solid var(--proofops-blue); }
+.proofops-loop__detail--labor,
+.proofops-loop__detail--inspect { border-top: 3px solid var(--proofops-cyan); }
+
+.proofops-loop__detail-kicker,
+.proofops-loop__detail dt {
+  margin: 0;
+  color: var(--proofops-cyan);
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.proofops-loop__detail h3 {
+  margin: 8px 0 16px;
+  color: var(--silver-bright);
+  font-size: clamp(1.3rem, 2.8vw, 2rem);
+  line-height: 1.1;
+}
+
+.proofops-loop__detail dl {
+  display: grid;
+  gap: 14px;
+  margin: 0;
+}
+
+.proofops-loop__detail dd {
+  margin: 5px 0 0;
+  color: var(--silver);
+  font-size: 0.92rem;
+  line-height: 1.58;
+}
+
+.proofops-boundary {
+  display: grid;
+  gap: 20px;
+  border: 1px solid rgba(201, 211, 223, 0.18);
+  border-left: 3px solid var(--proofops-cyan);
+  border-radius: 10px;
+  background: rgba(7, 12, 22, 0.66);
+  padding: clamp(18px, 3vw, 28px);
+}
+
+@media (min-width: 900px) {
+  .proofops-boundary {
+    grid-template-columns: 0.78fr 1.22fr;
+  }
+}
+
+.proofops-boundary > div > p {
+  margin: 12px 0 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+  line-height: 1.6;
+}
+
+.proofops-boundary__grid {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+}
+
+@media (min-width: 560px) {
+  .proofops-boundary__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.proofops-boundary__item {
+  border: 1px solid rgba(201, 211, 223, 0.14);
+  border-radius: 8px;
+  background: rgba(5, 9, 16, 0.52);
+  padding: 13px;
+}
+
+.proofops-boundary__item dt {
+  color: var(--muted);
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.56rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.proofops-boundary__item dd {
+  margin: 7px 0 0;
+  color: var(--silver-bright);
+  font-size: 0.86rem;
+  line-height: 1.42;
+}
+
+.proofops-boundary__item--amber { border-color: rgba(240, 184, 95, 0.38); }
+.proofops-boundary__item--green { border-color: rgba(95, 208, 160, 0.38); }
+.proofops-boundary__item--blocked { border-color: rgba(252, 165, 165, 0.38); }
+.proofops-boundary__item--cyan { border-color: rgba(143, 216, 255, 0.38); }
+
+.proofops-tabs {
+  display: grid;
+  gap: 16px;
+}
+
+@media (min-width: 860px) {
+  .proofops-tabs {
+    grid-template-columns: 0.42fr 0.58fr;
+    align-items: start;
+  }
+}
+
+.proofops-tabs__buttons {
+  display: grid;
+  gap: 8px;
+}
+
+.proofops-tabs__buttons button {
+  border: 1px solid rgba(201, 211, 223, 0.14);
+  border-radius: 8px;
+  background: rgba(8, 13, 22, 0.55);
+  color: var(--silver);
+  cursor: pointer;
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  line-height: 1.3;
+  min-height: 48px;
+  padding: 12px;
+  text-align: left;
+  text-transform: uppercase;
+}
+
+.proofops-tabs__buttons button.is-active,
+.proofops-tabs__buttons button:hover,
+.proofops-tabs__buttons button:focus-visible {
+  border-color: var(--proofops-cyan);
+  color: var(--silver-bright);
+  background: rgba(143, 216, 255, 0.08);
+}
+
+.proofops-tabs__panel,
+.proofops-safe-claim,
+.proofops-ceiling {
+  border: 1px solid var(--proofops-border);
+  border-radius: 10px;
+  background: var(--proofops-panel);
+  padding: 20px;
+}
+
+.proofops-tabs__panel p,
+.proofops-safe-claim p,
+.proofops-ceiling span {
+  color: var(--muted);
+  font-size: 0.92rem;
+  line-height: 1.6;
+}
+
+.proofops-tabs__panel ul {
+  display: grid;
+  gap: 8px;
+  margin: 16px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.proofops-tabs__panel li {
+  border-left: 2px solid rgba(143, 216, 255, 0.44);
+  color: var(--silver);
+  font-size: 0.86rem;
+  line-height: 1.5;
+  padding-left: 10px;
+}
+
+.proofops-ceiling h3 {
+  margin: 8px 0 0;
+  color: var(--silver-bright);
+  font-size: clamp(1.15rem, 2vw, 1.55rem);
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+}
+
+.proofops-ceiling--amber { border-top: 3px solid var(--proofops-amber); }
+.proofops-ceiling--green { border-top: 3px solid var(--proofops-green); }
+.proofops-ceiling--blocked { border-top: 3px solid var(--proofops-blocked); }
+.proofops-ceiling--cyan { border-top: 3px solid var(--proofops-cyan); }
+
+.proofops-blocked-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 32px;
+  border: 1px solid rgba(252, 165, 165, 0.35);
+  border-radius: 999px;
+  background: rgba(252, 165, 165, 0.06);
+  color: #ffc2ca;
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  line-height: 1.2;
+  padding: 8px 11px;
+  text-transform: uppercase;
+}
+
+.proofops-safe-claim {
+  border-top: 3px solid var(--proofops-green);
+}
+
+.proofops-safe-claim blockquote {
+  margin: 16px 0 12px;
+  border-left: 3px solid var(--proofops-green);
+  color: var(--silver-bright);
+  font-size: clamp(1rem, 1.8vw, 1.22rem);
+  font-weight: 650;
+  line-height: 1.5;
+  padding-left: 14px;
+}
+
+.proofops-blocked-grid {
+  display: grid;
+  gap: 10px;
+}
+
+@media (min-width: 620px) {
+  .proofops-blocked-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 980px) {
+  .proofops-blocked-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.proofops-blocked-grid__item {
+  min-width: 0;
+  border: 1px solid rgba(252, 165, 165, 0.26);
+  border-radius: 8px;
+  background: rgba(252, 165, 165, 0.045);
+  padding: 12px;
+}
+
+.proofops-blocked-grid__item strong {
+  display: block;
+  margin-top: 7px;
+  color: var(--silver-bright);
+  font-size: 0.86rem;
+  line-height: 1.35;
+}
+
+.proofops-lifecycle {
+  display: grid;
+  gap: 10px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+@media (min-width: 760px) {
+  .proofops-lifecycle {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+.proofops-lifecycle li {
+  position: relative;
+  border: 1px solid rgba(143, 216, 255, 0.18);
+  border-radius: 8px;
+  background: rgba(8, 13, 22, 0.58);
+  padding: 15px;
+}
+
+.proofops-lifecycle span {
+  color: var(--proofops-cyan);
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.58rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.proofops-lifecycle strong {
+  display: block;
+  margin-top: 9px;
+  color: var(--silver-bright);
+  font-size: 1rem;
+}
+
+.proofops-lifecycle p {
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: 0.84rem;
+  line-height: 1.48;
+}
+
+.proofops-flagship {
+  border: 1px solid rgba(240, 184, 95, 0.4);
+  border-radius: 12px;
+  background:
+    radial-gradient(100% 70% at 100% 0%, rgba(240, 184, 95, 0.1), transparent 60%),
+    rgba(7, 12, 22, 0.78);
+  padding: clamp(20px, 3vw, 30px);
+}
+
+.proofops-flagship__grid {
+  display: grid;
+  gap: 18px;
+}
+
+@media (min-width: 880px) {
+  .proofops-flagship__grid {
+    grid-template-columns: 0.92fr 1.08fr;
+    align-items: start;
+  }
+}
+
+@media (max-width: 620px) {
+  .proofops-loop__head {
+    align-items: start;
+    flex-direction: column;
+  }
+
+  .proofops-loop__head > p {
+    text-align: left;
+  }
+
+  .proofops-loop__rail {
+    grid-template-columns: 1fr;
+  }
+
+  .proofops-loop__detail {
+    position: static;
+  }
+
+  .proofops-compact-list div {
+    display: grid;
+  }
+
+  .proofops-compact-list dd {
+    text-align: left;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .proofops-loop__step {
+    transition: none !important;
+  }
+
+  .proofops-loop__step:hover,
+  .proofops-loop__step:focus-visible {
+    transform: none !important;
+  }
+}

--- a/app/hoxline/page.tsx
+++ b/app/hoxline/page.tsx
@@ -16,17 +16,17 @@ import {
 export const metadata: Metadata = {
   title: "Hoxline | HawkinsOperations",
   description:
-    "Hoxline by HawkinsOperations is a rendering-only reviewer route for ProofOps claim boundaries and the HO-DET-001 controlled-validation bridge.",
+    "Hoxline by HawkinsOperations is a ProofOps control plane for bounded AI-assisted security work, reviewer evidence paths, and claim boundaries.",
   alternates: {
     canonical: "/hoxline/",
   },
 };
 
 const heroFacts = [
-  ["Product", "Hoxline by HawkinsOperations"],
-  ["Artifact", "HO-DET-001"],
-  ["Evidence state", "CONTROLLED_TEST_VALIDATED"],
-  ["Proof ceiling", "CONTROLLED_TEST_VALIDATED"],
+  ["Public form", "Hoxline by HawkinsOperations"],
+  ["Product role", "ProofOps control plane"],
+  ["Current example", "HO-DET-001"],
+  ["Evidence ceiling", "CONTROLLED_TEST_VALIDATED"],
   ["public_safe", "false"],
   ["human_review_required", "true"],
 ];
@@ -46,21 +46,123 @@ const blockedClaims = [
   "case closed status",
 ];
 
+const controlSurfaces = [
+  {
+    label: "Intake",
+    title: "AI output intake",
+    detail: "Generated security work enters as a named artifact with scope, source, and reviewer context attached.",
+  },
+  {
+    label: "Graph",
+    title: "Evidence graphing",
+    detail: "Artifact, validation, runtime candidate, signal, review, and claim nodes stay separated for inspection.",
+  },
+  {
+    label: "State",
+    title: "Validation state",
+    detail: "Controlled fixture status is shown as evidence state, not as runtime or signal truth.",
+  },
+  {
+    label: "Ceiling",
+    title: "Proof ceiling",
+    detail: "The current ceiling travels with the artifact so public language cannot climb past evidence.",
+  },
+  {
+    label: "Decision",
+    title: "Claim decision",
+    detail: "Claim Authority separates allowed controlled-validation wording from blocked stronger families.",
+  },
+  {
+    label: "Review",
+    title: "Reviewer handoff",
+    detail: "The route points reviewers to proof, source, validation, and platform authority before trust is granted.",
+  },
+];
+
+const hoxlineAnswer = [
+  ["Generated output", "Useful draft material, never authority."],
+  ["Evidence", "References attached to source-controlled artifacts."],
+  ["Validation", "Controlled behavior checks with explicit fixture scope."],
+  ["Proof records", "Owned by the proof authority surface, not this page."],
+  ["Public rendering", "Readable website surface only."],
+  ["Claim authority", "Hoxline capability for allowed and blocked wording."],
+];
+
+const claimMatrix = [
+  {
+    label: "Allowed",
+    title: "Controlled validation evidence exists",
+    detail: "HO-DET-001 has controlled positive and negative fixture validation evidence under the current ceiling.",
+    tone: "green",
+  },
+  {
+    label: "Blocked",
+    title: "Runtime or signal promotion",
+    detail: "Runtime-active, runtime proven, signal observed, and public signal proof wording remain blocked.",
+    tone: "blocked",
+  },
+  {
+    label: "Blocked",
+    title: "Public release or deployment wording",
+    detail: "public_safe remains false; production, customer, deployment, and SOCaaS status are not claimed.",
+    tone: "blocked",
+  },
+  {
+    label: "Required",
+    title: "Human and authority review",
+    detail: "human_review_required remains true and authority references must be inspected before stronger claims.",
+    tone: "amber",
+  },
+];
+
+const authorityMap = [
+  ["hoxline", "product/control plane", "Routes AI-assisted work into evidence-bound claim decisions."],
+  ["hawkinsoperations-detections", "source truth", "Owns detection packages, rule context, and source metadata."],
+  ["hawkinsoperations-validation", "behavior truth", "Owns controlled fixture behavior status."],
+  ["hawkinsoperations-platform", "contracts/ledgers/promotion authority", "Owns schemas, ledgers, and promotion mechanics."],
+  ["hawkinsoperations-proof", "proof authority", "Owns proof records and evidence ceilings."],
+  ["hawkinsoperations-website", "rendering only", "Displays public reviewer routes without creating proof."],
+  ["HawkinsOperations.github", "org/reviewer routing", "Connects org-level review and workflow routing."],
+];
+
+const reviewerPath = [
+  {
+    title: "Inspect the controlled demo package",
+    detail: "Start with the HO-DET-001 bridge, release packet, and existing bounded case-file route.",
+  },
+  {
+    title: "Inspect the proof ceiling and blocked claims",
+    detail: "Confirm the ceiling is CONTROLLED_TEST_VALIDATED and stronger claim families remain blocked.",
+  },
+  {
+    title: "Inspect authority references",
+    detail: "Check proof, detections, validation, and platform surfaces before trusting public wording.",
+  },
+];
+
+const nextGate = [
+  "Separate runtime evidence from the appropriate authority path.",
+  "Preserved signal evidence tied to the artifact and telemetry contract.",
+  "Updated promotion ledger state in the platform authority surface.",
+  "Proof authority update that raises the ceiling without relying on website rendering.",
+  "Explicit human review decision before public wording changes.",
+];
+
 const lenses: ReviewerLens[] = [
   {
-    label: "Manager scan",
-    title: "What Hoxline controls",
-    body: "Hoxline controls how AI-assisted security output is allowed to become an evidence-bound claim.",
+    label: "Executive",
+    title: "What leadership can trust",
+    body: "Hoxline makes the evidence ceiling and blocked claim families visible before AI-assisted security work becomes public wording.",
     checkpoints: [
-      "Start with the allowed controlled-validation claim.",
-      "Check that public_safe remains false.",
-      "Check that website rendering is not proof.",
+      "The product controls claim movement, not proof truth.",
+      "The safe claim stays below CONTROLLED_TEST_VALIDATED.",
+      "public_safe remains false and human review remains required.",
     ],
   },
   {
-    label: "Engineer path",
-    title: "What to inspect",
-    body: "Review the ProofCard, Gauntlet run, evidence graph, and promotion state before stronger wording is considered.",
+    label: "Detection engineer",
+    title: "What implementation teams inspect",
+    body: "Engineers can trace the artifact through source, controlled validation, telemetry expectations, and blocked runtime or signal gates.",
     checkpoints: [
       "Open the HO-DET-001 ProofCard bridge.",
       "Inspect controlled positive and negative fixture counts.",
@@ -68,13 +170,23 @@ const lenses: ReviewerLens[] = [
     ],
   },
   {
-    label: "Claim boundary",
-    title: "What remains blocked",
-    body: "Controlled validation does not become runtime proof, signal proof, public-safe proof, production status, or customer status.",
+    label: "Reviewer",
+    title: "Where review starts",
+    body: "Reviewers start from the release packet, then verify proof ceilings and source-controlled authority surfaces before trusting copy.",
     checkpoints: [
-      "AI is labor, not authority.",
-      "Evidence sources remain authority.",
-      "Human review gates promotion.",
+      "Website rendering is not proof.",
+      "The proof ceiling is attached to the artifact.",
+      "Draft packaging work is not treated as merged proof.",
+    ],
+  },
+  {
+    label: "Claim authority",
+    title: "How wording is decided",
+    body: "Claim Firewall is an internal Hoxline Claim Authority capability that separates allowed wording from blocked wording.",
+    checkpoints: [
+      "Controlled validation proves controlled validation only.",
+      "Runtime, signal, public-safe, and production claims stay blocked.",
+      "Hoxline does not replace proof authority.",
     ],
   },
 ];
@@ -85,17 +197,17 @@ export default function HoxlinePage() {
       <ProofOpsPageHero
         eyebrow="Hoxline by HawkinsOperations"
         title="Hoxline"
-        accent="ProofOps cockpit"
-        subtitle="A control plane for deciding what AI-assisted security work is allowed to become."
-        description="Hoxline turns fast security work into reviewer-readable claim decisions while keeping proof authority, source truth, validation truth, platform contracts, and website rendering separate."
+        accent="ProofOps control"
+        subtitle="ProofOps control for the AI security era."
+        description="AI is not the authority. Evidence is. Hoxline controls what AI-assisted security work is allowed to become while proof authority, source truth, validation truth, platform contracts, and website rendering remain separate."
         metrics={[
-          { label: "Route", value: "DRAFT_RENDERING_ROUTE", tone: "cyan" },
+          { label: "Product", value: "control plane", tone: "cyan" },
           { label: "Ceiling", value: "CONTROLLED_TEST_VALIDATED", tone: "amber" },
           { label: "public_safe", value: "false", tone: "blocked" },
           { label: "Human review", value: "required", tone: "green" },
         ]}
       >
-        <p className="proofops-kicker">Reviewer facts</p>
+        <p className="proofops-kicker">Product boundary</p>
         <dl className="proofops-compact-list">
           {heroFacts.map(([label, value]) => (
             <div key={label}>
@@ -104,26 +216,55 @@ export default function HoxlinePage() {
             </div>
           ))}
         </dl>
+        <div className="mt-4 grid gap-3">
+          <LinkCard
+            href="#controlled-demo"
+            title="Inspect controlled demo"
+            description="Open the HO-DET-001 spotlight and claim decision boundary."
+          />
+          <LinkCard
+            href="#reviewer-path"
+            title="Reviewer route"
+            description="Follow the bounded path through package, ceiling, and authority references."
+          />
+        </div>
       </ProofOpsPageHero>
 
       <section className="proofops-section">
         <div className="container">
-          <ProofOpsLoopDiagram />
+          <SectionHeader
+            title="The Claim Problem"
+            eyebrow="AI speed meets evidence discipline"
+            description="AI can draft convincing security claims faster than an organization can safely prove them. Hoxline keeps generated output, evidence, validation, telemetry, proof ceilings, and human review from collapsing into one public sentence."
+          />
+          <div className="proofops-grid-3">
+            {[
+              ["Fast output", "AI-assisted work can create detection ideas, summaries, and reviewer notes quickly."],
+              ["Slow authority", "Evidence, validation, telemetry, proof records, and review gates must stay explicit."],
+              ["Claim pressure", "The dangerous step is turning useful output into wording that sounds stronger than the evidence."],
+            ].map(([title, detail]) => (
+              <article key={title} className="proofops-card">
+                <p className="proofops-kicker">Problem</p>
+                <h3>{title}</h3>
+                <p>{detail}</p>
+              </article>
+            ))}
+          </div>
         </div>
       </section>
 
       <section className="proofops-section">
         <div className="container">
           <ClaimBoundaryPanel
-            title="Hoxline controls claim promotion, not proof truth."
-            description="The product route shows how claim authority should read the evidence ceiling. It does not create the evidence ceiling itself."
+            title="Product thesis: AI is not the authority. Evidence is."
+            description="Hoxline is the control layer for claim movement. It does not make the website a proof source, does not promote public_safe, and does not convert controlled validation into runtime or signal proof."
             boundaries={[
-              { label: "Proof authority", value: "hawkinsoperations-proof", tone: "amber" },
-              { label: "Source truth", value: "hawkinsoperations-detections", tone: "cyan" },
-              { label: "Behavior truth", value: "hawkinsoperations-validation", tone: "cyan" },
-              { label: "Promotion authority", value: "hawkinsoperations-platform", tone: "amber" },
-              { label: "Rendering", value: "hawkinsoperations-website only", tone: "neutral" },
+              { label: "AI role", value: "labor and drafting", tone: "cyan" },
+              { label: "Evidence role", value: "authority input", tone: "amber" },
+              { label: "Hoxline role", value: "claim-control layer", tone: "cyan" },
+              { label: "Website role", value: "rendering only", tone: "neutral" },
               { label: "Current ceiling", value: "CONTROLLED_TEST_VALIDATED", tone: "green" },
+              { label: "Promotion", value: "human_review_required true", tone: "blocked" },
             ]}
           />
         </div>
@@ -132,29 +273,141 @@ export default function HoxlinePage() {
       <section className="proofops-section">
         <div className="container">
           <SectionHeader
-            title="Safe claim vs blocked claim"
-            eyebrow="Claim Authority"
-            description="One safe claim is allowed. Stronger claim families remain visibly blocked until separate evidence and promotion gates exist."
+            title="What Hoxline Controls"
+            eyebrow="From generated output to claim-ready evidence"
+            description="Hoxline organizes the movement from AI-assisted work into reviewer-readable evidence boundaries. Each control keeps one authority surface from being confused with another."
           />
-          <div className="proofops-grid-2">
-            <SafeClaimCard
-              claim="HO-DET-001 has controlled validation evidence from controlled positive and negative process-creation fixtures and remains under review."
-              detail="This wording stays below the controlled-validation ceiling and keeps human review visible."
-            />
-            <div className="proofops-card">
-              <p className="proofops-kicker">Blocked wording</p>
-              <h3>What the page does not claim</h3>
-              <p>
-                This route does not claim public-safe proof, production-ready status,
-                SOCaaS availability, customer deployment, runtime truth, signal truth,
-                AI approval, analyst approval, final human authorization, or case closure.
-              </p>
-              <div className="mt-4 flex flex-wrap gap-2">
-                {["runtime", "signal", "public_safe", "production", "customer"].map((item) => (
-                  <SignalBlockedBadge key={item} label={item} />
-                ))}
+          <div className="proofops-grid-3">
+            {controlSurfaces.map((surface) => (
+              <article key={surface.title} className="proofops-card">
+                <p className="proofops-kicker">{surface.label}</p>
+                <h3>{surface.title}</h3>
+                <p>{surface.detail}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="proofops-section">
+        <div className="container">
+          <SectionHeader
+            title="The Hoxline Answer"
+            eyebrow="Separate the layers"
+            description="The product value is not a bigger claim. It is a disciplined route that keeps generated output, evidence, validation, proof records, public rendering, and claim authority in separate compartments."
+          />
+          <div className="proofops-grid-3">
+            {hoxlineAnswer.map(([title, detail]) => (
+              <article key={title} className="proofops-card">
+                <p className="proofops-kicker">Layer</p>
+                <h3>{title}</h3>
+                <p>{detail}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="proofops-section">
+        <div className="container">
+          <SectionHeader
+            title="ProofOps Loop"
+            eyebrow="Interactive control diagram"
+            description="Tap a step to inspect the control. The active step shows what happens, what control applies, and what remains blocked."
+          />
+          <ProofOpsLoopDiagram />
+        </div>
+      </section>
+
+      <section id="controlled-demo" className="proofops-section">
+        <div className="container">
+          <SectionHeader
+            title="HO-DET-001 Controlled Demo Spotlight"
+            eyebrow="One artifact, one loop, one bounded claim"
+            description="HO-DET-001 is the flagship example for the current route. It demonstrates controlled validation boundaries without promoting runtime, signal, public-safe, production, customer, or final authorization claims."
+          />
+          <article className="proofops-flagship">
+            <div className="proofops-flagship__grid">
+              <div>
+                <p className="proofops-kicker">Artifact</p>
+                <h2 className="mt-3 text-3xl font-semibold leading-tight text-slate-50 md:text-4xl">
+                  HO-DET-001: controlled validation bridge
+                </h2>
+                <p className="mt-4 text-sm leading-6 text-slate-300">
+                  The demo package shows controlled positive and negative fixture validation evidence and keeps the current ceiling visible. It does not authorize stronger public wording.
+                </p>
+                <div className="mt-5 flex flex-wrap gap-2">
+                  <SignalBlockedBadge label="public_safe false" />
+                  <SignalBlockedBadge label="human review required" />
+                  <SignalBlockedBadge label="runtime not promoted" />
+                  <SignalBlockedBadge label="signal not promoted" />
+                </div>
+              </div>
+              <div className="proofops-grid-2">
+                <EvidenceCeilingCard
+                  label="State"
+                  ceiling="CONTROLLED_TEST_VALIDATED"
+                  detail="Controlled validation evidence exists for the bounded package."
+                  tone="green"
+                />
+                <EvidenceCeilingCard
+                  label="ProofCard"
+                  ceiling="Rendering route"
+                  detail="The website can display the ProofCard context but does not become proof authority."
+                  tone="cyan"
+                />
+                <SafeClaimCard
+                  claim="HO-DET-001 has controlled validation evidence from controlled positive and negative process-creation fixtures and remains under review."
+                  detail="This wording stays below the current evidence ceiling."
+                />
+                <EvidenceCeilingCard
+                  label="Blocked claim"
+                  ceiling="Runtime / signal / public-safe"
+                  detail="Runtime, signal, public-safe, production, customer, and final authorization wording remain blocked."
+                  tone="blocked"
+                />
               </div>
             </div>
+            <div className="mt-6 grid gap-4 md:grid-cols-3">
+              <LinkCard
+                href="https://github.com/HawkinsOperations/hoxline/pull/7"
+                title="PR #7 bridge"
+                description="Merged HO-DET-001 ProofCard v0 / Gauntlet controlled-validation bridge."
+                external
+              />
+              <LinkCard
+                href="https://github.com/HawkinsOperations/hoxline/pull/9"
+                title="Release packet"
+                description="Merged reviewer packet summarizing bridge, strategy docs, and website route."
+                external
+              />
+              <LinkCard
+                href="/proof/ho-det-001/"
+                title="HO-DET-001 route"
+                description="Open the bounded reviewer case-file rendering route."
+              />
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section className="proofops-section">
+        <div className="container">
+          <SectionHeader
+            title="Claim Boundary Matrix"
+            eyebrow="Claim Authority"
+            description="Hoxline makes the decision surface visible: what the current evidence allows, what remains blocked, and what needs authority review."
+          />
+          <div className="proofops-grid-4">
+            {claimMatrix.map((item) => (
+              <EvidenceCeilingCard
+                key={`${item.label}-${item.title}`}
+                label={item.label}
+                ceiling={item.title}
+                detail={item.detail}
+                tone={item.tone as "green" | "blocked" | "amber"}
+              />
+            ))}
           </div>
           <div className="mt-6">
             <BlockedClaimGrid claims={blockedClaims} />
@@ -165,11 +418,41 @@ export default function HoxlinePage() {
       <section className="proofops-section">
         <div className="container">
           <SectionHeader
-            title="Reviewer navigation"
-            eyebrow="Inspect the bounded package"
-            description="Start with the bridge and release packet. PR #10 is draft demo-packaging work only and is not treated as merged proof."
+            title="Authority Architecture"
+            eyebrow="Seven surfaces, separate authority"
+            description="The architecture is intentionally split. Hoxline controls product flow and claim decisions, while proof, source, validation, platform, rendering, and organization routing keep their own authority boundaries."
           />
-          <ReviewerLensTabs lenses={lenses} />
+          <div className="proofops-grid-3">
+            {authorityMap.map(([repo, role, detail]) => (
+              <article key={repo} className="proofops-card">
+                <p className="proofops-kicker">{role}</p>
+                <h3>{repo}</h3>
+                <p>{detail}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section id="reviewer-path" className="proofops-section">
+        <div className="container">
+          <SectionHeader
+            title="Reviewer Start Path"
+            eyebrow="Where to begin"
+            description="A reviewer should not start by trusting the page. Start with the controlled package, then inspect ceilings and authority references."
+          />
+          <div className="proofops-grid-3">
+            {reviewerPath.map((step, index) => (
+              <article key={step.title} className="proofops-card">
+                <p className="proofops-kicker">Step {index + 1}</p>
+                <h3>{step.title}</h3>
+                <p>{step.detail}</p>
+              </article>
+            ))}
+          </div>
+          <div className="mt-6">
+            <ReviewerLensTabs lenses={lenses} />
+          </div>
           <div className="mt-6 grid gap-4 md:grid-cols-2 lg:grid-cols-4">
             <LinkCard
               href="https://github.com/HawkinsOperations/hoxline/pull/7"
@@ -190,33 +473,46 @@ export default function HoxlinePage() {
               external
             />
             <LinkCard
-              href="/proof/ho-det-001/"
-              title="HO-DET-001 route"
-              description="Existing website rendering route for the bounded HO-DET-001 reviewer case file."
+              href="/validation/"
+              title="Validation registry"
+              description="Inspect controlled fixture status and blocked runtime or signal states."
             />
           </div>
         </div>
       </section>
 
+      <section className="proofops-section">
+        <div className="container">
+          <ClaimBoundaryPanel
+            title="Trust Boundary"
+            description="This is the compact operating boundary for the page. Hoxline helps control claims, but it does not create proof authority or promote stronger states by rendering them."
+            boundaries={[
+              { label: "Website rendering", value: "not proof", tone: "neutral" },
+              { label: "Hoxline", value: "not proof authority", tone: "cyan" },
+              { label: "runtime / signal", value: "blocked", tone: "blocked" },
+              { label: "public_safe", value: "false", tone: "blocked" },
+              { label: "Human review", value: "required", tone: "amber" },
+              { label: "Controlled validation", value: "current ceiling only", tone: "green" },
+            ]}
+          />
+        </div>
+      </section>
+
       <section className="proofops-section pb-24">
-        <div className="container proofops-grid-3">
-          <EvidenceCeilingCard
-            label="Controlled validation"
-            ceiling="CONTROLLED_TEST_VALIDATED"
-            detail="Fixture validation is the strongest claim supported here."
+        <div className="container">
+          <SectionHeader
+            title="Next Gate"
+            eyebrow="Evidence required before stronger claims"
+            description="Stronger wording would require separate evidence and authority updates. Website rendering cannot supply those gates."
           />
-          <EvidenceCeilingCard
-            label="Website route"
-            ceiling="RENDERING_ONLY"
-            detail="Website rendering is not proof and does not create proof authority."
-            tone="cyan"
-          />
-          <EvidenceCeilingCard
-            label="Promotion gate"
-            ceiling="HUMAN_REVIEW_REQUIRED"
-            detail="human_review_required remains true before stronger wording."
-            tone="blocked"
-          />
+          <div className="proofops-grid-3">
+            {nextGate.map((gate) => (
+              <article key={gate} className="proofops-card">
+                <p className="proofops-kicker">Required next evidence</p>
+                <h3>{gate}</h3>
+              </article>
+            ))}
+          </div>
         </div>
       </section>
     </div>

--- a/app/hoxline/page.tsx
+++ b/app/hoxline/page.tsx
@@ -1,139 +1,192 @@
 import type { Metadata } from "next";
-import Image from "next/image";
-import BoundaryNotice from "@components/BoundaryNotice";
 import LinkCard from "@components/LinkCard";
-import PageHero from "@components/PageHero";
 import SectionHeader from "@components/SectionHeader";
+import {
+  BlockedClaimGrid,
+  ClaimBoundaryPanel,
+  EvidenceCeilingCard,
+  ProofOpsLoopDiagram,
+  ProofOpsPageHero,
+  ReviewerLensTabs,
+  SafeClaimCard,
+  SignalBlockedBadge,
+  type ReviewerLens,
+} from "@components/proofops";
 
 export const metadata: Metadata = {
-  title: "Hoxline reviewer route | HawkinsOperations",
+  title: "Hoxline | HawkinsOperations",
   description:
-    "Rendering-only reviewer route for the Hoxline HO-DET-001 controlled-validation bridge.",
+    "Hoxline by HawkinsOperations is a rendering-only reviewer route for ProofOps claim boundaries and the HO-DET-001 controlled-validation bridge.",
   alternates: {
     canonical: "/hoxline/",
   },
 };
 
-const bridgeFacts = [
+const heroFacts = [
+  ["Product", "Hoxline by HawkinsOperations"],
   ["Artifact", "HO-DET-001"],
   ["Evidence state", "CONTROLLED_TEST_VALIDATED"],
   ["Proof ceiling", "CONTROLLED_TEST_VALIDATED"],
   ["public_safe", "false"],
   ["human_review_required", "true"],
-  ["Route status", "DRAFT_RENDERING_ROUTE"],
-];
-
-const boundaries = [
-  "Hoxline is the HawkinsOperations ProofOps control plane for AI-assisted security work.",
-  "Hoxline controls how security work moves from AI-assisted output to evidence-bound claims.",
-  "Claim Firewall is an internal Claim Authority capability.",
-  "The HO-DET-001 bridge is CONTROLLED_TEST_VALIDATED only.",
-  "Website rendering is not proof.",
-  "The website does not create proof authority.",
-  "public_safe remains false.",
-  "human_review_required remains true.",
 ];
 
 const blockedClaims = [
-  "runtime status",
-  "signal status",
-  "public-safe status",
-  "production status",
-  "SOCaaS status",
-  "customer deployment",
-  "AI approval",
-  "analyst approval",
-  "final authorization",
-  "ProofCard authority",
-  "case closure",
+  "runtime-active status",
+  "runtime proven status",
+  "signal observed status",
+  "public-safe proof",
+  "production-ready status",
+  "SOCaaS-ready status",
+  "SOCaaS deployed status",
+  "customer deployed status",
+  "AI approved disposition",
+  "analyst approved disposition",
+  "final human authorization",
+  "case closed status",
 ];
 
-export default function HoxlineReviewerRoutePage() {
+const lenses: ReviewerLens[] = [
+  {
+    label: "Manager scan",
+    title: "What Hoxline controls",
+    body: "Hoxline controls how AI-assisted security output is allowed to become an evidence-bound claim.",
+    checkpoints: [
+      "Start with the allowed controlled-validation claim.",
+      "Check that public_safe remains false.",
+      "Check that website rendering is not proof.",
+    ],
+  },
+  {
+    label: "Engineer path",
+    title: "What to inspect",
+    body: "Review the ProofCard, Gauntlet run, evidence graph, and promotion state before stronger wording is considered.",
+    checkpoints: [
+      "Open the HO-DET-001 ProofCard bridge.",
+      "Inspect controlled positive and negative fixture counts.",
+      "Confirm runtime and signal gates remain blocked.",
+    ],
+  },
+  {
+    label: "Claim boundary",
+    title: "What remains blocked",
+    body: "Controlled validation does not become runtime proof, signal proof, public-safe proof, production status, or customer status.",
+    checkpoints: [
+      "AI is labor, not authority.",
+      "Evidence sources remain authority.",
+      "Human review gates promotion.",
+    ],
+  },
+];
+
+export default function HoxlinePage() {
   return (
-    <>
-      <PageHero
+    <div className="proofops-page">
+      <ProofOpsPageHero
+        eyebrow="Hoxline by HawkinsOperations"
         title="Hoxline"
-        subtitle="Rendering-only reviewer route for the HO-DET-001 controlled-validation bridge."
-        description="Hoxline by HawkinsOperations keeps AI-assisted security work below the evidence ceiling until authority sources and human review support stronger wording."
-        badges={[
-          { label: "DRAFT_RENDERING_ROUTE" },
-          { label: "CONTROLLED_TEST_VALIDATED" },
-          { label: "public_safe false" },
-          { label: "human_review_required true" },
+        accent="ProofOps cockpit"
+        subtitle="A control plane for deciding what AI-assisted security work is allowed to become."
+        description="Hoxline turns fast security work into reviewer-readable claim decisions while keeping proof authority, source truth, validation truth, platform contracts, and website rendering separate."
+        metrics={[
+          { label: "Route", value: "DRAFT_RENDERING_ROUTE", tone: "cyan" },
+          { label: "Ceiling", value: "CONTROLLED_TEST_VALIDATED", tone: "amber" },
+          { label: "public_safe", value: "false", tone: "blocked" },
+          { label: "Human review", value: "required", tone: "green" },
         ]}
-      />
+      >
+        <p className="proofops-kicker">Reviewer facts</p>
+        <dl className="proofops-compact-list">
+          {heroFacts.map(([label, value]) => (
+            <div key={label}>
+              <dt>{label}</dt>
+              <dd>{value}</dd>
+            </div>
+          ))}
+        </dl>
+      </ProofOpsPageHero>
 
-      <section className="cockpit-section--tight">
-        <div className="container grid gap-6 lg:grid-cols-[1fr_0.8fr]">
-          <div className="surface overflow-hidden p-0" data-truth-surface="public-rendering">
-            <Image
-              src="/brand/hawkinsoperations-hero-wide.png"
-              alt="HawkinsOperations reviewer surface"
-              width={1400}
-              height={820}
-              className="h-full min-h-[320px] w-full object-cover"
-              priority
+      <section className="proofops-section">
+        <div className="container">
+          <ProofOpsLoopDiagram />
+        </div>
+      </section>
+
+      <section className="proofops-section">
+        <div className="container">
+          <ClaimBoundaryPanel
+            title="Hoxline controls claim promotion, not proof truth."
+            description="The product route shows how claim authority should read the evidence ceiling. It does not create the evidence ceiling itself."
+            boundaries={[
+              { label: "Proof authority", value: "hawkinsoperations-proof", tone: "amber" },
+              { label: "Source truth", value: "hawkinsoperations-detections", tone: "cyan" },
+              { label: "Behavior truth", value: "hawkinsoperations-validation", tone: "cyan" },
+              { label: "Promotion authority", value: "hawkinsoperations-platform", tone: "amber" },
+              { label: "Rendering", value: "hawkinsoperations-website only", tone: "neutral" },
+              { label: "Current ceiling", value: "CONTROLLED_TEST_VALIDATED", tone: "green" },
+            ]}
+          />
+        </div>
+      </section>
+
+      <section className="proofops-section">
+        <div className="container">
+          <SectionHeader
+            title="Safe claim vs blocked claim"
+            eyebrow="Claim Authority"
+            description="One safe claim is allowed. Stronger claim families remain visibly blocked until separate evidence and promotion gates exist."
+          />
+          <div className="proofops-grid-2">
+            <SafeClaimCard
+              claim="HO-DET-001 has controlled validation evidence from controlled positive and negative process-creation fixtures and remains under review."
+              detail="This wording stays below the controlled-validation ceiling and keeps human review visible."
             />
-          </div>
-          <div className="moon-panel" style={{ padding: 24 }}>
-            <p className="cockpit-eyebrow">Reviewer facts</p>
-            <dl className="mt-5 grid gap-3">
-              {bridgeFacts.map(([label, value]) => (
-                <div key={label} className="flex min-w-0 flex-wrap items-center justify-between gap-3 border-b border-white/10 pb-3">
-                  <dt className="text-sm text-slate-400">{label}</dt>
-                  <dd className="mono text-xs uppercase text-slate-100">{value}</dd>
-                </div>
-              ))}
-            </dl>
-          </div>
-        </div>
-      </section>
-
-      <section className="container cockpit-section--tight">
-        <BoundaryNotice text="DRAFT_RENDERING_ROUTE: this page references draft Hoxline PR #7 for reviewer context only. Website rendering is not proof, does not create proof authority, and does not imply the bridge is merged." />
-      </section>
-
-      <section className="cockpit-section--tight">
-        <div className="container">
-          <SectionHeader title="ProofOps Boundary" eyebrow="Hoxline reviewer route" />
-          <div className="mt-6 grid gap-4 md:grid-cols-2">
-            {boundaries.map((boundary) => (
-              <div key={boundary} className="moon-panel" style={{ padding: 18 }}>
-                <p className="text-sm leading-6 text-slate-300">{boundary}</p>
+            <div className="proofops-card">
+              <p className="proofops-kicker">Blocked wording</p>
+              <h3>What the page does not claim</h3>
+              <p>
+                This route does not claim public-safe proof, production-ready status,
+                SOCaaS availability, customer deployment, runtime truth, signal truth,
+                AI approval, analyst approval, final human authorization, or case closure.
+              </p>
+              <div className="mt-4 flex flex-wrap gap-2">
+                {["runtime", "signal", "public_safe", "production", "customer"].map((item) => (
+                  <SignalBlockedBadge key={item} label={item} />
+                ))}
               </div>
-            ))}
+            </div>
+          </div>
+          <div className="mt-6">
+            <BlockedClaimGrid claims={blockedClaims} />
           </div>
         </div>
       </section>
 
-      <section className="cockpit-section--tight">
-        <div className="container grid gap-6 lg:grid-cols-[0.85fr_1fr]">
-          <div>
-            <SectionHeader title="Not Claimed" eyebrow="Blocked public wording" />
-            <p className="mt-4 max-w-2xl text-sm leading-6 text-slate-400">
-              This route does not claim runtime, signal, public-safe, production, SOCaaS,
-              customer deployment, AI approval, analyst approval, final authorization,
-              ProofCard authority, or case closure.
-            </p>
-          </div>
-          <ul className="grid gap-3 sm:grid-cols-2" aria-label="Blocked claim families">
-            {blockedClaims.map((claim) => (
-              <li key={claim} className="moon-panel mono text-xs uppercase text-slate-300" style={{ padding: 14 }}>
-                not claimed: {claim}
-              </li>
-            ))}
-          </ul>
-        </div>
-      </section>
-
-      <section className="cockpit-section--tight">
+      <section className="proofops-section">
         <div className="container">
-          <SectionHeader title="Reviewer Links" eyebrow="Draft dependency" />
-          <div className="mt-6 grid gap-4 md:grid-cols-3">
+          <SectionHeader
+            title="Reviewer navigation"
+            eyebrow="Inspect the bounded package"
+            description="Start with the bridge and release packet. PR #10 is draft demo-packaging work only and is not treated as merged proof."
+          />
+          <ReviewerLensTabs lenses={lenses} />
+          <div className="mt-6 grid gap-4 md:grid-cols-2 lg:grid-cols-4">
             <LinkCard
               href="https://github.com/HawkinsOperations/hoxline/pull/7"
-              title="Hoxline PR #7"
-              description="Draft product PR for the HO-DET-001 ProofCard v0 / Gauntlet controlled-validation bridge."
+              title="PR #7 bridge"
+              description="Merged HO-DET-001 ProofCard v0 / Gauntlet controlled-validation bridge."
+              external
+            />
+            <LinkCard
+              href="https://github.com/HawkinsOperations/hoxline/pull/9"
+              title="Release packet"
+              description="Merged reviewer packet summarizing the bridge, strategy docs, and website route."
+              external
+            />
+            <LinkCard
+              href="https://github.com/HawkinsOperations/hoxline/pull/10"
+              title="PR #10 draft"
+              description="Draft controlled demo packaging work. Demo packaging only; not merged proof."
               external
             />
             <LinkCard
@@ -141,14 +194,31 @@ export default function HoxlineReviewerRoutePage() {
               title="HO-DET-001 route"
               description="Existing website rendering route for the bounded HO-DET-001 reviewer case file."
             />
-            <LinkCard
-              href="/claim-firewall/"
-              title="Claim Firewall"
-              description="Internal Hoxline Claim Authority capability route."
-            />
           </div>
         </div>
       </section>
-    </>
+
+      <section className="proofops-section pb-24">
+        <div className="container proofops-grid-3">
+          <EvidenceCeilingCard
+            label="Controlled validation"
+            ceiling="CONTROLLED_TEST_VALIDATED"
+            detail="Fixture validation is the strongest claim supported here."
+          />
+          <EvidenceCeilingCard
+            label="Website route"
+            ceiling="RENDERING_ONLY"
+            detail="Website rendering is not proof and does not create proof authority."
+            tone="cyan"
+          />
+          <EvidenceCeilingCard
+            label="Promotion gate"
+            ceiling="HUMAN_REVIEW_REQUIRED"
+            detail="human_review_required remains true before stronger wording."
+            tone="blocked"
+          />
+        </div>
+      </section>
+    </div>
   );
 }

--- a/components/proofops/BlockedClaimGrid.tsx
+++ b/components/proofops/BlockedClaimGrid.tsx
@@ -1,0 +1,12 @@
+export default function BlockedClaimGrid({ claims }: { claims: string[] }) {
+  return (
+    <div className="proofops-blocked-grid" aria-label="Blocked claim families">
+      {claims.map((claim) => (
+        <div key={claim} className="proofops-blocked-grid__item">
+          <span>Blocked</span>
+          <strong>{claim}</strong>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/proofops/ClaimBoundaryPanel.tsx
+++ b/components/proofops/ClaimBoundaryPanel.tsx
@@ -1,0 +1,35 @@
+type Boundary = {
+  label: string;
+  value: string;
+  tone?: "cyan" | "amber" | "green" | "blocked" | "neutral";
+};
+
+export interface ClaimBoundaryPanelProps {
+  title?: string;
+  description?: string;
+  boundaries: Boundary[];
+}
+
+export default function ClaimBoundaryPanel({
+  title = "Claim boundary",
+  description = "The website renders reviewer context only. Authority remains with the owning evidence surfaces.",
+  boundaries,
+}: ClaimBoundaryPanelProps) {
+  return (
+    <section className="proofops-boundary" aria-labelledby="claim-boundary-title">
+      <div>
+        <p className="proofops-kicker">Authority boundary</p>
+        <h2 id="claim-boundary-title">{title}</h2>
+        <p>{description}</p>
+      </div>
+      <dl className="proofops-boundary__grid">
+        {boundaries.map((item) => (
+          <div key={item.label} className={`proofops-boundary__item proofops-boundary__item--${item.tone ?? "neutral"}`}>
+            <dt>{item.label}</dt>
+            <dd>{item.value}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}

--- a/components/proofops/EvidenceCeilingCard.tsx
+++ b/components/proofops/EvidenceCeilingCard.tsx
@@ -1,0 +1,21 @@
+export interface EvidenceCeilingCardProps {
+  label: string;
+  ceiling: string;
+  detail: string;
+  tone?: "cyan" | "amber" | "green" | "blocked" | "neutral";
+}
+
+export default function EvidenceCeilingCard({
+  label,
+  ceiling,
+  detail,
+  tone = "amber",
+}: EvidenceCeilingCardProps) {
+  return (
+    <article className={`proofops-ceiling proofops-ceiling--${tone}`}>
+      <p>{label}</p>
+      <h3>{ceiling}</h3>
+      <span>{detail}</span>
+    </article>
+  );
+}

--- a/components/proofops/ProofOpsLoopDiagram.tsx
+++ b/components/proofops/ProofOpsLoopDiagram.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+type ProofOpsStep = {
+  title: string;
+  happens: string;
+  control: string;
+  blocked: string;
+  tone: "labor" | "inspect" | "ceiling" | "blocked" | "human" | "safe";
+};
+
+const steps: ProofOpsStep[] = [
+  {
+    title: "AI-assisted security work",
+    happens: "AI helps draft, summarize, and organize security work.",
+    control: "AI is labor, not authority.",
+    blocked: "AI cannot approve claims or close cases.",
+    tone: "labor",
+  },
+  {
+    title: "Artifact Intake",
+    happens: "A specific artifact enters the reviewer path.",
+    control: "The artifact keeps its ID, source, and scope attached.",
+    blocked: "No unnamed work is promoted.",
+    tone: "inspect",
+  },
+  {
+    title: "Evidence Graph",
+    happens: "The graph links artifact, validation, runtime candidate, signal, review, and claim decision nodes.",
+    control: "References stay attached to authority sources.",
+    blocked: "Rendered cards do not become evidence.",
+    tone: "inspect",
+  },
+  {
+    title: "Telemetry Contract Check",
+    happens: "The expected telemetry family is checked against the artifact contract.",
+    control: "Telemetry expectations are separated from observation claims.",
+    blocked: "No signal observed status is claimed.",
+    tone: "inspect",
+  },
+  {
+    title: "Controlled Validation",
+    happens: "Controlled positive and negative fixtures define the current evidence state.",
+    control: "The ceiling is CONTROLLED_TEST_VALIDATED.",
+    blocked: "Controlled validation proves controlled validation only.",
+    tone: "ceiling",
+  },
+  {
+    title: "Runtime Candidate Ledger",
+    happens: "Runtime candidacy is represented as a future gate.",
+    control: "Runtime evidence must come from a separate authority path.",
+    blocked: "This page does not claim runtime-active status.",
+    tone: "blocked",
+  },
+  {
+    title: "Signal Observation",
+    happens: "Signal observation remains a distinct future gate.",
+    control: "Preserved signal evidence is required before stronger wording.",
+    blocked: "This page does not claim signal observed status.",
+    tone: "blocked",
+  },
+  {
+    title: "Human Review Gate",
+    happens: "A human review gate controls promotion.",
+    control: "human_review_required remains true.",
+    blocked: "Final authorization is not claimed here.",
+    tone: "human",
+  },
+  {
+    title: "ProofCard",
+    happens: "The ProofCard summarizes current evidence and blocked claims.",
+    control: "ProofCard rendering is not proof authority.",
+    blocked: "Website rendering is not proof.",
+    tone: "ceiling",
+  },
+  {
+    title: "Claim Authority",
+    happens: "Claim Firewall applies internal Hoxline Claim Authority rules.",
+    control: "Claim Firewall is a capability inside Hoxline.",
+    blocked: "Claim Firewall is not the product identity.",
+    tone: "human",
+  },
+  {
+    title: "Safe Claim / Blocked Claim",
+    happens: "A safe controlled-validation claim is allowed; stronger claim families stay blocked.",
+    control: "public_safe remains false.",
+    blocked: "This page does not claim public-safe proof.",
+    tone: "safe",
+  },
+];
+
+export default function ProofOpsLoopDiagram() {
+  const [activeIndex, setActiveIndex] = useState(4);
+  const activeStep = steps[activeIndex];
+
+  const statusLine = useMemo(
+    () => `${activeIndex + 1} of ${steps.length}: ${activeStep.title}`,
+    [activeIndex, activeStep.title],
+  );
+
+  return (
+    <section className="proofops-loop" aria-labelledby="proofops-loop-title">
+      <div className="proofops-loop__head">
+        <div>
+          <p className="proofops-kicker">Interactive ProofOps loop</p>
+          <h2 id="proofops-loop-title">AI helps. Evidence gates. Humans promote.</h2>
+        </div>
+        <p>{statusLine}</p>
+      </div>
+
+      <div className="proofops-loop__stage">
+        <ol className="proofops-loop__rail" aria-label="Hoxline ProofOps loop steps">
+          {steps.map((step, index) => (
+            <li key={step.title}>
+              <button
+                type="button"
+                className={`proofops-loop__step proofops-loop__step--${step.tone} ${
+                  index === activeIndex ? "is-active" : ""
+                }`}
+                aria-pressed={index === activeIndex}
+                aria-label={`Select step ${index + 1}: ${step.title}`}
+                onClick={() => setActiveIndex(index)}
+              >
+                <span className="proofops-loop__index">{String(index + 1).padStart(2, "0")}</span>
+                <span className="proofops-loop__label">{step.title}</span>
+              </button>
+            </li>
+          ))}
+        </ol>
+
+        <article className={`proofops-loop__detail proofops-loop__detail--${activeStep.tone}`} aria-live="polite">
+          <p className="proofops-loop__detail-kicker">Active gate</p>
+          <h3>{activeStep.title}</h3>
+          <dl>
+            <div>
+              <dt>What happens</dt>
+              <dd>{activeStep.happens}</dd>
+            </div>
+            <div>
+              <dt>Control</dt>
+              <dd>{activeStep.control}</dd>
+            </div>
+            <div>
+              <dt>Still blocked</dt>
+              <dd>{activeStep.blocked}</dd>
+            </div>
+          </dl>
+        </article>
+      </div>
+    </section>
+  );
+}

--- a/components/proofops/ProofOpsLoopDiagram.tsx
+++ b/components/proofops/ProofOpsLoopDiagram.tsx
@@ -105,6 +105,7 @@ export default function ProofOpsLoopDiagram() {
         <div>
           <p className="proofops-kicker">Interactive ProofOps loop</p>
           <h2 id="proofops-loop-title">AI helps. Evidence gates. Humans promote.</h2>
+          <p className="proofops-loop__hint">Tap a step to inspect the control.</p>
         </div>
         <p>{statusLine}</p>
       </div>

--- a/components/proofops/ProofOpsPageHero.tsx
+++ b/components/proofops/ProofOpsPageHero.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from "react";
+
+type HeroMetric = {
+  label: string;
+  value: string;
+  tone?: "cyan" | "amber" | "green" | "blocked" | "neutral";
+};
+
+export interface ProofOpsPageHeroProps {
+  eyebrow: string;
+  title: string;
+  accent?: string;
+  subtitle: string;
+  description: string;
+  metrics: HeroMetric[];
+  children?: ReactNode;
+}
+
+export default function ProofOpsPageHero({
+  eyebrow,
+  title,
+  accent,
+  subtitle,
+  description,
+  metrics,
+  children,
+}: ProofOpsPageHeroProps) {
+  return (
+    <section className="proofops-hero">
+      <div className="container proofops-hero__grid">
+        <div className="proofops-hero__copy">
+          <p className="proofops-kicker">{eyebrow}</p>
+          <h1 className="proofops-hero__title">
+            {title}
+            {accent && <span>{accent}</span>}
+          </h1>
+          <p className="proofops-hero__subtitle">{subtitle}</p>
+          <p className="proofops-hero__description">{description}</p>
+          <div className="proofops-hero__metrics" aria-label="Reviewer status">
+            {metrics.map((metric) => (
+              <div
+                key={`${metric.label}-${metric.value}`}
+                className={`proofops-metric proofops-metric--${metric.tone ?? "neutral"}`}
+              >
+                <span>{metric.label}</span>
+                <strong>{metric.value}</strong>
+              </div>
+            ))}
+          </div>
+        </div>
+        <aside className="proofops-hero__panel" aria-label="ProofOps boundary summary">
+          {children}
+        </aside>
+      </div>
+    </section>
+  );
+}

--- a/components/proofops/ReviewerLensTabs.tsx
+++ b/components/proofops/ReviewerLensTabs.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useState } from "react";
+
+export type ReviewerLens = {
+  label: string;
+  title: string;
+  body: string;
+  checkpoints: string[];
+};
+
+export default function ReviewerLensTabs({ lenses }: { lenses: ReviewerLens[] }) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const activeLens = lenses[activeIndex];
+
+  return (
+    <section className="proofops-tabs" aria-label="Reviewer lenses">
+      <div className="proofops-tabs__buttons" role="tablist" aria-label="Reviewer lens selector">
+        {lenses.map((lens, index) => (
+          <button
+            key={lens.label}
+            type="button"
+            role="tab"
+            aria-selected={activeIndex === index}
+            className={activeIndex === index ? "is-active" : ""}
+            onClick={() => setActiveIndex(index)}
+          >
+            {lens.label}
+          </button>
+        ))}
+      </div>
+      <article className="proofops-tabs__panel" role="tabpanel">
+        <p className="proofops-kicker">Reviewer lens</p>
+        <h3>{activeLens.title}</h3>
+        <p>{activeLens.body}</p>
+        <ul>
+          {activeLens.checkpoints.map((checkpoint) => (
+            <li key={checkpoint}>{checkpoint}</li>
+          ))}
+        </ul>
+      </article>
+    </section>
+  );
+}

--- a/components/proofops/SafeClaimCard.tsx
+++ b/components/proofops/SafeClaimCard.tsx
@@ -1,0 +1,10 @@
+export default function SafeClaimCard({ claim, detail }: { claim: string; detail: string }) {
+  return (
+    <article className="proofops-safe-claim">
+      <p className="proofops-kicker">Allowed wording</p>
+      <h3>Safe claim</h3>
+      <blockquote>{claim}</blockquote>
+      <p>{detail}</p>
+    </article>
+  );
+}

--- a/components/proofops/SignalBlockedBadge.tsx
+++ b/components/proofops/SignalBlockedBadge.tsx
@@ -1,0 +1,3 @@
+export default function SignalBlockedBadge({ label }: { label: string }) {
+  return <span className="proofops-blocked-badge">{label}</span>;
+}

--- a/components/proofops/index.ts
+++ b/components/proofops/index.ts
@@ -1,0 +1,9 @@
+export { default as BlockedClaimGrid } from "./BlockedClaimGrid";
+export { default as ClaimBoundaryPanel } from "./ClaimBoundaryPanel";
+export { default as EvidenceCeilingCard } from "./EvidenceCeilingCard";
+export { default as ProofOpsLoopDiagram } from "./ProofOpsLoopDiagram";
+export { default as ProofOpsPageHero } from "./ProofOpsPageHero";
+export { default as ReviewerLensTabs } from "./ReviewerLensTabs";
+export { default as SafeClaimCard } from "./SafeClaimCard";
+export { default as SignalBlockedBadge } from "./SignalBlockedBadge";
+export type { ReviewerLens } from "./ReviewerLensTabs";

--- a/docs/design/HOXLINE_WEBSITE_VISUAL_SYSTEM_V0.md
+++ b/docs/design/HOXLINE_WEBSITE_VISUAL_SYSTEM_V0.md
@@ -46,7 +46,21 @@ Artifacts already has a strong evidence-bay layout, cards with ceilings, and rev
 
 Before: the page read like a rendering report and made Hoxline feel smaller than the underlying proof packet.
 
-After: the first viewport names Hoxline by HawkinsOperations, shows `CONTROLLED_TEST_VALIDATED`, `public_safe false`, and `human_review_required true`, and routes into the interactive ProofOps loop.
+After v0 expansion: the page now reads as the flagship product route for Hoxline by HawkinsOperations. The first viewport names Hoxline as ProofOps control for the AI security era, states that AI is not authority and evidence is, shows `CONTROLLED_TEST_VALIDATED`, `public_safe false`, and `human_review_required true`, and gives reviewer route / controlled demo entry points before any doctrine-style boundary copy.
+
+New Hoxline flagship sections:
+
+- The Claim Problem: AI can draft convincing security claims faster than organizations can safely prove them.
+- Product Thesis: AI is not authority; evidence is.
+- What Hoxline Controls: AI output intake, evidence graphing, validation state, proof ceiling, claim decision, and reviewer handoff.
+- The Hoxline Answer: generated output, evidence, validation, proof records, public rendering, and claim authority remain separate.
+- Interactive ProofOps Loop: the canonical eleven-step loop stays interactive, with active detail near the controls.
+- HO-DET-001 Controlled Demo Spotlight: one artifact, one loop, one ProofCard context, one safe claim, and blocked stronger claims.
+- Claim Boundary Matrix: allowed, blocked, and required-review wording states.
+- Authority Architecture: seven-surface authority map for Hoxline, detections, validation, platform, proof, website, and organization routing.
+- Reviewer Start Path: controlled demo package, proof ceiling / blocked claims, then authority references.
+- Trust Boundary: compact non-claim panel.
+- Next Gate: evidence required before stronger claims.
 
 ### Detections
 
@@ -80,6 +94,18 @@ The diagram is implemented as buttons, supports keyboard focus, and uses an acti
 - Controlled validation proves controlled validation only.
 - Website rendering is not proof.
 
+## Interaction Model Update
+
+- ProofOps loop: connected staged control diagram on desktop, single-column stepper on mobile, neutral default steps, active step emphasis, visible focus, and the microcopy "Tap a step to inspect the control."
+- Reviewer lenses: tabbed views for Executive, Detection engineer, Reviewer, and Claim authority perspectives.
+- Claim matrix: compact allowed / blocked / required-review cards keep wording decisions scannable without converting the page into a report.
+
+## Mobile Fixes
+
+- Sticky header rendering is forced to a solid dark surface with a higher stacking context through `app/globals.css`, preventing content ghosting behind mobile nav.
+- Mobile ProofOps hero decoration removes the amber top-right radial glow so the `/detections/` route does not show the unwanted yellow / white artifact.
+- Loop controls collapse to a one-column stepper on narrow screens, avoiding horizontal overflow and keeping the active detail panel directly after the controls.
+
 ## Before / After Summary
 
 - Before: Hoxline, Detections, and AI Security used correct boundary text but did not feel like one product family.
@@ -97,4 +123,4 @@ This visual system does not claim runtime-active status, runtime proven status, 
 
 VISUAL_SCREENSHOT_UNAVAILABLE: project-local Playwright is not installed and the in-app browser surface was unavailable during this run.
 
-FIGMA_HANDOFF_UNAVAILABLE: no target Figma file or active local handoff was available. This design document is the repo-local handoff artifact.
+FIGMA_HANDOFF_TODO_AFTER_FLAGSHIP_REDESIGN: create a `Hoxline Product Page v0` frame with mobile hero, desktop hero, ProofOps loop diagram concept, authority map concept, and claim decision matrix when a target Figma file or active local handoff is available. This design document remains the repo-local handoff artifact.

--- a/docs/design/HOXLINE_WEBSITE_VISUAL_SYSTEM_V0.md
+++ b/docs/design/HOXLINE_WEBSITE_VISUAL_SYSTEM_V0.md
@@ -1,0 +1,100 @@
+# Hoxline Website Visual System v0
+
+Status: DESIGN_HANDOFF / WEBSITE_RENDERING_ONLY / NO_PROOF_PROMOTION
+
+Date: 2026-06-14
+
+## Design Goals
+
+- Make Hoxline visually obvious as the HawkinsOperations ProofOps product route.
+- Bring `/hoxline/`, `/detections/`, and `/ai-security/` into one product family.
+- Reduce report-like copy density by moving detail into cards, tabs, lifecycle strips, and an interactive loop diagram.
+- Keep proof ceilings, authority surfaces, and blocked claim families visible.
+- Preserve the rule that website rendering is not proof.
+
+## Color Roles
+
+- Dark command-center base: site background and panel depth.
+- Controlled cyan/blue: navigation, inspection, active diagram state, and source/validation routing.
+- Proof amber: proof ceiling and controlled-validation state.
+- Blocked red/pink: blocked claim families and promotion gates.
+- Emerald/green: safe or allowed wording only.
+- Slate/neutral: non-claims, rendering boundaries, and reviewer notes.
+
+## Component List
+
+- `ProofOpsPageHero`: shared hero with reviewer status metrics and first-screen product identity.
+- `ProofOpsLoopDiagram`: clickable and keyboard-selectable loop with active step detail.
+- `ClaimBoundaryPanel`: authority model and rendering-not-proof summary.
+- `ReviewerLensTabs`: density control for manager, engineer, and claim-boundary perspectives.
+- `EvidenceCeilingCard`: compact proof ceiling and status card.
+- `SignalBlockedBadge`: blocked status chip.
+- `SafeClaimCard`: allowed wording panel.
+- `BlockedClaimGrid`: blocked claim family grid.
+
+## Page-By-Page Audit Notes
+
+### Home
+
+Home already has the strongest cockpit rhythm: proof spine, reviewer mode, six-door navigation, and artifact bridge. No home rewrite was required.
+
+### Artifacts
+
+Artifacts already has a strong evidence-bay layout, cards with ceilings, and reviewer routes. No rewrite was required.
+
+### Hoxline
+
+Before: the page read like a rendering report and made Hoxline feel smaller than the underlying proof packet.
+
+After: the first viewport names Hoxline by HawkinsOperations, shows `CONTROLLED_TEST_VALIDATED`, `public_safe false`, and `human_review_required true`, and routes into the interactive ProofOps loop.
+
+### Detections
+
+Before: the page was a linear list of detection cards with limited visual rhythm.
+
+After: it includes a compact lifecycle strip, a flagship HO-DET-001 controlled-validation feature, shared ceiling cards, and a blocked-claim grid.
+
+### AI Security
+
+Before: the route was accurate but dense and report-like.
+
+After: it separates AI support, deterministic verifier, human authority, proof ceiling, and blocked claims with reusable components and the shared ProofOps loop.
+
+## Diagram Design Spec
+
+The diagram shows the canonical Hoxline loop:
+
+AI-assisted security work -> Artifact Intake -> Evidence Graph -> Telemetry Contract Check -> Controlled Validation -> Runtime Candidate Ledger -> Signal Observation -> Human Review Gate -> ProofCard -> Claim Authority -> Safe Claim / Blocked Claim
+
+Each step exposes:
+
+- what happens
+- what control applies
+- what remains blocked
+
+The diagram is implemented as buttons, supports keyboard focus, and uses an active detail panel. It makes these boundaries visible:
+
+- AI is labor.
+- Evidence is authority.
+- Human review gates promotion.
+- Controlled validation proves controlled validation only.
+- Website rendering is not proof.
+
+## Before / After Summary
+
+- Before: Hoxline, Detections, and AI Security used correct boundary text but did not feel like one product family.
+- After: all three routes use the same ProofOps cockpit components, colors, cards, and diagram language.
+- Before: much of the copy was long-form report prose.
+- After: primary information is split into lifecycle strips, cards, tabs, and route links.
+- Before: Hoxline was a reviewer route.
+- After: Hoxline is presented as the product route while still preserving rendering-only boundaries.
+
+## What Remains Blocked
+
+This visual system does not claim runtime-active status, runtime proven status, signal observed status, public-safe proof, production-ready status, SOCaaS-ready status, SOCaaS deployed status, customer deployed status, live Splunk fired status, Cribl routed live telemetry, Wazuh routed live telemetry, AWS-live status, autonomous SOC operation, AI approved disposition, analyst approved disposition, final human authorization, case closed status, public runtime proof, public signal proof, enterprise purchase intent, customer traction, revenue, legal availability, trademark clearance, LLC formation, or product-market fit.
+
+## Screenshot And Figma Notes
+
+VISUAL_SCREENSHOT_UNAVAILABLE: project-local Playwright is not installed and the in-app browser surface was unavailable during this run.
+
+FIGMA_HANDOFF_UNAVAILABLE: no target Figma file or active local handoff was available. This design document is the repo-local handoff artifact.


### PR DESCRIPTION
## Summary

Upgrades `/hoxline/`, `/detections/`, and `/ai-security/` onto a shared Hoxline / ProofOps cockpit visual system. Adds an interactive ProofOps loop diagram, denser-but-clearer reviewer navigation, shared claim-boundary components, and a repo-local design handoff because screenshots/Figma handoff were unavailable.

## Pages Changed

- `/hoxline/`
- `/detections/`
- `/ai-security/`

## Components Added/Updated

- `components/proofops/ProofOpsPageHero.tsx`
- `components/proofops/ProofOpsLoopDiagram.tsx`
- `components/proofops/ClaimBoundaryPanel.tsx`
- `components/proofops/ReviewerLensTabs.tsx`
- `components/proofops/EvidenceCeilingCard.tsx`
- `components/proofops/SignalBlockedBadge.tsx`
- `components/proofops/SafeClaimCard.tsx`
- `components/proofops/BlockedClaimGrid.tsx`
- `components/proofops/index.ts`
- Shared CSS in `app/globals.css`
- Design handoff: `docs/design/HOXLINE_WEBSITE_VISUAL_SYSTEM_V0.md`

## Visual Audit Findings

- Home and Artifacts already had stronger cockpit-style visual rhythm and reviewer navigation.
- Hoxline was accurate but too report-like for the product route.
- Detections and AI Security were correct but text-heavy and linear.
- The three upgraded routes now share one visual language: dark command-center base, cyan/blue inspection accents, amber proof-ceiling accents, blocked red/pink claim boundaries, and green safe/allowed wording.

## Diagram Behavior

`ProofOpsLoopDiagram` renders the canonical Hoxline loop as clickable, keyboard-focusable step buttons with an active detail panel. Each step shows what happens, what control applies, and what remains blocked. The diagram keeps AI as labor, evidence as authority, human review as promotion gate, and website rendering as non-proof.

## Validation Results

- `npm run typecheck`: pass
- `npm run check:site`: pass
- `npm run build`: pass
- `git diff --check`: pass
- Local HTTP checks for `/hoxline/`, `/detections/`, and `/ai-security/`: HTTP 200 with ProofOps/boundary content present
- No `npm test` or `npm run lint` scripts are present in `package.json`

## Claim-Boundary Classification

Changed-file search hits were classified as `OK_NEGATIVE_BOUNDARY`, `OK_BLOCKED_CLAIM`, or `OK_REQUIRED_NEXT_EVIDENCE`. No factual promotion was found.

## Proof Ceiling

CONTROLLED_TEST_VALIDATED where the HO-DET-001 bridge is referenced.

## public_safe

false

## human_review_required

true

## Non-Claims

This PR does not create proof authority, runtime truth, signal truth, public-safe proof, production readiness, SOCaaS availability, customer deployment, autonomous SOC operation, AI-approved disposition, analyst-approved disposition, final human authorization, public runtime proof, public signal proof, legal availability, revenue, product-market fit, or case closure.

## Blockers

None found during local validation and self-audit.

## Screenshots Availability Note

VISUAL_SCREENSHOT_UNAVAILABLE: project-local Playwright is not installed and the in-app browser surface was unavailable during this run. Local HTTP route checks and production build validation passed.

## Figma Availability Note

FIGMA_HANDOFF_UNAVAILABLE: no target Figma file or active local handoff was available. A repo-local design handoff doc was created instead.