### PR TITLE
[website] align Hoxline runtime candidate boundaries

### DIFF
--- a/app/hoxline/page.tsx
+++ b/app/hoxline/page.tsx
@@ -173,9 +173,9 @@ const publicReviewerPacket = [
       "The packet does not claim runtime proof, signal observation, production readiness, customer deployment, SOCaaS deployment, AI approval, analyst approval, case closure, or public proof promotion.",
   },
   {
-    title: "HO-DET-011 / HO-DET-012 boundary",
+    title: "Private runtime candidate boundary",
     detail:
-      "Both remain waiting on real operator evidence; marker hits without governed execution IDs do not establish operator receipt evidence.",
+      "HO-DET-009, HO-DET-010, HO-DET-011, and HO-DET-012 may be referenced only as private runtime candidate and standing collector support. They remain NOT_PUBLIC_SAFE, human review required, and not public proof.",
   },
   {
     title: "Private reference boundary",

--- a/app/proof/ho-det-001/page.tsx
+++ b/app/proof/ho-det-001/page.tsx
@@ -95,7 +95,7 @@ export default function HoDet001CaseFilePage() {
 
       <section className="cockpit-section--tight">
         <div className="container grid gap-6 lg:grid-cols-[1.4fr_0.9fr] items-start">
-          <ProofPathTimeline detectionId={record.detectionId} title="SOCaaS Pilot Receipt · source to public boundary" steps={traceSteps} />
+          <ProofPathTimeline detectionId={record.detectionId} title="Controlled Validation Receipt · source to public boundary" steps={traceSteps} />
           <StatusConsole
             rows={[
               { tone: "ice", label: "Proof level", value: record.proofLevel },
@@ -113,7 +113,7 @@ export default function HoDet001CaseFilePage() {
         <div className="container">
           <SectionHeader
             title={record.receiptTitle ?? "HO-DET-001 receipt"}
-            eyebrow="SOCaaS Pilot Receipt"
+            eyebrow="Controlled Validation Receipt"
             description={record.receiptSummary}
           />
           <div className="mt-6 grid gap-4 lg:grid-cols-4">

--- a/src/data/claims.ts
+++ b/src/data/claims.ts
@@ -7,7 +7,7 @@ export const allowedClaims = [
   "HawkinsOperations separates source truth, runtime truth, signal truth, evidence truth, and public proof.",
   "HO-DET-001 is CONTROLLED_TEST_VALIDATED.",
   "HO-DET-001 has controlled-test validation status.",
-  "HO-DET-001 may be rendered as a SOCaaS Pilot Receipt when the receipt keeps source, validation, case packet, AI support, human review, and proof authority separate.",
+  "HO-DET-001 may be rendered as a Controlled Validation Receipt when the receipt keeps source, validation, case packet, AI support, human review, and proof authority separate.",
   "Source presence does not prove runtime.",
   "Validation does not prove public signal.",
   "Public proof requires evidence linkage and explicit promotion.",

--- a/src/data/proofPackManifest.ts
+++ b/src/data/proofPackManifest.ts
@@ -52,7 +52,7 @@ export const releaseRouteCaveat = {
 
 export const reviewerPacket = {
   name: "REVIEWER_PACKET.md",
-  scope: "Boundary packet for the HO-DET-001 SOCaaS Pilot Receipt.",
+  scope: "Boundary packet for the HO-DET-001 Controlled Validation Receipt.",
   evidenceChain: [
     "Detection source",
     "Alert shape",

--- a/src/data/proofRecords.ts
+++ b/src/data/proofRecords.ts
@@ -94,7 +94,7 @@ export const lifetimeCaseLedgerV1 = {
 export const proofRecords: ProofRecord[] = [
   {
     detectionId: "HO-DET-001",
-    title: "SOCaaS Pilot Receipt · controlled-test validation",
+    title: "Controlled Validation Receipt · controlled-test validation",
     proofLevel: proofCeiling,
     proofRecordState: "PROOF_RECORD_PRESENT",
     validationState: "controlled-test validation status",
@@ -117,7 +117,7 @@ export const proofRecords: ProofRecord[] = [
       "Blocked promotions are visible instead of hidden.",
       "Website rendering remains separated from evidence authority.",
       "The platform verifier preserves NOT_PUBLIC_SAFE and BLOCKED runtime promotion fields.",
-      "The SOCaaS Pilot Receipt shows source, alert shape, validation, case packet, AI support, and human review as separate stages.",
+      "The controlled validation receipt shows source, alert shape, validation, case packet, AI support, and human review as separate stages.",
     ],
     notClaimed: [
       "Runtime activation is not claimed.",
@@ -141,9 +141,9 @@ export const proofRecords: ProofRecord[] = [
       "Runtime and signal claims reviewed independently.",
       "Public wording reviewed against blocked promotions.",
     ],
-    receiptTitle: "HO-DET-001 SOCaaS Pilot Receipt",
+    receiptTitle: "HO-DET-001 Controlled Validation Receipt",
     receiptSummary:
-      "A reviewer-readable receipt for a SOCaaS-style pilot loop: source-controlled detection, controlled alert shape, deterministic validation, support-only case packet flow, proof authority, and human review gate. The website renders the receipt; it does not authorize stronger proof.",
+      "A reviewer-readable receipt for a controlled validation loop: source-controlled detection, controlled alert shape, deterministic validation, support-only case packet flow, proof authority, and human review gate. The website renders the receipt; it does not authorize stronger proof.",
     detectionSource: [
       "Detection route: Suspicious PowerShell EncodedCommand.",
       "Source truth lives in the detections repository; source presence does not prove runtime deployment.",


### PR DESCRIPTION
Aligns public wording with Hoxline product/proof boundaries: removes active SOCaaS Pilot Receipt labels, keeps website rendering below proof authority, and adds bounded private runtime candidate wording for HO-DET-009/010/011/012 without publishing evidence. Validation run: npm run check:site, npm run typecheck, npm run build, git diff --check. Boundary: no raw evidence, no public proof promotion, no Lifetime Ledger append, no website-as-proof claim, no runtime rerun.