### PR TITLE
feat(site): refine homepage instrument deck

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -17983,3 +17983,139 @@ a.card.group:hover { border-color: rgba(143, 216, 255, 0.45); }
     transform: translate(-50%, -50%);
   }
 }
+
+/* ════════════════════════════════════════════════════════════════════════
+   INSTRUMENT DECK v1 — homepage tablet repair + density polish
+   design/homepage-instrument-deck-v1. Rendering/interaction only.
+   Screenshot-grounded: kills the iPad white-line band, hero blur, overflow,
+   and tightens the page-end. Desktop is preserved.
+   ════════════════════════════════════════════════════════════════════════ */
+
+/* Overflow: clip (not hidden) avoids the scroll-container hairline seam that
+   the old `overflow-x: hidden + overflow-y: visible` combo can produce. */
+main {
+  overflow-x: clip;
+  overflow-y: visible;
+}
+
+/* Touch devices: remove the fixed full-viewport overlays. body::after is a
+   repeating horizontal band (background-size: 100% 9rem) — the prime suspect
+   for the white horizontal line seen while scrolling on iPad. Also stop the
+   animated hero sweep that can paint a moving light band / soften text. */
+@media (pointer: coarse) {
+  body::before,
+  body::after {
+    display: none !important;
+  }
+  .awb__glow {
+    display: none !important;
+    animation: none !important;
+  }
+  .site-header {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+
+/* Real tablet tier (the missing 641–1024 breakpoint). */
+@media (max-width: 1024px) {
+  html,
+  body {
+    max-width: 100%;
+    overflow-x: clip;
+  }
+  body::before,
+  body::after {
+    display: none;
+  }
+  .site-header > .container {
+    flex-wrap: wrap;
+    gap: 8px 14px;
+    padding-top: 10px;
+    padding-bottom: 8px;
+  }
+  .site-header > .container > nav[aria-label="Primary navigation"] {
+    order: 3;
+    flex-basis: 100%;
+    width: 100%;
+    gap: 0.95rem;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding-bottom: 8px;
+    scrollbar-width: thin;
+    scrollbar-color: var(--moon-border-bright) transparent;
+  }
+  .site-header .cta {
+    display: none !important;
+  }
+  .site-header .nav-link {
+    min-width: max-content;
+    font-size: 0.66rem;
+    letter-spacing: 0.14em;
+  }
+  .awb {
+    grid-template-columns: 1fr;
+  }
+  .awb__glow {
+    display: none;
+  }
+  /* Crisp solid hero headline instead of gradient-clipped text, which renders
+     soft/blurry in Safari — the reported iPad hero softness. */
+  .awb__accent {
+    -webkit-text-fill-color: var(--silver-bright);
+    color: var(--silver-bright);
+    background: none;
+  }
+  .awb__metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .awb__pipeline {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .awb__pipe-item {
+    flex: 1 1 calc(33.333% - 6px);
+  }
+  .awb__pipe-link {
+    display: none;
+  }
+  .orbx__workspace {
+    grid-template-columns: 1fr;
+  }
+  .orbx__stage {
+    max-width: 340px;
+  }
+}
+
+@media (max-width: 680px) {
+  .awb__pipe-item {
+    flex: 1 1 calc(50% - 6px);
+  }
+  .orbx__stage {
+    max-width: 300px;
+  }
+}
+
+/* Tap targets on touch surfaces (~44px). */
+@media (pointer: coarse) {
+  .awb__pipe,
+  .awb__cta,
+  .orbx__stepper button,
+  .sdc__door {
+    min-height: 44px;
+  }
+  .orbx__node {
+    min-width: 44px;
+    min-height: 44px;
+  }
+}
+
+/* Finished end-state: tighten the closing boundary section so the page does
+   not read as a false bottom, and give the footer a clear top edge. */
+#trust-boundary {
+  padding-top: clamp(28px, 4vw, 48px);
+  padding-bottom: clamp(36px, 5vw, 56px);
+}
+footer {
+  border-top: 1px solid var(--moon-border);
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,25 +2,20 @@ import type { Metadata } from "next";
 import ControlsFiredGraph from "@components/ControlsFiredGraph";
 import HomeAutomationCockpitV2 from "@components/command-center/HomeAutomationCockpitV2";
 import ProofOfWorkCounterRail from "@components/command-center/ProofOfWorkCounterRail";
-import V1ToV2EvolutionStrip from "@components/command-center/V1ToV2EvolutionStrip";
-import VerifyTerminalDrawer from "@components/command-center/VerifyTerminalDrawer";
 import OrbitInteractionWorkbench from "@components/visual-intelligence/OrbitInteractionWorkbench";
 import CurrentProofSpine from "@components/CurrentProofSpine";
 import HomeAttackCoverageBridge from "@components/HomeAttackCoverageBridge";
 import HomeReviewerBridgeToArtifacts from "@components/HomeReviewerBridgeToArtifacts";
 import HomeTrustBoundaryPanel from "@components/HomeTrustBoundaryPanel";
 import ProofLoopRail from "@components/ProofLoopRail";
-import ReviewerModeSelector from "@components/ReviewerModeSelector";
 import SixDoorCockpit from "@components/SixDoorCockpit";
 import {
-  AuthorityConstellation,
   BoundedMetricsRail,
   ClaimDecisionMatrixVisual,
   ComplexityStatsRail,
   DataPackSourceStrip,
   OutputArtifactWall,
   StageStatusChart,
-  VisualModuleRail,
 } from "@components/visual-intelligence";
 
 export const metadata: Metadata = {
@@ -40,9 +35,6 @@ export default function HomePage() {
           <HomeAutomationCockpitV2 />
           <div className="mt-6">
             <ProofOfWorkCounterRail />
-          </div>
-          <div className="mt-5">
-            <VerifyTerminalDrawer />
           </div>
           <div className="mt-5">
             <DataPackSourceStrip />
@@ -85,18 +77,6 @@ export default function HomePage() {
           <div className="mt-5">
             <BoundedMetricsRail />
           </div>
-          <div className="mt-5">
-            <AuthorityConstellation compact />
-          </div>
-          <div className="mt-5">
-            <VisualModuleRail />
-          </div>
-        </div>
-      </section>
-
-      <section id="v1-v2-evolution" className="cockpit-section--tight">
-        <div className="container">
-          <V1ToV2EvolutionStrip />
         </div>
       </section>
 
@@ -132,25 +112,6 @@ export default function HomePage() {
       <section id="attack-coverage" className="cockpit-section--tight">
         <div className="container reveal reveal--up">
           <HomeAttackCoverageBridge />
-        </div>
-      </section>
-
-      <section id="reviewer-mode" className="cockpit-section--tight">
-        <div className="container">
-          <div className="home-section__head mb-6">
-            <p className="cockpit-eyebrow">Reviewer mode</p>
-            <h2
-              className="cockpit-headline mt-2"
-              style={{ fontSize: "clamp(1.7rem, 2.8vw, 2.4rem)" }}
-            >
-              Pick the lens you read this site through.
-            </h2>
-            <p className="muted mt-3 text-sm leading-6 max-w-3xl">
-              The site routes the same proof differently for an executive scan, a proof-pack
-              audit, or a technical deep dive. Use the keyboard arrows to switch lenses.
-            </p>
-          </div>
-          <ReviewerModeSelector />
         </div>
       </section>
 

--- a/components/ControlsFiredGraph.tsx
+++ b/components/ControlsFiredGraph.tsx
@@ -99,9 +99,9 @@ export default function ControlsFiredGraph() {
     <div className="cfg" aria-labelledby={titleId} aria-describedby={descId}>
       <header className="cfg__head">
         <div>
-          <p className="cfg__eyebrow">Governance Saves · proof of value</p>
+          <p className="cfg__eyebrow">Governance Saves · generated from source records</p>
           <h3 id={titleId} className="cfg__title">
-            Controls Fired Before Bad Truth Shipped
+            Governance controls that fired before overclaims shipped
           </h3>
           <p id={descId} className="cfg__sub">
             {governanceSavesSummary.publicRenderedCount} public-facing records from{" "}


### PR DESCRIPTION
## Summary

* Refine homepage into a tighter Instrument Deck command surface
* Reduce redundant homepage sections and keep the Hoxline loop as the signature interactive visual
* Improve tablet/iPad overflow, blur, tap target, and footer/end-state behavior
* Soften governance-control wording while preserving public-safe proof boundaries
* Preserve route structure and current public claim ceiling

## Validation

* git diff --check
* npm run check:site
* npm run typecheck
* npm run build

## Screenshot review

Screenshots captured locally under:
C:\Raylee\Logbook\June\homepage_instrument_deck_v1_screenshots\

## Proof ceiling

Homepage rendering and interaction polish only. No proof authority changed. No runtime, signal, production, customer, analyst, AI approval, SOCaaS, deployment, public-safe runtime, website-as-proof, green-CI-as-approval, enterprise adoption, product-market fit, or customer validation claim promoted.