### PR TITLE
Fix Hoxline route discovery and legacy AevumGuard route

### DIFF
--- a/app/aevumguard/page.tsx
+++ b/app/aevumguard/page.tsx
@@ -1,84 +1,127 @@
 import type { Metadata } from "next";
-import BoundaryNotice from "@components/BoundaryNotice";
 import LinkCard from "@components/LinkCard";
-import PageHero from "@components/PageHero";
 import SectionHeader from "@components/SectionHeader";
+import {
+  ClaimBoundaryPanel,
+  EvidenceCeilingCard,
+  SignalBlockedBadge,
+} from "@components/proofops";
 import { externalLinks } from "@data/navigation";
 
-const productLoop = [
-  "AI-assisted security work",
-  "Artifact Intake",
-  "Evidence Graph",
-  "Telemetry Contract Check",
-  "Controlled Validation",
-  "Runtime Candidate Ledger",
-  "Signal Observation",
-  "Human Review Gate",
-  "ProofCard",
-  "Claim Authority",
-  "Safe Claim / Blocked Claim",
-];
-
 export const metadata: Metadata = {
-  title: "Hoxline | HawkinsOperations",
+  title: "Hoxline moved | HawkinsOperations",
   description:
-    "Hoxline separates AI output from evidence-bound claim authority.",
+    "AevumGuard is a legacy compatibility route. Hoxline by HawkinsOperations is the current product front door.",
   alternates: {
-    canonical: "/aevumguard/",
+    canonical: "/hoxline/",
   },
 };
 
-export default function HoxlinePage() {
+export default function AevumGuardCompatibilityPage() {
   return (
-    <>
-      <PageHero
-        title="Hoxline"
-        subtitle="ProofOps control for the AI security era."
-        description="Hoxline separates AI output from evidence-bound claim authority."
-        badges={[{ label: "PRODUCT_FRONT_DOOR" }, { label: "RENDERING_ONLY" }]}
-      />
-
-      <section className="cockpit-section--tight">
-        <div className="container reveal reveal--up">
-          <SectionHeader title="Product Doctrine" eyebrow="Hoxline" />
-          <p className="muted mt-3 max-w-3xl text-sm leading-6">
-            AI is not the authority. Evidence is. HawkinsOperations is the brand/system;
-            Hoxline is the product/front-door repo for the governed product experience.
-          </p>
-          <div className="mt-6 grid gap-4 md:grid-cols-2">
+    <div className="proofops-page">
+      <section className="proofops-hero">
+        <div className="container proofops-hero__grid">
+          <div className="proofops-hero__copy">
+            <p className="proofops-kicker">Legacy compatibility route</p>
+            <h1 className="proofops-hero__title">
+              Hoxline
+              <span>moved</span>
+            </h1>
+            <p className="proofops-hero__subtitle">
+              AevumGuard was legacy naming. Hoxline by HawkinsOperations is the current product front door.
+            </p>
+            <p className="proofops-hero__description">
+              Use the current `/hoxline/` route for the flagship ProofOps control-plane page. This compatibility route exists only for older links and does not create proof authority.
+            </p>
+            <div className="proofops-hero__metrics" aria-label="Legacy route status">
+              <div className="proofops-metric proofops-metric--cyan">
+                <span>Current route</span>
+                <strong>/hoxline/</strong>
+              </div>
+              <div className="proofops-metric proofops-metric--amber">
+                <span>Legacy route</span>
+                <strong>/aevumguard/</strong>
+              </div>
+              <div className="proofops-metric proofops-metric--blocked">
+                <span>public_safe</span>
+                <strong>false</strong>
+              </div>
+              <div className="proofops-metric proofops-metric--green">
+                <span>Human review</span>
+                <strong>required</strong>
+              </div>
+            </div>
+          </div>
+          <aside className="proofops-hero__panel" aria-label="Current Hoxline route">
+            <p className="proofops-kicker">Open current product page</p>
             <LinkCard
-              href={externalLinks.aevumguard}
-              title="Hoxline repo"
-              description="Compatibility repo path for Hoxline by HawkinsOperations and Claim Authority capabilities."
-              external
+              href="/hoxline/"
+              title="Open Hoxline"
+              description="Go to the current ProofOps control-plane product route."
             />
             <LinkCard
-              href="/claim-firewall/"
-              title="Claim Firewall capability"
-              description="Legacy capability route for the internal Hoxline Claim Authority wording enforcement edge."
+              href={externalLinks.hoxline}
+              title="Hoxline repo"
+              description="Open the current Hoxline source repository."
+              external
+            />
+          </aside>
+        </div>
+      </section>
+
+      <section className="proofops-section">
+        <div className="container">
+          <SectionHeader
+            title="Compatibility only"
+            eyebrow="AevumGuard legacy boundary"
+            description="This page is not the product front door. It exists to move older links toward Hoxline while keeping proof and claim boundaries visible."
+          />
+          <div className="proofops-grid-3">
+            <EvidenceCeilingCard
+              label="Current product route"
+              ceiling="/hoxline/"
+              detail="The flagship Hoxline page is the public product route."
+              tone="cyan"
+            />
+            <EvidenceCeilingCard
+              label="Legacy name"
+              ceiling="AevumGuard"
+              detail="Legacy naming only; not the current product front door."
+              tone="amber"
+            />
+            <EvidenceCeilingCard
+              label="Website role"
+              ceiling="RENDERING_ONLY"
+              detail="Website rendering routes reviewers and users. It is not proof."
+              tone="blocked"
             />
           </div>
         </div>
       </section>
 
-      <section className="cockpit-section--tight">
-        <div className="container reveal reveal--up">
-          <SectionHeader title="Core Loop" eyebrow="Product flow" />
-          <ol className="claim-firewall-demo__outcomes" aria-label="Hoxline core loop">
-            {productLoop.map((step, index) => (
-              <li key={step}>
-                <span>{String(index + 1).padStart(2, "0")}</span>
-                <strong>{step}</strong>
-                <em>{index === productLoop.length - 1 ? "claim state" : "next"}</em>
-              </li>
-            ))}
-          </ol>
+      <section className="proofops-section pb-24">
+        <div className="container">
+          <ClaimBoundaryPanel
+            title="Legacy route trust boundary"
+            description="Hoxline remains the product route, but neither this compatibility page nor the website creates proof authority or stronger claim status."
+            boundaries={[
+              { label: "Website rendering", value: "not proof", tone: "neutral" },
+              { label: "Hoxline", value: "not proof authority", tone: "cyan" },
+              { label: "Controlled validation", value: "current ceiling only", tone: "green" },
+              { label: "public_safe", value: "false", tone: "blocked" },
+              { label: "Human review", value: "required", tone: "amber" },
+              { label: "Stronger claims", value: "blocked", tone: "blocked" },
+            ]}
+          />
+          <div className="mt-6 flex flex-wrap gap-2">
+            <SignalBlockedBadge label="runtime not claimed" />
+            <SignalBlockedBadge label="signal not claimed" />
+            <SignalBlockedBadge label="production not claimed" />
+            <SignalBlockedBadge label="customer not claimed" />
+          </div>
         </div>
       </section>
-
-      <section className="container cockpit-section--tight">
-        <BoundaryNotice text="RENDERING_ONLY: this page changes public website wording and routing only. Runtime, signal, public-safe, production, customer, SOCaaS, autonomous SOC, AI-approved, analyst-approved, and case-closed claims remain blocked / not claimed." />
-      </section>
-    </>
+    </div>
   );
 }

--- a/app/claim-firewall/page.tsx
+++ b/app/claim-firewall/page.tsx
@@ -44,7 +44,7 @@ export default function ClaimFirewallPage() {
             <p>Hoxline is the product identity for the current product/front-door repo. Claim Firewall is not the product, platform, front-door repo, or an eighth repo.</p>
             <p>Website rendering is not proof authority. Claim Firewall supports claim hygiene only as an internal capability.</p>
             <div className="controls-hero__pills" aria-label="Claim Firewall external links">
-              <a href="https://github.com/HawkinsOperations/aevumguard" target="_blank" rel="noopener noreferrer">
+              <a href="https://github.com/HawkinsOperations/hoxline" target="_blank" rel="noopener noreferrer">
                 <span>View Hoxline repo</span>
               </a>
               <a href="https://github.com/orgs/HawkinsOperations/discussions/51" target="_blank" rel="noopener noreferrer">

--- a/app/controls/page.tsx
+++ b/app/controls/page.tsx
@@ -5,7 +5,7 @@ export const metadata: Metadata = {
   description:
     "The /controls/ route remains as a compatibility page. Hoxline is the product front door; Claim Firewall is an internal Claim Authority capability.",
   alternates: {
-    canonical: "/aevumguard/",
+    canonical: "/hoxline/",
   },
 };
 
@@ -25,7 +25,7 @@ export default function ControlsPage() {
             Claim Firewall remains an internal Hoxline Claim Authority enforcement capability. This /controls/ route remains as a compatibility page for older reviewer links.
           </p>
           <div className="controls-hero__pills" aria-label="Controls compatibility route">
-            <a href="/aevumguard/">
+            <a href="/hoxline/">
               <span>Open Hoxline</span>
             </a>
             <a href="/claim-firewall/">

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -5,7 +5,6 @@ import { recentGovernedArtifacts } from "@data/recentGovernedArtifacts";
 
 const staticRoutes = [
   "/",
-  "/aevumguard/",
   "/hoxline/",
   "/proof/",
   "/artifacts/",

--- a/components/ClaimFirewall.tsx
+++ b/components/ClaimFirewall.tsx
@@ -59,15 +59,15 @@ const authorityStack = [
   ["platform", "control mechanics"],
   ["proof", "proof and claim authority"],
   ["website", "rendering only"],
-  ["aevumguard", "product front door"],
+  ["hoxline", "product front door"],
   ["Claim Firewall", "internal Hoxline capability"],
 ] as const;
 
 const receipts = [
   {
     label: "Product repo",
-    value: "HawkinsOperations/aevumguard",
-    href: "https://github.com/HawkinsOperations/aevumguard",
+    value: "HawkinsOperations/hoxline",
+    href: "https://github.com/HawkinsOperations/hoxline",
   },
   {
     label: "Announcement",

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -74,7 +74,7 @@ export default function Footer() {
               </a>
             </li>
             <li>
-              <a href={externalLinks.aevumguard} target="_blank" rel="noopener noreferrer">
+              <a href={externalLinks.hoxline} target="_blank" rel="noopener noreferrer">
                 Hoxline ↗
               </a>
             </li>

--- a/public/.well-known/hawkinsoperations-proof.json
+++ b/public/.well-known/hawkinsoperations-proof.json
@@ -22,9 +22,9 @@
       "use": "Review public proof navigation, verifier cards, and claim ceilings."
     },
     {
-      "id": "aevumguard",
+      "id": "hoxline",
       "label": "Hoxline",
-      "url": "https://hawkinsoperations.com/aevumguard/",
+      "url": "https://hawkinsoperations.com/hoxline/",
       "use": "Review the product front door and Claim Authority boundary without inferring runtime or signal truth."
     },
     {

--- a/public/agent.md
+++ b/public/agent.md
@@ -7,7 +7,7 @@ This public website exposes read, review, and navigation metadata for agents and
 - `/.well-known/hawkinsoperations-proof.json`
 - `/.well-known/agent-skills/index.json`
 - `/proof/`
-- `/aevumguard/`
+- `/hoxline/`
 - `/validation/`
 - `/architecture/truth-surfaces/`
 - `/architecture/repo-authority-map/`

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,7 +3,9 @@
   <url><loc>https://hawkinsoperations.com/</loc></url>
   <url><loc>https://hawkinsoperations.com/pipeline/</loc></url>
   <url><loc>https://hawkinsoperations.com/proof/</loc></url>
-  <url><loc>https://hawkinsoperations.com/aevumguard/</loc></url>
+  <url><loc>https://hawkinsoperations.com/hoxline/</loc></url>
+  <url><loc>https://hawkinsoperations.com/detections/</loc></url>
+  <url><loc>https://hawkinsoperations.com/ai-security/</loc></url>
   <url><loc>https://hawkinsoperations.com/proof/ho-det-001/</loc></url>
   <url><loc>https://hawkinsoperations.com/artifacts/</loc></url>
   <url><loc>https://hawkinsoperations.com/about/</loc></url>

--- a/scripts/verify-site-contract.mjs
+++ b/scripts/verify-site-contract.mjs
@@ -61,7 +61,7 @@ const navigationData = readFileSync(join(root, "src/data/navigation.ts"), "utf8"
 const primaryNavMatch = navigationData.match(/export const primaryNavigation: NavItem\[] = \[([\s\S]*?)\];/);
 const expectedPrimaryNav = [
   { label: "Home", href: "/" },
-  { label: "Hoxline", href: "/aevumguard/" },
+  { label: "Hoxline", href: "/hoxline/" },
   { label: "Proof", href: "/proof/" },
   { label: "Artifacts", href: "/artifacts/" },
   { label: "Detections", href: "/detections/" },
@@ -143,28 +143,25 @@ const proofHoDet001Page = readFileSync(join(root, "app/proof/ho-det-001/page.tsx
 const currentProofSpine = readFileSync(join(root, "components/CurrentProofSpine.tsx"), "utf8");
 const claimFirewallPage = readFileSync(join(root, "app/claim-firewall/page.tsx"), "utf8");
 const aevumguardPage = readFileSync(join(root, "app/aevumguard/page.tsx"), "utf8");
+const hoxlinePage = readFileSync(join(root, "app/hoxline/page.tsx"), "utf8");
 const controlsPage = readFileSync(join(root, "app/controls/page.tsx"), "utf8");
 const claimFirewallComponent = readFileSync(join(root, "components/ClaimFirewall.tsx"), "utf8");
 const proofRecordsData = readFileSync(join(root, "src/data/proofRecords.ts"), "utf8");
 const navigationSource = readFileSync(join(root, "src/data/navigation.ts"), "utf8");
 const hoxlineFrontDoorRequiredTerms = [
   ["src/data/navigation.ts", navigationSource, 'label: "Hoxline"'],
-  ["src/data/navigation.ts", navigationSource, 'href: "/aevumguard/"'],
-  ["src/data/navigation.ts", navigationSource, "aevumguard"],
-  ["app/aevumguard/page.tsx", aevumguardPage, "Hoxline separates AI output from evidence-bound claim authority."],
-  ["app/aevumguard/page.tsx", aevumguardPage, "ProofOps control for the AI security era."],
-  ["app/aevumguard/page.tsx", aevumguardPage, "AI is not the authority. Evidence is."],
-  ["app/aevumguard/page.tsx", aevumguardPage, "AI-assisted security work"],
-  ["app/aevumguard/page.tsx", aevumguardPage, "Artifact Intake"],
-  ["app/aevumguard/page.tsx", aevumguardPage, "Evidence Graph"],
-  ["app/aevumguard/page.tsx", aevumguardPage, "Telemetry Contract Check"],
-  ["app/aevumguard/page.tsx", aevumguardPage, "Controlled Validation"],
-  ["app/aevumguard/page.tsx", aevumguardPage, "Runtime Candidate Ledger"],
-  ["app/aevumguard/page.tsx", aevumguardPage, "Signal Observation"],
-  ["app/aevumguard/page.tsx", aevumguardPage, "Human Review Gate"],
-  ["app/aevumguard/page.tsx", aevumguardPage, "ProofCard"],
-  ["app/aevumguard/page.tsx", aevumguardPage, "Claim Authority"],
-  ["app/aevumguard/page.tsx", aevumguardPage, "Safe Claim / Blocked Claim"],
+  ["src/data/navigation.ts", navigationSource, 'href: "/hoxline/"'],
+  ["src/data/navigation.ts", navigationSource, "hoxline"],
+  ["app/hoxline/page.tsx", hoxlinePage, "ProofOps control for the AI security era."],
+  ["app/hoxline/page.tsx", hoxlinePage, "AI is not the authority. Evidence is."],
+  ["app/hoxline/page.tsx", hoxlinePage, "The Claim Problem"],
+  ["app/hoxline/page.tsx", hoxlinePage, "HO-DET-001 Controlled Demo Spotlight"],
+  ["app/hoxline/page.tsx", hoxlinePage, "Authority Architecture"],
+  ["app/hoxline/page.tsx", hoxlinePage, "Next Gate"],
+  ["app/aevumguard/page.tsx", aevumguardPage, "Legacy compatibility route"],
+  ["app/aevumguard/page.tsx", aevumguardPage, "AevumGuard was legacy naming"],
+  ["app/aevumguard/page.tsx", aevumguardPage, 'canonical: "/hoxline/"'],
+  ["app/aevumguard/page.tsx", aevumguardPage, 'href="/hoxline/"'],
   ["app/proof/page.tsx", proofPage, "Claim Firewall control surface"],
   ["app/proof/page.tsx", proofPage, "Open Claim Firewall"],
   ["app/proof/page.tsx", proofPage, "website rendering below proof authority"],
@@ -173,7 +170,7 @@ const hoxlineFrontDoorRequiredTerms = [
   ["app/claim-firewall/page.tsx", claimFirewallPage, "Claim Firewall is not the product, platform, front-door repo, or an eighth repo."],
   ["app/claim-firewall/page.tsx", claimFirewallPage, "Website rendering is not proof"],
   ["app/claim-firewall/page.tsx", claimFirewallPage, "Public proof requires evidence linkage and explicit promotion."],
-  ["app/controls/page.tsx", controlsPage, 'href="/aevumguard/"'],
+  ["app/controls/page.tsx", controlsPage, 'href="/hoxline/"'],
   ["app/controls/page.tsx", controlsPage, "Compatibility only"],
 ];
 const hoxlineFrontDoorFailures = hoxlineFrontDoorRequiredTerms
@@ -350,11 +347,14 @@ if (!Array.isArray(discoveryProof.blocked_claims) || !discoveryProof.blocked_cla
 if (!Array.isArray(discoveryProof.reviewer_routes) || discoveryProof.reviewer_routes.length < 4) {
   discoveryFailures.push("public/.well-known/hawkinsoperations-proof.json must expose reviewer_routes for machine-readable navigation.");
 }
-if (!discoveryProof.reviewer_routes?.some((route) => route.id === "aevumguard" && route.url === "https://hawkinsoperations.com/aevumguard/")) {
-  discoveryFailures.push("public/.well-known/hawkinsoperations-proof.json must expose /aevumguard/ as the product front-door reviewer route.");
+if (!discoveryProof.reviewer_routes?.some((route) => route.id === "hoxline" && route.url === "https://hawkinsoperations.com/hoxline/")) {
+  discoveryFailures.push("public/.well-known/hawkinsoperations-proof.json must expose /hoxline/ as the product front-door reviewer route.");
 }
-if (!agentMarkdown.includes("/aevumguard/")) {
-  discoveryFailures.push("public/agent.md must list /aevumguard/ as a public entry point.");
+if (!agentMarkdown.includes("/hoxline/")) {
+  discoveryFailures.push("public/agent.md must list /hoxline/ as a public entry point.");
+}
+if (agentMarkdown.includes("/aevumguard/")) {
+  discoveryFailures.push("public/agent.md must not list /aevumguard/ as a current public entry point.");
 }
 if (agentMarkdown.includes("/claim-firewall/")) {
   discoveryFailures.push("public/agent.md must not list /claim-firewall/ as a public discovery entry point.");

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -6,7 +6,7 @@ export type NavItem = {
 
 export const primaryNavigation: NavItem[] = [
   { label: "Home", href: "/", description: "Reviewer cockpit" },
-  { label: "Hoxline", href: "/aevumguard/", description: "Product front door" },
+  { label: "Hoxline", href: "/hoxline/", description: "Product front door" },
   { label: "Proof", href: "/proof/", description: "Claim authority" },
   { label: "Artifacts", href: "/artifacts/", description: "Reviewer receipts" },
   { label: "Detections", href: "/detections/", description: "Detection engineering" },
@@ -36,7 +36,8 @@ export const externalLinks = {
   validation: "https://github.com/HawkinsOperations/hawkinsoperations-validation",
   platform: "https://github.com/HawkinsOperations/hawkinsoperations-platform",
   proof: "https://github.com/HawkinsOperations/hawkinsoperations-proof",
-  aevumguard: "https://github.com/HawkinsOperations/aevumguard",
+  hoxline: "https://github.com/HawkinsOperations/hoxline",
+  legacyAevumGuard: "https://github.com/HawkinsOperations/aevumguard",
   governanceSavesCandidates: "https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/docs/governance-saves/GOVERNANCE-SAVES-CANDIDATES.md",
   governanceSavesEvidenceMatrix: "https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/docs/governance-saves/GOVERNANCE-SAVES-EVIDENCE-MATRIX.md",
   platformDetectionFactoryController: "https://github.com/HawkinsOperations/hawkinsoperations-platform/blob/main/docs/factory/DETECTION_FACTORY_CONTROLLER_V0.md",

--- a/src/data/repos.ts
+++ b/src/data/repos.ts
@@ -51,8 +51,8 @@ export const repos: RepoRecord[] = [
     doesNotProve: "Unlinked runtime state or claims outside the record.",
   },
   {
-    name: "aevumguard",
-    href: externalLinks.aevumguard,
+    name: "hoxline",
+    href: externalLinks.hoxline,
     purpose: "Product front-door repo for governed AI-assisted security work.",
     truthSurface: "Product / front door",
     owns: "Hoxline product framing and Claim Authority capabilities, starting with Claim Firewall.",


### PR DESCRIPTION
## Summary

Fixes the post-merge Hoxline route discovery problem after PR #64. The flagship product page remains `/hoxline/`, and normal navigation/discovery now points users there instead of the legacy `/aevumguard/` route.

## Files Changed

- `src/data/navigation.ts`
- `src/data/repos.ts`
- `app/aevumguard/page.tsx`
- `app/controls/page.tsx`
- `app/claim-firewall/page.tsx`
- `app/sitemap.ts`
- `components/Footer.tsx`
- `components/ClaimFirewall.tsx`
- `public/.well-known/hawkinsoperations-proof.json`
- `public/agent.md`
- `public/sitemap.xml`
- `scripts/verify-site-contract.mjs`

## Why Needed

PR #64 successfully created the expanded `/hoxline/` flagship product page, but the primary nav and public discovery metadata still treated `/aevumguard/` as the Hoxline front door. That caused normal users to land on the old short Product Doctrine route instead of the new product page.

## Nav Update

- Primary nav `Hoxline` now points to `/hoxline/`.
- Current Hoxline repo link now uses `https://github.com/HawkinsOperations/hoxline`.
- Legacy AevumGuard repo reference is retained only as `legacyAevumGuard` compatibility metadata.

## Legacy Route Behavior

- `/aevumguard/` no longer renders the old Product Doctrine/Core Loop front-door page.
- It now renders a compact legacy compatibility page titled `Hoxline moved`.
- The page states that AevumGuard was legacy naming, Hoxline is current, and the current product route is `/hoxline/`.
- Canonical is `/hoxline/`.
- Proof boundaries remain visible: website rendering is not proof; Hoxline is not proof authority; `public_safe` remains false; human review remains required.

## Sitemap / Discovery Update

- `app/sitemap.ts` keeps `/hoxline/` and removes `/aevumguard/` from generated static routes.
- Checked-in `public/sitemap.xml` now includes `/hoxline/`, `/detections/`, and `/ai-security/`, and no longer promotes `/aevumguard/`.
- `public/.well-known/hawkinsoperations-proof.json` reviewer route now uses id `hoxline` and URL `https://hawkinsoperations.com/hoxline/`.
- `public/agent.md` now lists `/hoxline/` instead of `/aevumguard/`.
- `scripts/verify-site-contract.mjs` now enforces `/hoxline/` as the product front-door invariant.

## Validation Results

Baseline on `main` before edits:
- `npm run typecheck`: pass
- `npm run check:site`: pass
- `npm run build`: pass
- `git diff --check`: pass

After edits:
- `npm run typecheck`: pass
- `npm run check:site`: pass
- `npm run build`: pass
- `git diff --check`: pass

Local HTTP checks passed:
- `/`: 200
- `/hoxline/`: 200
- `/aevumguard/`: 200 compatibility page
- `/detections/`: 200
- `/ai-security/`: 200
- `/sitemap.xml`: 200

Content checks passed:
- Primary nav Hoxline href is `/hoxline/`.
- `/hoxline/` contains `The Claim Problem`, `HO-DET-001 Controlled Demo Spotlight`, `Authority Architecture`, and `Next Gate`.
- `/aevumguard/` points clearly to `/hoxline/`.
- `/aevumguard/` no longer shows old Product Doctrine/Core Loop content.
- Sitemap includes `/hoxline/` and excludes `/aevumguard/`.

No `npm test` or `npm run lint` scripts exist in `package.json`.

## Claim-Boundary Classifications

Changed-file search hits were classified as:
- `OK_NEGATIVE_BOUNDARY`: proof authority separation, not-proof wording, public_safe false, not claimed states.
- `OK_BLOCKED_CLAIM`: blocked examples and policy terms for runtime, signal, production, customer, SOCaaS, approval, authorization, and case closure.
- `OK_REQUIRED_NEXT_EVIDENCE`: validation-policy terms requiring separate evidence before stronger claims.
- `OK_LEGACY_COMPATIBILITY`: AevumGuard references limited to the compatibility route and legacy naming.

No blocker classifications found.

## Non-Claims

This PR does not claim runtime-active status, signal observed status, public-safe proof, production-ready status, SOCaaS readiness, SOCaaS deployment, customer deployment, autonomous SOC operation, AI approval, analyst approval, final authorization, case closure, public runtime proof, public signal proof, revenue, legal availability, trademark clearance, LLC formation, or product-market fit.

## Blockers

None found.

## Recommendation

Ready for preview deploy and phone/browser verification. Do not merge until the preview confirms navigation, `/aevumguard/` compatibility behavior, and sitemap/discovery surfaces are correct.