### PR TITLE
Add homepage Playwright visual QA scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ out/
 .wrangler/
 npm-debug.log*
 tsconfig.tsbuildinfo
+test-results/
+playwright-report/

--- a/app/globals.css
+++ b/app/globals.css
@@ -18119,3 +18119,210 @@ main {
 footer {
   border-top: 1px solid var(--moon-border);
 }
+
+/* ════════════════════════════════════════════════════════════════════════
+   COMMAND SURFACE MOTION v1 — landing hero elevation (design / rendering only)
+   06-28-26 landing_page_visual_design_only_v1.
+   Elevates the existing above-the-fold cockpit (.awb) into a governed
+   command surface: an operator signal field, artifacts moving through gates,
+   a live active-gate pulse, a flowing evidence rail, and a clearer
+   safe-flow vs held/gated reading.
+   Boundaries: no copy, claim, status, route, or dependency change. Every
+   animation below is reduced-motion AND coarse-pointer guarded (see the two
+   guard blocks at the end), and the hero "signal field" is hosted on the
+   already coarse/≤1024px-hidden .awb__glow layer so tablet + mobile stay
+   clean (no moving bands, no overflow). Desktop-only premium texture.
+   ════════════════════════════════════════════════════════════════════════ */
+
+/* Operator signal field — faint blueprint grid + a slow diagonal trace beam,
+   layered on the existing decorative hero glow (desktop only). */
+.awb__glow::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(to right, rgba(143, 216, 255, 0.05) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(143, 216, 255, 0.05) 1px, transparent 1px);
+  background-size: 46px 46px;
+  -webkit-mask: radial-gradient(125% 95% at 0% 0%, #000 6%, transparent 60%);
+  mask: radial-gradient(125% 95% at 0% 0%, #000 6%, transparent 60%);
+  opacity: 0.7;
+}
+.awb__glow::after {
+  content: "";
+  position: absolute;
+  top: -40%;
+  left: 0;
+  width: 55%;
+  height: 180%;
+  pointer-events: none;
+  background: linear-gradient(
+    105deg,
+    transparent 0%,
+    rgba(103, 232, 249, 0.06) 46%,
+    rgba(103, 232, 249, 0.12) 52%,
+    transparent 100%
+  );
+  filter: blur(2px);
+  animation: awbTraceBeam 9s ease-in-out infinite;
+}
+@keyframes awbTraceBeam {
+  0%   { transform: translateX(-60%) rotate(8deg); opacity: 0; }
+  18%  { opacity: 1; }
+  82%  { opacity: 1; }
+  100% { transform: translateX(240%) rotate(8deg); opacity: 0; }
+}
+
+/* Artifacts moving through gates — a light token travels each pipeline
+   connector toward the next gate. Connectors only render above 1024px. */
+.awb__pipe-link {
+  position: relative;
+  overflow: hidden;
+}
+.awb__pipe-link::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 45%;
+  height: 100%;
+  border-radius: 2px;
+  background: linear-gradient(90deg, transparent, var(--ice-blue), transparent);
+  box-shadow: 0 0 6px 0 var(--ice-blue-glow);
+  animation: awbGateFlow 2.6s linear infinite;
+}
+.awb__pipe-item:nth-child(2) .awb__pipe-link::after { animation-delay: 0.52s; }
+.awb__pipe-item:nth-child(3) .awb__pipe-link::after { animation-delay: 1.04s; }
+.awb__pipe-item:nth-child(4) .awb__pipe-link::after { animation-delay: 1.56s; }
+.awb__pipe-item:nth-child(5) .awb__pipe-link::after { animation-delay: 2.08s; }
+@keyframes awbGateFlow {
+  0%   { transform: translateX(-120%); opacity: 0; }
+  35%  { opacity: 1; }
+  100% { transform: translateX(240%); opacity: 0; }
+}
+
+/* Live gate — the active stage button reads as currently evaluating. */
+.awb__pipe { position: relative; }
+.awb__pipe.is-active::after {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  border-radius: 11px;
+  pointer-events: none;
+  border: 1px solid var(--ice-blue);
+  opacity: 0.35;
+  animation: awbGatePulse 2.4s ease-in-out infinite;
+}
+@keyframes awbGatePulse {
+  0%, 100% { opacity: 0.16; box-shadow: 0 0 0 0 rgba(143, 216, 255, 0); }
+  50%      { opacity: 0.55; box-shadow: 0 0 16px -2px var(--ice-blue-glow); }
+}
+.awb__pipe:focus-visible {
+  outline: 2px solid var(--ice-blue);
+  outline-offset: 2px;
+}
+
+/* Evidence rail — a soft highlight flows down the active stage accent bar,
+   reading as live evidence held against the artifact. Height-independent
+   (animates background-position so it works for any panel height). */
+.awb__stage::before {
+  background-color: var(--awb-accent, var(--ice-blue));
+  background-image: linear-gradient(
+    180deg,
+    transparent 0%,
+    rgba(248, 251, 255, 0.85) 50%,
+    transparent 100%
+  );
+  background-repeat: no-repeat;
+  background-size: 100% 36%;
+  background-position: 0 -40%;
+  animation: awbRailSheen 4.5s ease-in-out infinite;
+}
+@keyframes awbRailSheen {
+  0%   { background-position: 0 -40%; }
+  100% { background-position: 0 140%; }
+}
+
+/* Safe flow vs held / gated — give the evidence-scoped claim lane an amber
+   "held" edge and a soft hold pulse so it reads as a blocked lane distinct
+   from the cyan safe path. Copy is unchanged. */
+.awb__gated {
+  position: relative;
+  overflow: hidden;
+}
+.awb__gated::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: linear-gradient(180deg, #fcd34d, rgba(250, 204, 21, 0.22));
+}
+.awb__gated-dot {
+  animation: awbHoldPulse 2.8s ease-in-out infinite;
+}
+.awb__badge--gated {
+  animation: awbHoldPulse 2.8s ease-in-out infinite;
+}
+@keyframes awbHoldPulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(252, 211, 77, 0.55); }
+  50%      { box-shadow: 0 0 0 4px rgba(252, 211, 77, 0); }
+}
+
+/* Primary CTA — restrained one-shot sheen on hover only (no idle motion). */
+.awb__cta--primary {
+  position: relative;
+  overflow: hidden;
+}
+.awb__cta--primary::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -60%;
+  width: 40%;
+  height: 100%;
+  pointer-events: none;
+  background: linear-gradient(105deg, transparent, rgba(248, 251, 255, 0.32), transparent);
+  transform: skewX(-18deg);
+  opacity: 0;
+}
+.awb__cta--primary:hover::after {
+  animation: awbCtaSheen 0.9s ease;
+}
+@keyframes awbCtaSheen {
+  0%   { left: -60%; opacity: 0; }
+  22%  { opacity: 1; }
+  100% { left: 130%; opacity: 0; }
+}
+
+/* Reduced motion — disable every command-surface animation added above. */
+@media (prefers-reduced-motion: reduce) {
+  .awb__glow::after,
+  .awb__pipe-link::after,
+  .awb__pipe.is-active::after,
+  .awb__stage::before,
+  .awb__gated-dot,
+  .awb__badge--gated,
+  .awb__cta--primary:hover::after {
+    animation: none !important;
+  }
+  .awb__glow::after { opacity: 0; }
+  .awb__pipe-link::after { opacity: 0; }
+  .awb__stage::before { background-image: none; }
+}
+
+/* Coarse pointer (touch) — keep tablet + mobile static and clean. The hero
+   field is already hidden with .awb__glow; here we also still the localized
+   pulses so nothing animates on touch surfaces. */
+@media (pointer: coarse) {
+  .awb__pipe-link::after,
+  .awb__pipe.is-active::after,
+  .awb__stage::before,
+  .awb__gated-dot,
+  .awb__badge--gated {
+    animation: none !important;
+  }
+  .awb__stage::before { background-image: none; }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "react-dom": "18.3.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4.2.4",
         "@types/node": "^22.10.0",
         "@types/react": "^18.3.12",
@@ -658,6 +659,22 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -1088,6 +1105,20 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "license": "ISC"
@@ -1497,6 +1528,38 @@
     "node_modules/picocolors": {
       "version": "1.1.1",
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.13",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "build": "next build && node scripts/finalize-dist.mjs",
     "check:site": "node scripts/verify-site-contract.mjs",
     "preview": "npx --yes serve dist",
+    "test:visual": "playwright test",
+    "test:visual:headed": "playwright test --headed",
     "typecheck": "tsc --noEmit",
     "generate:brand-assets": "node scripts/generate-brand-assets.mjs"
   },
@@ -16,6 +18,7 @@
     "react-dom": "18.3.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4.2.4",
     "@types/node": "^22.10.0",
     "@types/react": "^18.3.12",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/visual",
+  outputDir: "test-results",
+  timeout: 45_000,
+  expect: {
+    timeout: 10_000,
+  },
+  fullyParallel: false,
+  reporter: [["list"], ["html", { outputFolder: "playwright-report", open: "never" }]],
+  use: {
+    baseURL: "http://127.0.0.1:3210",
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: "npx next dev -p 3210",
+    url: "http://127.0.0.1:3210",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        browserName: "chromium",
+      },
+    },
+  ],
+});

--- a/tests/visual/homepage.visual.spec.ts
+++ b/tests/visual/homepage.visual.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+const viewports = [
+  { name: "desktop-1440", width: 1440, height: 1100 },
+  { name: "laptop-1280", width: 1280, height: 900 },
+  { name: "tablet-1024", width: 1024, height: 900 },
+  { name: "tablet-narrow-834", width: 834, height: 1112 },
+  { name: "mobile-390", width: 390, height: 844 },
+];
+
+async function expectNoHorizontalOverflow(page: Page) {
+  const overflow = await page.evaluate(() => {
+    const root = document.documentElement;
+    const body = document.body;
+    return Math.max(root.scrollWidth - root.clientWidth, body.scrollWidth - body.clientWidth);
+  });
+
+  expect(overflow).toBeLessThanOrEqual(1);
+}
+
+async function expectTextNotClipped(locator: Locator) {
+  await expect(locator).toBeVisible();
+  const isReadable = await locator.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    const style = window.getComputedStyle(element);
+    const viewportWidth = document.documentElement.clientWidth;
+
+    return (
+      rect.width > 0 &&
+      rect.height > 0 &&
+      rect.left >= -1 &&
+      rect.right <= viewportWidth + 1 &&
+      element.scrollWidth - element.clientWidth <= 1 &&
+      style.visibility !== "hidden" &&
+      style.display !== "none"
+    );
+  });
+
+  expect(isReadable).toBe(true);
+}
+
+test.describe("homepage visual QA", () => {
+  for (const viewport of viewports) {
+    test(`loads cleanly at ${viewport.name}`, async ({ page }, testInfo) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await page.emulateMedia({ reducedMotion: "reduce" });
+      await page.goto("/", { waitUntil: "networkidle" });
+
+      const hero = page.locator(".awb").first();
+      const headline = page.locator("#awb-title").first();
+      const primaryCta = page.getByRole("link", { name: "Open Hoxline" }).first();
+      const secondaryCta = page.getByRole("link", { name: "Try Claim Firewall" }).first();
+
+      await expect(hero).toBeVisible();
+      await expectTextNotClipped(headline);
+      await expectTextNotClipped(primaryCta);
+      await expectTextNotClipped(secondaryCta);
+      await expectNoHorizontalOverflow(page);
+
+      await page.screenshot({
+        path: testInfo.outputPath(`${viewport.name}.png`),
+        fullPage: true,
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- Adds Playwright visual QA scaffold for homepage rendering checks.
- Adds Chromium-only local visual checks.
- Covers 1440, 1280, 1024, 834, and 390 viewport widths.
- Includes landing page CSS visual elevation already committed locally.

## Validation

- `npm run typecheck` passed
- `npm run check:site` passed
- `npm run test:visual` passed, 5/5 Chromium viewport checks

## Not run

- `npm run build` was not rerun due prior build hang/interruption risk

## Remaining risks

- `npm install` reported 2 vulnerabilities; no audit fix run
- Known `app/aevumguard/` stale route remains untouched
- Build hang investigation remains separate

## Proof ceiling

This PR proves only local website visual QA scaffolding and controlled homepage rendering checks. It does not prove runtime, signal, controlled validation truth, production readiness, customer deployment, public-safe proof, final human approval, merge readiness, or website-as-proof.