### PR TITLE
Fix duplicate mobile podcast navigation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -18417,6 +18417,12 @@ main {
   }
 }
 
+@media (max-width: 767px) {
+  .site-header .podcast-header-link {
+    display: none !important;
+  }
+}
+
 @media (max-width: 680px) {
   .awb__pipe-item {
     flex: 1 1 calc(50% - 6px);

--- a/tests/visual/podcast.visual.spec.ts
+++ b/tests/visual/podcast.visual.spec.ts
@@ -32,16 +32,19 @@ test.describe("podcast field guide visual QA", () => {
       await expect(page.getByRole("heading", { name: "From Logs to AI Triage" })).toBeVisible();
       await expect(page.locator(".podcast-card")).toHaveCount(3);
       await expect(page.locator('img[src^="/podcast/"]')).toHaveCount(6);
+      const desktopPodcastNavigation = page.locator(".podcast-header-link");
+      const mobilePodcastNavigation = page.locator(".podcast-mobile-nav-link");
       const podcastNavigation =
-        viewport.width < 768
-          ? page.locator(".podcast-mobile-nav-link")
-          : page.locator(".podcast-header-link");
+        viewport.width < 768 ? mobilePodcastNavigation : desktopPodcastNavigation;
       await expect(podcastNavigation).toBeVisible();
       if (viewport.width < 768) {
+        await expect(desktopPodcastNavigation).toBeHidden();
         const touchTargetHeight = await podcastNavigation.evaluate(
           (element) => element.getBoundingClientRect().height,
         );
         expect(touchTargetHeight).toBeGreaterThanOrEqual(44);
+      } else {
+        await expect(mobilePodcastNavigation).toBeHidden();
       }
       await podcastNavigation.focus();
       const focusOutline = await podcastNavigation.evaluate((element) => {


### PR DESCRIPTION
## Release repair

Public mobile verification after PR #81 reached the apex domain found the podcast destination rendered twice below 768 px: once as the tablet CTA and once in the mobile navigation scroller.

This follow-up keeps the tablet CTA at 768–1024 px, hides it below 768 px, and leaves the dedicated mobile podcast link as the single mobile destination. The visual test now asserts the inactive breakpoint-specific link is hidden, preventing recurrence.

## Scope

- `app/globals.css`
- `tests/visual/podcast.visual.spec.ts`

## Validation

- `npm run check:site` — PASS
- `npm run typecheck` — PASS
- `npm run build` — PASS; 48 static routes
- `npm run test:visual` — PASS; 10/10 at 1920×1080, 1440×900, 768×1024, 430×932, and 390×844
- No privacy, evidence, proof, runtime, content, DNS, or Cloudflare configuration change

## Claim boundary

Presentation-only responsive repair. It changes no status, metric, evidence, or authority claim. No independent human review is claimed; the mission's scoped release-repair merge exception applies.

## Deployment and rollback

The existing Cloudflare Pages Git integration should publish `dist` from merged `main`. Revert commit `e5ab922` through a normal follow-up PR if rollback is required.