### PR TITLE
Normalize Hoxline naming across public surfaces

### DIFF
--- a/app/aevumguard/page.tsx
+++ b/app/aevumguard/page.tsx
@@ -11,13 +11,13 @@ import { externalLinks } from "@data/navigation";
 export const metadata: Metadata = {
   title: "Hoxline moved | HawkinsOperations",
   description:
-    "AevumGuard is a legacy compatibility route. Hoxline by HawkinsOperations is the current product front door.",
+    "AevumGuard was a prior working name. Hoxline by HawkinsOperations is the current product front door.",
   alternates: {
     canonical: "/hoxline/",
   },
 };
 
-export default function AevumGuardCompatibilityPage() {
+export default function HoxlineCompatibilityPage() {
   return (
     <div className="proofops-page">
       <section className="proofops-hero">
@@ -29,7 +29,7 @@ export default function AevumGuardCompatibilityPage() {
               <span>moved</span>
             </h1>
             <p className="proofops-hero__subtitle">
-              AevumGuard was legacy naming. Hoxline by HawkinsOperations is the current product front door.
+              AevumGuard was a prior working name. Hoxline by HawkinsOperations is the current product front door.
             </p>
             <p className="proofops-hero__description">
               Use the current `/hoxline/` route for the flagship ProofOps control-plane page. This compatibility route exists only for older links and does not create proof authority.
@@ -74,7 +74,7 @@ export default function AevumGuardCompatibilityPage() {
         <div className="container">
           <SectionHeader
             title="Compatibility only"
-            eyebrow="AevumGuard legacy boundary"
+            eyebrow="Prior-name boundary"
             description="This page is not the product front door. It exists to move older links toward Hoxline while keeping proof and claim boundaries visible."
           />
           <div className="proofops-grid-3">
@@ -86,8 +86,8 @@ export default function AevumGuardCompatibilityPage() {
             />
             <EvidenceCeilingCard
               label="Legacy name"
-              ceiling="AevumGuard"
-              detail="Legacy naming only; not the current product front door."
+              ceiling="prior working name"
+              detail="AevumGuard was a prior working name. Hoxline is the current product name."
               tone="amber"
             />
             <EvidenceCeilingCard

--- a/docs/design/WEBSITE_PR68_ORG_SYSTEM_REVIEW.md
+++ b/docs/design/WEBSITE_PR68_ORG_SYSTEM_REVIEW.md
@@ -21,7 +21,7 @@ Current production remains proof-disciplined but still reads partly like a docum
 
 ## Repos inspected
 
-### Hoxline / local `aevumguard`
+### Hoxline / local `hoxline`
 
 Paths inspected:
 

--- a/docs/design/WEBSITE_VISUAL_INTELLIGENCE_V1.md
+++ b/docs/design/WEBSITE_VISUAL_INTELLIGENCE_V1.md
@@ -6,9 +6,9 @@ Implementation now uses the real Hoxline Capability Visual Data Pack v1 from mer
 
 Source files:
 
-- `C:\Raylee\Repo\HawkinsOperations\aevumguard\examples\showcase\ho-det-001-capability-visual-data-pack-v1.json`
-- `C:\Raylee\Repo\HawkinsOperations\aevumguard\examples\showcase\ho-det-001-capability-visual-data-pack-v1.md`
-- `C:\Raylee\Repo\HawkinsOperations\aevumguard\schemas\capability-visual-data-pack-v1.schema.json`
+- `C:\Raylee\Repo\HawkinsOperations\hoxline\examples\showcase\ho-det-001-capability-visual-data-pack-v1.json`
+- `C:\Raylee\Repo\HawkinsOperations\hoxline\examples\showcase\ho-det-001-capability-visual-data-pack-v1.md`
+- `C:\Raylee\Repo\HawkinsOperations\hoxline\schemas\capability-visual-data-pack-v1.schema.json`
 
 Merged source commit verified locally:
 

--- a/scripts/verify-site-contract.mjs
+++ b/scripts/verify-site-contract.mjs
@@ -164,7 +164,7 @@ const hoxlineFrontDoorRequiredTerms = [
   ["app/hoxline/page.tsx", hoxlinePage, "Authority Architecture"],
   ["app/hoxline/page.tsx", hoxlinePage, "Next Gate"],
   ["app/aevumguard/page.tsx", aevumguardPage, "Legacy compatibility route"],
-  ["app/aevumguard/page.tsx", aevumguardPage, "AevumGuard was legacy naming"],
+  ["app/aevumguard/page.tsx", aevumguardPage, "AevumGuard was a prior working name"],
   ["app/aevumguard/page.tsx", aevumguardPage, 'canonical: "/hoxline/"'],
   ["app/aevumguard/page.tsx", aevumguardPage, 'href="/hoxline/"'],
   ["app/proof/page.tsx", proofPage, "Claim Firewall control surface"],

--- a/src/data/attackDetectionOps.ts
+++ b/src/data/attackDetectionOps.ts
@@ -51,7 +51,7 @@ export const detectionLifecycleSteps: DetectionLifecycleStep[] = [
     label: "Claim boundary",
     surface: "Hoxline / Claim Firewall",
     status: "unsupported runtime/signal/public-safe wording blocked or downgraded",
-    source: "aevumguard/examples/showcase/ho-det-001-capability-visual-data-pack-v1.json",
+    source: "hoxline/examples/showcase/ho-det-001-capability-visual-data-pack-v1.json",
   },
   {
     label: "Website render",

--- a/src/data/hoxlineVisualIntelligence.ts
+++ b/src/data/hoxlineVisualIntelligence.ts
@@ -127,16 +127,16 @@ const toneForStatus = (status: HoxlineStageStatus): VisualTone => {
 };
 
 // Copied from Hoxline PR #13 after merge.
-// Source: C:\Raylee\Repo\HawkinsOperations\aevumguard\examples\showcase\ho-det-001-capability-visual-data-pack-v1.json
-// Schema: C:\Raylee\Repo\HawkinsOperations\aevumguard\schemas\capability-visual-data-pack-v1.schema.json
+// Source: C:\Raylee\Repo\HawkinsOperations\hoxline\examples\showcase\ho-det-001-capability-visual-data-pack-v1.json
+// Schema: C:\Raylee\Repo\HawkinsOperations\hoxline\schemas\capability-visual-data-pack-v1.schema.json
 export const hoxlineDataSource = {
   mode: "CAPABILITY_VISUAL_DATA_PACK_V1",
   sourcePath:
-    "C:\\Raylee\\Repo\\HawkinsOperations\\aevumguard\\examples\\showcase\\ho-det-001-capability-visual-data-pack-v1.json",
+    "C:\\Raylee\\Repo\\HawkinsOperations\\hoxline\\examples\\showcase\\ho-det-001-capability-visual-data-pack-v1.json",
   markdownPath:
-    "C:\\Raylee\\Repo\\HawkinsOperations\\aevumguard\\examples\\showcase\\ho-det-001-capability-visual-data-pack-v1.md",
+    "C:\\Raylee\\Repo\\HawkinsOperations\\hoxline\\examples\\showcase\\ho-det-001-capability-visual-data-pack-v1.md",
   schemaPath:
-    "C:\\Raylee\\Repo\\HawkinsOperations\\aevumguard\\schemas\\capability-visual-data-pack-v1.schema.json",
+    "C:\\Raylee\\Repo\\HawkinsOperations\\hoxline\\schemas\\capability-visual-data-pack-v1.schema.json",
   localSourceCommit: "903da4e5cccc9eeb53a4c21b8639c7d472b7eb7d",
   sourcePr: "Hoxline PR #13",
   showcaseId: "ho-det-001-capability-visual-data-pack-v1",

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -37,7 +37,7 @@ export const externalLinks = {
   platform: "https://github.com/HawkinsOperations/hawkinsoperations-platform",
   proof: "https://github.com/HawkinsOperations/hawkinsoperations-proof",
   hoxline: "https://github.com/HawkinsOperations/hoxline",
-  legacyAevumGuard: "https://github.com/HawkinsOperations/aevumguard",
+  legacyHoxlineRedirect: "https://github.com/HawkinsOperations/hoxline",
   governanceSavesCandidates: "https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/docs/governance-saves/GOVERNANCE-SAVES-CANDIDATES.md",
   governanceSavesEvidenceMatrix: "https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/docs/governance-saves/GOVERNANCE-SAVES-EVIDENCE-MATRIX.md",
   platformDetectionFactoryController: "https://github.com/HawkinsOperations/hawkinsoperations-platform/blob/main/docs/factory/DETECTION_FACTORY_CONTROLLER_V0.md",

--- a/src/data/systemShowcase.ts
+++ b/src/data/systemShowcase.ts
@@ -50,7 +50,7 @@ export type ClaimFirewallExample = {
 };
 
 export const orgSystemSources = [
-  "C:\\Raylee\\Repo\\HawkinsOperations\\aevumguard\\examples\\showcase\\ho-det-001-capability-visual-data-pack-v1.json",
+  "C:\\Raylee\\Repo\\HawkinsOperations\\hoxline\\examples\\showcase\\ho-det-001-capability-visual-data-pack-v1.json",
   "C:\\Raylee\\Repo\\HawkinsOperations\\hawkinsoperations-detections\\detections\\DETECTION_FACTORY_INDEX.md",
   "C:\\Raylee\\Repo\\HawkinsOperations\\hawkinsoperations-validation\\activity\\detection-activity-ledger-v1.json",
   "C:\\Raylee\\Repo\\HawkinsOperations\\hawkinsoperations-proof\\README.md",


### PR DESCRIPTION
## Purpose
Clean stale active product naming so this repo aligns with Hoxline as the current HawkinsOperations product/front-door identity.

## Product Truth
- Hoxline by HawkinsOperations
- ProofOps control for the AI security era
- Claim Firewall is an internal Claim Authority capability inside Hoxline
- AevumGuard was a prior working name only

## Proof Ceiling
PUBLIC_METADATA_CLEANUP_ONLY

This PR does not claim runtime proof, signal proof, production deployment, customer deployment, SOCaaS deployment, public-safe runtime proof, trademark clearance, or legal name clearance.

## Validation
- git diff --check: PASS (xit=0)
- 
pm run check:site: PASS (Site contract checks passed.)
- 
pm run typecheck: PASS (xit=0)
- 
pm run build: PASS (Compiled successfully; generated 47 static pages; xit=0)
- grep cleanup: PASS

## Remaining Historical References
AevumGuard hits:
- HISTORY_ONLY: app/aevumguard/page.tsx:14:    "AevumGuard was a prior working name. Hoxline by HawkinsOperations is the current product front door.",
- HISTORY_ONLY: app/aevumguard/page.tsx:32:              AevumGuard was a prior working name. Hoxline by HawkinsOperations is the current product front door.
- HISTORY_ONLY: app/aevumguard/page.tsx:44:                <strong>/aevumguard/</strong>
- HISTORY_ONLY: app/aevumguard/page.tsx:90:              detail="AevumGuard was a prior working name. Hoxline is the current product name."
- HISTORY_ONLY: scripts/verify-site-contract.mjs:11:  "app/aevumguard/page.tsx",
- HISTORY_ONLY: scripts/verify-site-contract.mjs:150:const aevumguardPage = readFileSync(join(root, "app/aevumguard/page.tsx"), "utf8");
- HISTORY_ONLY: scripts/verify-site-contract.mjs:166:  ["app/aevumguard/page.tsx", aevumguardPage, "Legacy compatibility route"],
- HISTORY_ONLY: scripts/verify-site-contract.mjs:167:  ["app/aevumguard/page.tsx", aevumguardPage, "AevumGuard was a prior working name"],
- HISTORY_ONLY: scripts/verify-site-contract.mjs:168:  ["app/aevumguard/page.tsx", aevumguardPage, 'canonical: "/hoxline/"'],
- HISTORY_ONLY: scripts/verify-site-contract.mjs:169:  ["app/aevumguard/page.tsx", aevumguardPage, 'href="/hoxline/"'],
- HISTORY_ONLY: scripts/verify-site-contract.mjs:358:if (agentMarkdown.includes("/aevumguard/")) {
- HISTORY_ONLY: scripts/verify-site-contract.mjs:359:  discoveryFailures.push("public/agent.md must not list /aevumguard/ as a current public entry point.");

Claim Firewall hits:
- KEEP_WITH_COMPATIBILITY_CONTEXT: SCOPE.md:10:- Next.js App Router static export routes for reviewer, proof, architecture, repository, claim firewall, field-note, operator, and legacy-boundary pages
- KEEP_WITH_COMPATIBILITY_CONTEXT: STATUS.md:9:After Cloudflare Pages preview deploy confirms `dist/` parity, plan the visual redesign PR using the new reviewer-routing direction (Six Truth Surfaces lane stack, Proof Promotion State Machine, Repository Authority DAG, Claim Firewall). All future visual changes must continue to keep the claim ceiling at `CONTROLLED_TEST_VALIDATED` and public-safe at `NOT_PUBLIC_SAFE`.
- KEEP_WITH_COMPATIBILITY_CONTEXT: app/about/page.tsx:264:                <dd>Runtime-active, signal-observed, public-safe runtime proof, autonomous SOC, AI-approved disposition, analyst-approved disposition. Those wordings remain blocked by the claim firewall.</dd>
- KEEP_WITH_COMPATIBILITY_CONTEXT: app/ai-security/page.tsx:155:              <h2>AI drafts. Verifiers test. Claim Firewall clamps. Human review decides.</h2>
- KEEP_WITH_COMPATIBILITY_CONTEXT: app/ai-security/page.tsx:162:              {["AI Draft", "Verifier", "Claim Firewall", "Human Review", "Public Wording"].map((step, index) => (
- KEEP_WITH_COMPATIBILITY_CONTEXT: app/architecture/page.tsx:57:          <LinkCard href="/claim-firewall/" title="Claim Firewall" description="Allowed claims, blocked terms, and wording examples." />
- KEEP_WITH_COMPATIBILITY_CONTEXT: app/changelog/page.tsx:20:      "Phase 2 added a Validation Registry dashboard, proof manifest console, verifier cards, platform contract blueprints, a receipt / ledger reviewer snapshot, and an expandable blocked-claim firewall. Rendering only — the website is not proof. Public ceiling remains CONTROLLED_TEST_VALIDATED; runtime, signal, and public-safe runtime proof remain blocked, and rows with no proof record stay marked NO_PROOF_RECORD.",
- KEEP_WITH_COMPATIBILITY_CONTEXT: app/changelog/page.tsx:38:      "Homepage moved to a black/electric-blue cockpit layout with a status console, claim firewall, and artifact family matrix. Rendering surface remains routing only.",
- KEEP_WITH_COMPATIBILITY_CONTEXT: app/claim-firewall/page.tsx:6:  title: "Claim Firewall capability | HawkinsOperations",
- KEEP_WITH_COMPATIBILITY_CONTEXT: app/claim-firewall/page.tsx:8:    "Claim Firewall is an internal Hoxline Claim Authority enforcement capability for checking unsupported public wording. It is not the product or a separate repo.",
- KEEP_WITH_COMPATIBILITY_CONTEXT: app/claim-firewall/page.tsx:20:          <aside className="controls-hero controls-hero--compact mt-5" aria-label="Claim Firewall product boundary">
- KEEP_WITH_COMPATIBILITY_CONTEXT: app/claim-firewall/page.tsx:25:            <p>Claim Firewall is a wording enforcement edge inside Hoxline.</p>
- KEEP_WITH_COMPATIBILITY_CONTEXT: app/claim-firewall/page.tsx:27:              Claim Firewall is not the product, platform, front-door repo, or an eighth repo.
- KEEP_WITH_COMPATIBILITY_CONTEXT: app/controls/page.tsx:6:    "The /controls/ route remains as a compatibility page. Hoxline is the product front door; Claim Firewall is an internal Claim Authority capability.",
- KEEP_WITH_COMPATIBILITY_CONTEXT: app/controls/page.tsx:25:            Claim Firewall remains an internal Hoxline Claim Authority enforcement capability. This /controls/ route remains as a compatibility page for older reviewer links.
- KEEP_WITH_COMPATIBILITY_CONTEXT: app/controls/page.tsx:40:          <p>Claim Firewall checks wording policy only as a TOOL_FUNCTION_ONLY capability inside Hoxline.</p>
- KEEP_WITH_COMPATIBILITY_CONTEXT: app/globals.css:6327:/* Claim Firewall command center (/controls) ------------------------ */
- KEEP_WITH_COMPATIBILITY_CONTEXT: app/globals.css:10876:/* Blocked-claim firewall expandable strip */
- KEEP_WITH_COMPATIBILITY_CONTEXT: app/hoxline/page.tsx:202:    body: "Claim Firewall is an internal Hoxline Claim Authority capability that separates allowed wording from blocked wording.",
- KEEP_WITH_COMPATIBILITY_CONTEXT: app/page.tsx:104:              <span className="artifact-tile__cat">CLAIM FIREWALL</span>
- KEEP_WITH_COMPATIBILITY_CONTEXT: app/page.tsx:109:              <span className="artifact-tile__link">Inspect Claim Firewall -&gt;</span>
- KEEP_WITH_COMPATIBILITY_CONTEXT: app/proof/governance-saves/page.tsx:57:            <LinkCard href="/claim-firewall/" title="Claim Firewall" description="Inspect the control surface for blocked wording." />
- KEEP_WITH_COMPATIBILITY_CONTEXT: app/proof/page.tsx:23:    "HawkinsOperations evidence vault and claim authority hub: governance saves, the claim firewall, Proof Pack 001, the runtime boundary, and proof records. The website routes reviewers to proof; it does not authorize claims.",
- KEEP_WITH_COMPATIBILITY_CONTEXT: app/proof/page.tsx:80:      {/* ── Claim firewall ───────────────────────────────────────────── */}
- KEEP_WITH_COMPATIBILITY_CONTEXT: app/proof/page.tsx:245:              <span className="artifact-tile__cat">CLAIM FIREWALL</span>
- KEEP_WITH_COMPATIBILITY_CONTEXT: app/proof/page.tsx:246:              <span className="artifact-tile__title">Claim Firewall control surface</span>
- KEEP_WITH_COMPATIBILITY_CONTEXT: app/proof/page.tsx:250:              <span className="artifact-tile__link">Open Claim Firewall -&gt;</span>
- KEEP_WITH_COMPATIBILITY_CONTEXT: components/ArtifactReviewerPaths.tsx:51:      "Check the claim firewall for allowed vs blocked public wording.",
- KEEP_WITH_COMPATIBILITY_CONTEXT: components/BlockedClaimFirewall.tsx:14:    <div className="bcf" data-ci-target="blocked-claims" aria-label="Blocked-claim firewall">
- KEEP_WITH_COMPATIBILITY_CONTEXT: components/BlockedClaimFirewall.tsx:16:        <span className="bcf__title">Blocked-claim firewall</span>
- KEEP_WITH_COMPATIBILITY_CONTEXT: components/BlockedClaimStrip.tsx:22:        <span className="chip chip-block">CLAIM FIREWALL · ACTIVE</span>
- KEEP_WITH_COMPATIBILITY_CONTEXT: components/ClaimFirewall.tsx:63:  ["Claim Firewall", "internal Hoxline capability"],
- KEEP_WITH_COMPATIBILITY_CONTEXT: components/ClaimFirewall.tsx:143:        <pre className="claim-firewall-demo__terminal" aria-label="Claim Firewall GitHub Action example">
- KEEP_WITH_COMPATIBILITY_CONTEXT: components/ClaimFirewall.tsx:186:        <div className="claim-firewall-demo__chips" aria-label="Claim Firewall policy areas">
- KEEP_WITH_COMPATIBILITY_CONTEXT: components/ClaimFirewall.tsx:214:          Claim Firewall is an internal Hoxline Claim Authority enforcement capability that checks wording against configured policy only.
- KEEP_WITH_COMPATIBILITY_CONTEXT: components/ClaimFirewall.tsx:227:          <li>TOOL_FUNCTION_ONLY for the Claim Firewall capability inside Hoxline.</li>
- KEEP_WITH_COMPATIBILITY_CONTEXT: components/ClaimFirewall.tsx:251:          Claim Firewall supports claim hygiene as a Hoxline capability. It does not approve claims. Evidence and human review decide truth.
- KEEP_WITH_COMPATIBILITY_CONTEXT: components/ClaimFirewall.tsx:265:        <ul className="claim-firewall-demo__outcomes" aria-label="Claim Firewall public receipts">
- KEEP_WITH_COMPATIBILITY_CONTEXT: components/ClaimFirewallPanel.tsx:18:  title = "Claim firewall",
- KEEP_WITH_COMPATIBILITY_CONTEXT: components/ClaimFirewallSplitPane.tsx:83:        <p className="cockpit-eyebrow">Claim firewall</p>

Additional Claim Firewall hits remain in capability/UI/class/route context only.
