### PR TITLE
[website] surface Hoxline public reviewer packet v0

### DIFF
--- a/app/hoxline/page.tsx
+++ b/app/hoxline/page.tsx
@@ -157,6 +157,37 @@ const reviewerPath = [
   },
 ];
 
+const publicReviewerPacket = [
+  {
+    title: "Current-state panel",
+    detail:
+      "Hoxline Public Reviewer Packet v0 keeps public_safe false, human review required, website rendering below proof, and green CI below approval.",
+  },
+  {
+    title: "Allowed claim",
+    detail: "HO-DET-001 has controlled validation evidence and remains under governed review.",
+  },
+  {
+    title: "Blocked stronger claims",
+    detail:
+      "The packet does not claim runtime proof, signal observation, production readiness, customer deployment, SOCaaS deployment, AI approval, analyst approval, case closure, or public proof promotion.",
+  },
+  {
+    title: "HO-DET-011 / HO-DET-012 boundary",
+    detail:
+      "Both remain waiting on real operator evidence; marker hits without governed execution IDs do not establish operator receipt evidence.",
+  },
+  {
+    title: "Private reference boundary",
+    detail:
+      "Private runtime reference digests are hash references only. They are not public proof and do not raise the public proof ceiling.",
+  },
+  {
+    title: "No promotion side effects",
+    detail: "No ledger append, no public proof promotion, and no schedule enablement are created by this page.",
+  },
+];
+
 const nextGate = [
   "Separate runtime evidence from the appropriate authority path.",
   "Preserved signal evidence tied to the artifact and telemetry contract.",
@@ -529,6 +560,29 @@ export default function HoxlinePage() {
           <div className="mt-6">
             <ReviewerLensTabs lenses={lenses} />
           </div>
+          <div className="mt-6">
+            <ClaimBoundaryPanel
+              title="Hoxline Public Reviewer Packet v0"
+              description="This route renders the packet as reviewer orientation only. Rendering is not proof, public_safe remains false, private runtime references are not public proof, human review remains required, no ledger append happened, no public proof promotion happened, and no schedule was enabled."
+              boundaries={[
+                { label: "Packet status", value: "NOT_PUBLIC_SAFE", tone: "blocked" },
+                { label: "Public ceiling", value: "CONTROLLED_TEST_VALIDATED", tone: "green" },
+                { label: "Private references", value: "hash references only", tone: "amber" },
+                { label: "Website", value: "rendering only", tone: "neutral" },
+                { label: "Human review", value: "required", tone: "amber" },
+                { label: "Promotion", value: "not promoted", tone: "blocked" },
+              ]}
+            />
+          </div>
+          <div className="mt-6 proofops-grid-3">
+            {publicReviewerPacket.map((item) => (
+              <article key={item.title} className="proofops-card">
+                <p className="proofops-kicker">Reviewer packet</p>
+                <h3>{item.title}</h3>
+                <p>{item.detail}</p>
+              </article>
+            ))}
+          </div>
           <div className="mt-6 grid gap-4 md:grid-cols-2 lg:grid-cols-4">
             <LinkCard
               href="https://github.com/HawkinsOperations/hoxline/pull/7"
@@ -546,6 +600,24 @@ export default function HoxlinePage() {
               href="https://github.com/HawkinsOperations/hoxline/pull/10"
               title="PR #10 draft"
               description="Draft controlled demo packaging work. Demo packaging only; not merged proof."
+              external
+            />
+            <LinkCard
+              href="https://github.com/HawkinsOperations/hoxline/blob/main/docs/reviewer/HOXLINE_PUBLIC_REVIEWER_PACKET_V0.md"
+              title="Reviewer packet doc"
+              description="Read the public reviewer packet boundary and current-state explanation."
+              external
+            />
+            <LinkCard
+              href="https://github.com/HawkinsOperations/hoxline/blob/main/examples/reviewer/hoxline-public-reviewer-packet-v0.json"
+              title="Reviewer packet JSON"
+              description="Inspect the sanitized current-state packet data."
+              external
+            />
+            <LinkCard
+              href="https://github.com/HawkinsOperations/hoxline/blob/main/schemas/public-reviewer-packet-v0.schema.json"
+              title="Reviewer packet schema"
+              description="Inspect the fail-closed schema constants for the packet."
               external
             />
             <LinkCard


### PR DESCRIPTION
## Objective

Surface Hoxline Public Reviewer Packet v0 on the `/hoxline/` route after the Hoxline packet verifier passed, without treating the website as proof authority.

## Source packet route

- Hoxline packet doc: `docs/reviewer/HOXLINE_PUBLIC_REVIEWER_PACKET_V0.md`
- Packet JSON: `examples/reviewer/hoxline-public-reviewer-packet-v0.json`
- Packet schema: `schemas/public-reviewer-packet-v0.schema.json`

## Rendering boundary

- Website rendering is not proof.
- `public_safe` remains false.
- Private runtime references are not public proof.
- Human review remains required.
- No ledger append happened.
- No public proof promotion happened.
- No schedule enablement happened.

## What changed

- Adds a bounded reviewer-packet panel to `app/hoxline/page.tsx`.
- Links to the Hoxline packet doc, JSON, and schema in the Hoxline repo.
- States the allowed HO-DET-001 claim.
- States blocked stronger claim families.
- States HO-DET-011 and HO-DET-012 remain waiting on real operator evidence.

## Validation

- Hoxline packet validation completed before this website sync:
  - `python -B -m pytest -q tests` -> pass, 103 passed and 18 subtests passed.
  - `python -B -m hoxline reviewer verify --input examples\reviewer\hoxline-public-reviewer-packet-v0.json --schema schemas\public-reviewer-packet-v0.schema.json` -> pass.
- Website validation:
  - `npm run check:site` -> pass.
  - `npm run build` -> pass.
  - `git diff --check` -> pass, line-ending warnings only.

## No promotion

This PR does not promote proof, does not promote public_safe, does not claim runtime proof, does not claim signal observation, does not claim production/customer/SOCaaS deployment, and does not claim AI, analyst, or case-closure approval.

## Rollback notes

Revert this PR to remove the `/hoxline/` route rendering sync. No proof source, public status source, ledger, schedule, or generated status input is changed.