### PR TITLE
[website] surface Hoxline one-command reviewer demo

### DIFF
--- a/app/hoxline/page.tsx
+++ b/app/hoxline/page.tsx
@@ -145,7 +145,7 @@ const authorityMap = [
 const reviewerPath = [
   {
     title: "Inspect the controlled demo package",
-    detail: "Start with the HO-DET-001 bridge, release packet, and existing bounded case-file route.",
+    detail: "Clone the Hoxline repo, run `python -B -m hoxline demo quickstart`, then read `.hoxline/demo-runs/<timestamp>/reviewer-pack.md`. The demo is deterministic, local, fixture-based, and not runtime proof.",
   },
   {
     title: "Inspect the proof ceiling and blocked claims",

--- a/public/data/public-status.json
+++ b/public/data/public-status.json
@@ -106,6 +106,7 @@
       "command": "git clone https://github.com/HawkinsOperations/hoxline.git"
     },
     "run_commands": [
+      { "label": "Hoxline one-command demo", "repo": "HawkinsOperations/hoxline", "working_directory": "hoxline repo root", "command": "python -B -m hoxline demo quickstart", "source_basis": "Org Start Here 30-second reviewer path; deterministic local fixture-based demo." },
       { "label": "Hoxline tests", "repo": "HawkinsOperations/hoxline", "working_directory": "hoxline repo root", "command": "python -B -m pytest -q tests", "source_basis": "Hoxline reviewer path requested for clone-run inspection." },
       { "label": "Hoxline Gauntlet output verifier", "repo": "HawkinsOperations/hoxline", "working_directory": "hoxline repo root", "command": "python -B -m hoxline gauntlet verify --input examples/gauntlet/ho-det-001-full-loop-run-v0.json --schema schemas/gauntlet-full-loop-run-v0.schema.json", "source_basis": "Capability visual data pack verifier command path." },
       { "label": "Website site contract", "repo": "HawkinsOperations/hawkinsoperations-website", "working_directory": "hawkinsoperations-website repo root", "command": "npm run check:site", "source_basis": "Website generated-status and public-surface contract verifier." },

--- a/scripts/verify-site-contract.mjs
+++ b/scripts/verify-site-contract.mjs
@@ -640,7 +640,7 @@ if (publicStatusJson.reviewer_actions?.download_json?.href !== "/data/public-sta
 if (!publicStatusJson.reviewer_actions?.clone_repo?.command?.includes("git clone https://github.com/HawkinsOperations/hoxline.git")) {
   publicStatusFailures.push("public/data/public-status.json must include the Hoxline clone command.");
 }
-for (const command of ["python -B -m pytest -q tests", "python -B -m hoxline gauntlet verify", "npm run check:site", "npm run build"]) {
+for (const command of ["python -B -m hoxline demo quickstart", "python -B -m pytest -q tests", "python -B -m hoxline gauntlet verify", "npm run check:site", "npm run build"]) {
   if (!publicStatusJson.reviewer_actions?.run_commands?.some((entry) => entry.command.includes(command))) {
     publicStatusFailures.push(`public/data/public-status.json reviewer_actions.run_commands must include ${command}.`);
   }

--- a/src/data/generated/public-status.generated.ts
+++ b/src/data/generated/public-status.generated.ts
@@ -198,6 +198,13 @@ export const GENERATED_PUBLIC_STATUS_V0_SNAPSHOT = {
     },
     run_commands: [
       {
+        label: "Hoxline one-command demo",
+        repo: "HawkinsOperations/hoxline",
+        working_directory: "hoxline repo root",
+        command: "python -B -m hoxline demo quickstart",
+        source_basis: "Org Start Here 30-second reviewer path; deterministic local fixture-based demo.",
+      },
+      {
         label: "Hoxline tests",
         repo: "HawkinsOperations/hoxline",
         working_directory: "hoxline repo root",


### PR DESCRIPTION
## Summary

Surfaces the merged Hoxline one-command reviewer demo on the `/hoxline/` route and in the website reviewer command data:

- adds `python -B -m hoxline demo quickstart` to reviewer run commands
- updates the Hoxline reviewer path copy to point to the fixture-based reviewer pack
- makes the site contract verifier require the one-command demo route

## Boundary

Website rendering remains routing only and not proof. This change does not publish private evidence, mutate runtime systems, append or change the Lifetime Ledger, promote public proof, promote public-safe status, or claim runtime proof. The routed demo is deterministic, local, fixture-based, and not runtime proof.

## Validation

- `npm run check:site` PASS
- `npm run typecheck` PASS
- `npm run build` PASS
- `node scripts\verify-site-contract.mjs` PASS
- `git diff --check` PASS